### PR TITLE
correct absolute path usage in FileUtil::deldir() and correct how that is

### DIFF
--- a/src/lib/EventHandlers/SystemListeners.php
+++ b/src/lib/EventHandlers/SystemListeners.php
@@ -590,7 +590,7 @@ class SystemListeners extends Zikula_AbstractEventHandler
         // remove generated category models for this record
         $dir = 'doctrinemodels/GeneratedDoctrineModel/' . $moduleName;
         if (file_exists(CacheUtil::getLocalDir($dir))) {
-            CacheUtil::removeLocalDir($dir);
+            CacheUtil::removeLocalDir($dir, true);
         }
 
         // remove saved data about the record

--- a/src/lib/util/CacheUtil.php
+++ b/src/lib/util/CacheUtil.php
@@ -64,11 +64,11 @@ class CacheUtil
      *
      * @return boolean true if successful, false otherwise.
      */
-    public static function removeLocalDir($dir)
+    public static function removeLocalDir($dir, $absolute = false)
     {
         $path = DataUtil::formatForOS(System::getVar('temp'), true) . '/' . $dir;
 
-        return FileUtil::deldir($path);
+        return FileUtil::deldir($path, $absolute);
     }
 
     /**
@@ -84,7 +84,7 @@ class CacheUtil
      */
     public static function clearLocalDir($dir)
     {
-        self::removeLocalDir($dir);
-        self::createLocalDir($dir);
+        self::removeLocalDir($dir, true);
+        self::createLocalDir($dir, null, true);
     }
 }

--- a/src/lib/util/FileUtil.php
+++ b/src/lib/util/FileUtil.php
@@ -271,7 +271,7 @@ class FileUtil
         if ($dh = opendir($path)) {
             while (($file = readdir($dh)) !== false) {
                 if (is_dir("$path/$file") && ($file != '.' && $file != '..')) {
-                    self::deldir("$path/$file");
+                    self::deldir("$path/$file", $absolute);
                 } else if ($file != '.' && $file != '..') {
                     unlink("$path/$file");
                 }


### PR DESCRIPTION
correct absolute path usage in FileUtil::deldir() and correct how that is utilized in CacheUtil. fixes #3058
