### PR TITLE
make method static. fixes #2724

### DIFF
--- a/src/lib/Zikula/Form/Plugin/CategorySelector.php
+++ b/src/lib/Zikula/Form/Plugin/CategorySelector.php
@@ -82,8 +82,8 @@ class Zikula_Form_Plugin_CategorySelector extends Zikula_Form_Plugin_DropdownLis
     /**
      * Load the parameters.
      *
-     * Shared by other category plugins.
-     * FIXME: Should this method be static?
+     * this method is static because it is also called by the
+     * CategoryCheckboxList plugin
      *
      * @param object  &$list               The list object (here: $this).
      * @param boolean $includeEmptyElement Whether or not to include an empty null item.
@@ -91,7 +91,7 @@ class Zikula_Form_Plugin_CategorySelector extends Zikula_Form_Plugin_DropdownLis
      *
      * @return void
      */
-    function loadParameters(&$list, $includeEmptyElement, $params)
+    static function loadParameters(&$list, $includeEmptyElement, $params)
     {
         $all            = isset($params['all'])         ? $params['all']         : false;
         $lang           = isset($params['lang'])        ? $params['lang']        : ZLanguage::getLanguageCode();


### PR DESCRIPTION
The loadParameters() method is not a standard Form lib method. It is being called internally by CategorySelector plugin from the starndard Form lib method load(). The method is also required in the CategoryCheckboxList plugin as a static call.
