### PR TITLE
add "hover" classes to core style.css closes #3014

### DIFF
--- a/src/style/core.css
+++ b/src/style/core.css
@@ -70,7 +70,9 @@ img.z-floatright {
 }
 
 .z-calendarimg { background-color: transparent; }
-.z-calendarimg:hover { background-color: blue; }
+.z-calendarimg:hover,
+.z-calendarimg.hover
+{ background-color: blue; }
 
 /******************************************************************************
 * Class to show a sortable li or div. Has to be set in the js code to avoid
@@ -117,7 +119,8 @@ img.z-floatright {
 }
 
 #z-maincontent ul.z-menulinks li.z-ml-disabled a,
-#z-maincontent ul.z-menulinks li.z-ml-disabled a:hover {
+#z-maincontent ul.z-menulinks li.z-ml-disabled a:hover,
+#z-maincontent ul.z-menulinks li.z-ml-disabled a.hover{
     text-decoration:line-through;
 }
 
@@ -303,7 +306,8 @@ table.z-admintable tbody tr.z-defaulttablerow {
     color: #055F00;
 }
 
-table.z-datatable tbody tr:hover {
+table.z-datatable tbody tr:hover,
+table.z-datatable tbody tr.hover {
     background-color: #eee;
     color: #000;
 }
@@ -380,7 +384,16 @@ table.z-admintable ul {
 .z-form div.z-formrow textarea:hover,
 .z-form div.z-formrow input:active,
 .z-form div.z-formrow select:active,
-.z-form div.z-formrow textarea:active {
+.z-form div.z-formrow textarea:active
+.z-form div.z-formrow input.focus,
+.z-form div.z-formrow select.focus,
+.z-form div.z-formrow textarea.focus,
+.z-form div.z-formrow input.hover,
+.z-form div.z-formrow select.hover,
+.z-form div.z-formrow textarea.hover,
+.z-form div.z-formrow input.active,
+.z-form div.z-formrow select.active,
+.z-form div.z-formrow textarea.active {
     border: 1px solid #aaa;
     background: #fff;
 }
@@ -663,7 +676,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
 .z-itemlist li.z-itemsortheader {
     padding-left: 30px !important;
 }
-.z-itemlist li:hover {
+.z-itemlist li:hover,
+.z-itemlist li.hover {
     background-color: #CFCFCF;
 }
 .z-itemlist li input,
@@ -939,9 +953,13 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
 }
 
 .z-button:hover,
+.z-button.hover,
 .z-buttons a:hover,
+.z-buttons a.hover,
 .z-buttons input:hover,
-.z-buttons button:hover {
+.z-buttons input.hover,
+.z-buttons button:hover,
+.z-buttons button.hover {
     color: #222;
     text-decoration: none !important;
     background: #cfcfcf; /*non-CSS3 browsers*/
@@ -953,7 +971,11 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
 .z-button:active,
 .z-buttons a:active,
 .z-buttons input:active,
-.z-buttons button:active {
+.z-buttons button:active,
+.z-button.active,
+.z-buttons a.active,
+.z-buttons input.active,
+.z-buttons button.active {
     color: #000;
     background: #fafafa; /*non-CSS3 browsers*/
     background: -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)); /*webkit*/
@@ -980,7 +1002,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
 .z-buttons .z-btred:visited {
     color: #d12f19;
 }
-.z-buttons .z-btred:hover {
+.z-buttons .z-btred:hover,
+.z-buttons .z-btred.hover {
     color: #d12f19;
     border: 1px solid #EF7868;
     background: #fbc2c4;
@@ -988,7 +1011,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: -moz-linear-gradient(top, #fbc2c4, #fbe3e4);
     background: linear-gradient(#fbc2c4, #fbe3e4);
 }
-.z-buttons .z-btred:active {
+.z-buttons .z-btred:active,
+.z-buttons .z-btred.active {
     color: #d12f19;
     border: 1px solid #EF7868;
     background: #EFA4A7;
@@ -1006,7 +1030,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
 .z-buttons .z-btblue:visited {
     color: #336699;
 }
-.z-buttons .z-btblue:hover {
+.z-buttons .z-btblue:hover,
+.z-buttons .z-btblue.hover {
     color: #336699;
     border: 1px solid #6FA7DF;
     background: #c2e1ef;
@@ -1014,7 +1039,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: -moz-linear-gradient(top, #c2e1ef, #dff4ff);
     background: linear-gradient(#c2e1ef, #dff4ff);
 }
-.z-buttons .z-btblue:active {
+.z-buttons .z-btblue:active,
+.z-buttons .z-btblue.active {
     color: #336699;
     border: 1px solid #6FA7DF;
     background: #A7CEDF;
@@ -1032,7 +1058,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
 .z-buttons .z-btgreen:visited {
     color: #529214;
 }
-.z-buttons .z-btgreen:hover {
+.z-buttons .z-btgreen:hover,
+.z-buttons .z-btgreen.hover {
     color: #529214;
     border: 1px solid #A0DF61;
     background: #D1EFD2;
@@ -1040,7 +1067,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: -moz-linear-gradient(top, #D1EFD2, #EFFFEF);
     background: linear-gradient(#D1EFD2, #EFFFEF);
 }
-.z-buttons .z-btgreen:active {
+.z-buttons .z-btgreen:active,
+.z-buttons .z-btgreen.active {
     color: #529214;
     border: 1px solid #A0DF61;
     background-color:#C2EFC3;
@@ -1086,14 +1114,16 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/icons/extrasmall/button_ok.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#ffffff), to(#dfdfdf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/button_ok.png") 10px 50% no-repeat, linear-gradient(#ffffff, #dfdfdf); /*CSS3*/
 }
-.z-buttons .z-bt-ok:hover {
+.z-buttons .z-bt-ok:hover,
+.z-buttons .z-bt-ok.hover {
     background: url("../images/icons/extrasmall/button_ok.png") #cfcfcf 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/button_ok.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #fafafa, #cfcfcf) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/button_ok.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#cfcfcf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/button_ok.png") 10px 50% no-repeat, linear-gradient(#fafafa, #cfcfcf); /*CSS3*/
 }
 
-.z-buttons .z-bt-ok:active {
+.z-buttons .z-bt-ok:active,
+.z-buttons .z-bt-ok.active {
     background: url("../images/icons/extrasmall/button_ok.png") #fafafa 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/button_ok.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #cfcfcf, #fafafa) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/button_ok.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)) repeat scroll 0 0 transparent; /*webkit*/
@@ -1107,14 +1137,16 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/icons/extrasmall/button_cancel.png") 10px 50% no-repeat, linear-gradient(#ffffff, #dfdfdf); /*CSS3*/
 }
 
-.z-buttons .z-bt-cancel:hover {
+.z-buttons .z-bt-cancel:hover,
+.z-buttons .z-bt-cancel.hover {
     background: url("../images/icons/extrasmall/button_cancel.png") #cfcfcf 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/button_cancel.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #fafafa, #cfcfcf) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/button_cancel.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#cfcfcf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/button_cancel.png") 10px 50% no-repeat, linear-gradient(#fafafa, #cfcfcf); /*CSS3*/
 }
 
-.z-buttons .z-bt-cancel:active {
+.z-buttons .z-bt-cancel:active,
+.z-buttons .z-bt-cancel.active {
     background: url("../images/icons/extrasmall/button_cancel.png") #fafafa 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/button_cancel.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #cfcfcf, #fafafa) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/button_cancel.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)) repeat scroll 0 0 transparent; /*webkit*/
@@ -1128,14 +1160,16 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/icons/extrasmall/14_layer_novisible.png") 10px 50% no-repeat, linear-gradient(#ffffff, #dfdfdf); /*CSS3*/
 }
 
-.z-buttons .z-bt-preview:hover {
+.z-buttons .z-bt-preview:hover,
+.z-buttons .z-bt-preview.hover {
     background: url("../images/icons/extrasmall/14_layer_novisible.png") #cfcfcf 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/14_layer_novisible.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #fafafa, #cfcfcf) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/14_layer_novisible.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#cfcfcf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/14_layer_novisible.png") 10px 50% no-repeat, linear-gradient(#fafafa, #cfcfcf); /*CSS3*/
 }
 
-.z-buttons .z-bt-preview:active {
+.z-buttons .z-bt-preview:active,
+.z-buttons .z-bt-preview.active {
     background: url("../images/icons/extrasmall/14_layer_novisible.png") #fafafa 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/14_layer_novisible.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #cfcfcf, #fafafa) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/14_layer_novisible.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)) repeat scroll 0 0 transparent; /*webkit*/
@@ -1149,14 +1183,16 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/icons/extrasmall/filenew.png") 10px 50% no-repeat, linear-gradient(#ffffff, #dfdfdf); /*CSS3*/
 }
 
-.z-buttons .z-bt-new:hover {
+.z-buttons .z-bt-new:hover,
+.z-buttons .z-bt-new.hover {
     background: url("../images/icons/extrasmall/filenew.png") #cfcfcf 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/filenew.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #fafafa, #cfcfcf) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/filenew.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#cfcfcf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/filenew.png") 10px 50% no-repeat, linear-gradient(#fafafa, #cfcfcf); /*CSS3*/
 }
 
-.z-buttons .z-bt-new:active {
+.z-buttons .z-bt-new:active,
+.z-buttons .z-bt-new.active {
     background: url("../images/icons/extrasmall/filenew.png") #fafafa 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/filenew.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #cfcfcf, #fafafa) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/filenew.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)) repeat scroll 0 0 transparent; /*webkit*/
@@ -1177,7 +1213,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/icons/extrasmall/filesave.png") 10px 50% no-repeat, linear-gradient(#fafafa, #cfcfcf); /*CSS3*/
 }
 
-.z-buttons .z-bt-save:active {
+.z-buttons .z-bt-save:active,
+.z-buttons .z-bt-save.active {
     background: url("../images/icons/extrasmall/filesave.png") #fafafa 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/filesave.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #cfcfcf, #fafafa) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/filesave.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)) repeat scroll 0 0 transparent; /*webkit*/
@@ -1191,14 +1228,16 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/icons/extrasmall/edit.png") 10px 50% no-repeat, linear-gradient(#ffffff, #dfdfdf); /*CSS3*/
 }
 
-.z-buttons .z-bt-edit:hover {
+.z-buttons .z-bt-edit:hover,
+.z-buttons .z-bt-edit.hover {
     background: url("../images/icons/extrasmall/edit.png") #cfcfcf 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/edit.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #fafafa, #cfcfcf) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/edit.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#cfcfcf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/edit.png") 10px 50% no-repeat, linear-gradient(#fafafa, #cfcfcf); /*CSS3*/
 }
 
-.z-buttons .z-bt-edit:active {
+.z-buttons .z-bt-edit:active,
+.z-buttons .z-bt-edit.active {
     background: url("../images/icons/extrasmall/edit.png") #fafafa 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/edit.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #cfcfcf, #fafafa) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/edit.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)) repeat scroll 0 0 transparent; /*webkit*/
@@ -1212,14 +1251,16 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/icons/extrasmall/folder.png") 10px 50% no-repeat, linear-gradient(#ffffff, #dfdfdf); /*CSS3*/
 }
 
-.z-buttons .z-bt-archive:hover {
+.z-buttons .z-bt-archive:hover,
+.z-buttons .z-bt-archive.hover {
     background: url("../images/icons/extrasmall/folder.png") #cfcfcf 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/folder.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #fafafa, #cfcfcf) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/folder.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#cfcfcf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/folder.png") 10px 50% no-repeat, linear-gradient(#fafafa, #cfcfcf); /*CSS3*/
 }
 
-.z-buttons .z-bt-archive:active {
+.z-buttons .z-bt-archive:active,
+.z-buttons .z-bt-archive.active {
     background: url("../images/icons/extrasmall/folder.png") #fafafa 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/folder.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #cfcfcf, #fafafa) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/folder.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)) repeat scroll 0 0 transparent; /*webkit*/
@@ -1233,14 +1274,16 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/icons/extrasmall/14_layer_deletelayer.png") 10px 50% no-repeat, linear-gradient(#ffffff, #dfdfdf); /*CSS3*/
 }
 
-.z-buttons .z-bt-delete:hover {
+.z-buttons .z-bt-delete:hover,
+.z-buttons .z-bt-delete.hover {
     background: url("../images/icons/extrasmall/14_layer_deletelayer.png") #cfcfcf 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/14_layer_deletelayer.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #fafafa, #cfcfcf) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/14_layer_deletelayer.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#cfcfcf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/14_layer_deletelayer.png") 10px 50% no-repeat, linear-gradient(#fafafa, #cfcfcf); /*CSS3*/
 }
 
-.z-buttons .z-bt-delete:active {
+.z-buttons .z-bt-delete:active,
+.z-buttons .z-bt-delete.active {
     background: url("../images/icons/extrasmall/14_layer_deletelayer.png") #fafafa 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/14_layer_deletelayer.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #cfcfcf, #fafafa) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/14_layer_deletelayer.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)) repeat scroll 0 0 transparent; /*webkit*/
@@ -1253,13 +1296,15 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/icons/extrasmall/filter.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#ffffff), to(#dfdfdf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/filter.png") 10px 50% no-repeat, linear-gradient(#ffffff, #dfdfdf); /*CSS3*/
 }
-.z-buttons .z-bt-filter:hover {
+.z-buttons .z-bt-filter:hover,
+.z-buttons .z-bt-filter.hover {
     background: url("../images/icons/extrasmall/filter.png") #cfcfcf 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/filter.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #fafafa, #cfcfcf) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/filter.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#cfcfcf)) repeat scroll 0 0 transparent; /*webkit*/
     background: url("../images/icons/extrasmall/filter.png") 10px 50% no-repeat, linear-gradient(#fafafa, #cfcfcf); /*CSS3*/
 }
-.z-buttons .z-bt-filter:active {
+.z-buttons .z-bt-filter:active,
+.z-buttons .z-bt-filter.active {
     background: url("../images/icons/extrasmall/filter.png") #fafafa 10px 50% no-repeat; /*non-CSS3 browsers*/
     background: url("../images/icons/extrasmall/filter.png") 10px 50% no-repeat, -moz-linear-gradient(top,  #cfcfcf, #fafafa) repeat scroll 0 0 transparent; /*gecko*/
     background: url("../images/icons/extrasmall/filter.png") 10px 50% no-repeat, -webkit-gradient(linear, left top, left bottom, from(#cfcfcf), to(#fafafa)) repeat scroll 0 0 transparent; /*webkit*/
@@ -1316,7 +1361,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     overflow: hidden;
 }
 
-.z-window:focus {
+.z-window:focus,
+.z-window.focus {
     outline: none;
 }
 
@@ -1403,7 +1449,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     cursor: pointer;
 }
 
-.z-window .z-window-control:hover {
+.z-window .z-window-control:hover,
+.z-window .z-window-control.hover {
     background-position: 80px 0;
 }
 
@@ -1591,7 +1638,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     text-decoration: none;
 }
 
-.z-tabs li > a:hover {
+.z-tabs li > a:hover,
+.z-tabs li > a.hover {
     background: #fff !important;
     color: #000;
     text-decoration: none;
@@ -1603,7 +1651,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     z-index: 2000;
 }
 
-.z-tabs li.active a:hover {
+.z-tabs li.active a:hover,
+.z-tabs li.active a.hover {
     border-right: 1px solid transparent;
 }
 
@@ -1634,7 +1683,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     display: block;
 }
 
-.z-accordion .z-acc-header:hover {
+.z-accordion .z-acc-header:hover,
+.z-accordion .z-acc-header.hover {
     background: #cfcfcf; /*non-CSS3 browsers*/
     background: -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#cfcfcf)); /*webkit*/
     background: -moz-linear-gradient(top, #fafafa, #cfcfcf); /*gecko*/
@@ -1673,14 +1723,16 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     background: url("../images/global/arrow_up_grey.png") transparent 100% 50% no-repeat;
     padding-right: 12px;
 }
-.z-order-asc:hover {
+.z-order-asc:hover,
+.z-order-asc.hover {
     background: url("../images/global/arrow_up_black.png") transparent 100% 50% no-repeat;
 }
 .z-order-desc {
     background: url("../images/global/arrow_down_grey.png") transparent 100% 50% no-repeat;
     padding-right: 12px;
 }
-.z-order-desc:hover {
+.z-order-desc:hover,
+.z-order-desc.hover {
     background: url("../images/global/arrow_down_black.png") transparent 100% 50% no-repeat;
 }
 .z-order-unsorted {
@@ -1756,7 +1808,8 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
     position: relative;
 }
 
-.z-drop:hover {
+.z-drop:hover,
+.z-drop.hover {
     background: url("../images/global/arrow_down_black.png") no-repeat scroll 100% 50% transparent;
 }
 
@@ -1801,21 +1854,24 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
 }
 
 #control_contextmenu ul li.selected,
-#control_contextmenu ul li:hover {
+#control_contextmenu ul li:hover,
+#control_contextmenu ul li.hover {
     background-color:#3875D7;
     color:#FFFFFF;
     cursor:pointer;
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
 }
 
-#control_contextmenu ul li.selected:hover {
+#control_contextmenu ul li.selected:hover,
+#control_contextmenu ul li.selected.hover {
     color: #333;
     background-color: #f3f3f3;
     cursor: pointer;
 }
 
 #control_contextmenu ul li.disabled,
-#control_contextmenu ul li:hover.disabled {
+#control_contextmenu ul li:hover.disabled,
+#control_contextmenu ul li.hover.disabled {
     background-color: #eee;
     color: #999;
     cursor: pointer;


### PR DESCRIPTION
convert e.g. table.z-datatable tbody tr:hover {}
to
table.z-datatable tbody tr.hover,
table.z-datatable tbody tr:hover {}

I don't really know what I'm doing here, but just followed directions in the ticket...
