### PR TITLE
Change declaration of Zikula_View_Theme::clear_config() to be compatible 

### DIFF
--- a/src/lib/Zikula/View/Theme.php
+++ b/src/lib/Zikula/View/Theme.php
@@ -780,18 +780,13 @@ class Zikula_View_Theme extends Zikula_View
     }
 
     /**
-     * Clears the configuration located on the temporary directory.
-     *
-     * @param string $template   The name of the template.
-     * @param string $cache_id   The cache ID (optional).
-     * @param string $compile_id The compile ID (optional).
-     * @param string $expire     Minimum age in sec. the cache file must be before it will get cleared (optional).
+     * Clears the Theme configuration located on the temporary directory.
      *
      * @return boolean True on success, false otherwise.
      */
-    public function clear_config()
+    public function clear_config($var = null)
     {
-        $configdir = CacheUtil::getLocalDir() . '/Theme_Config';
+        $configdir = CacheUtil::getLocalDir('Theme_Config');
 
         return $this->clear_folder($configdir, null, null, null);
     }


### PR DESCRIPTION
Change declaration of Zikula_View_Theme::clear_config() to be compatible with that of Smarty::clear_config(). Fixes #3086.

Also changed how that local directory location was constructed to take advantage of the CacheUtil function properly.
