### PR TITLE
Removes the modal:true from the Permission rules information display.

### DIFF
--- a/src/system/Permissions/templates/permissions_admin_menu.tpl
+++ b/src/system/Permissions/templates/permissions_admin_menu.tpl
@@ -5,7 +5,7 @@
             Element.addClassName('permissions_new', 'z-hide');
 
             $$('.showinstanceinformation').each(function(element) {
-                new Zikula.UI.Window(element,{width: 600, iframe: true, modal:true, resizable: true});
+                new Zikula.UI.Window(element,{width: 600, iframe: true, resizable: true});
             });
         });
     </script>


### PR DESCRIPTION
Removed the modal:true flag from the Zikula.UI.Window that displays the Permission rules information box.   Closes #3091
