### PR TITLE
add upgrade routine to PageLock module. Fixes #2959.

### DIFF
--- a/src/system/PageLock/lib/PageLock/Installer.php
+++ b/src/system/PageLock/lib/PageLock/Installer.php
@@ -35,6 +35,18 @@ class PageLock_Installer extends Zikula_AbstractInstaller
      */
     public function upgrade($oldversion)
     {
+        switch ($oldversion) {
+            case '1.0':
+            case '1.1': // shipped with Zikula 1.2.x
+            case '1.1.0':
+                // prefixes for column names may have changed
+                // easiest to just drop and recreate the table
+                DBUtil::dropTable('pagelock');
+                DBUtil::createTable('pagelock');
+            case '1.1.1':
+                //current version
+        }
+        
         return true;
     }
 

--- a/src/system/PageLock/tables.php
+++ b/src/system/PageLock/tables.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright Zikula Foundation 2009 - Zikula Application Framework
  *
@@ -12,43 +13,37 @@
  * information regarding copyright and licensing.
  */
 
-
-
 /**
  * define table information for the module
  *
  */
 function pagelock_tables()
 {
-  $dbtable = array();
-  $prefix = System::getVar('prefix');
-
+    $dbtable = array();
     // Lock table setup
+    $tableName = DBUtil::getLimitedTablename('pagelock');
+    $dbtable['pagelock'] = $tableName;
 
-  $tableName = DBUtil::getLimitedTablename('pagelock');
-  $dbtable['pagelock'] = $tableName;
-
-  $dbtable['pagelock_column'] =
-    array('id'                => 'plock_id',
-          'name'              => 'plock_name',
-          'createdDate'       => 'plock_cdate',
-          'expiresDate'       => 'plock_edate',
-          'lockedBySessionId' => 'plock_session',
-          'lockedByTitle'     => 'plock_title',
-          'lockedByIPNo'      => 'plock_ipno');
+    $dbtable['pagelock_column'] = array(
+        'id' => 'plock_id',
+        'name' => 'plock_name',
+        'createdDate' => 'plock_cdate',
+        'expiresDate' => 'plock_edate',
+        'lockedBySessionId' => 'plock_session',
+        'lockedByTitle' => 'plock_title',
+        'lockedByIPNo' => 'plock_ipno');
 
 
-  $def =
-    array('id'                => "I NOTNULL AUTO PRIMARY",
-          'name'              => "C(100) NOTNULL DEFAULT ''",
-          'createdDate'       => "T NOTNULL",
-          'expiresDate'       => "T NOTNULL",
-          'lockedBySessionId' => "C(50) NOTNULL",
-          'lockedByTitle'     => "C(100) NOTNULL",
-          'lockedByIPNo'      => "C(30) NOTNULL");
+    $def = array(
+        'id' => "I NOTNULL AUTO PRIMARY",
+        'name' => "C(100) NOTNULL DEFAULT ''",
+        'createdDate' => "T NOTNULL",
+        'expiresDate' => "T NOTNULL",
+        'lockedBySessionId' => "C(50) NOTNULL",
+        'lockedByTitle' => "C(100) NOTNULL",
+        'lockedByIPNo' => "C(30) NOTNULL");
 
-  $dbtable['pagelock_column_def'] = $def;
+    $dbtable['pagelock_column_def'] = $def;
 
-  return $dbtable;
+    return $dbtable;
 }
-


### PR DESCRIPTION
Since the table is simply a storage of temporary file locks, it is simplest to just drop the table and re-add it with whatever changes may be required.
