### PR TITLE
Entities "&#123" and "&#125" doesn't end in ";"

### DIFF
--- a/src/system/Blocks/templates/blocks_admin_view.tpl
+++ b/src/system/Blocks/templates/blocks_admin_view.tpl
@@ -133,7 +133,7 @@
         <tr class="{cycle values="z-odd,z-even" name=blockpositions}">
             <td>{$position.name|safehtml}</td>
             <td>{$position.description|truncate:25|safehtml}</td>
-            <td><pre style="margin:0;padding:0;">&#123blockposition name={$position.name|safehtml}&#125</pre></td>
+            <td><pre style="margin:0;padding:0;">&#123;blockposition name={$position.name|safehtml}&#125;</pre></td>
             <td class="z-right">
                 {foreach item=option from=$position.options}
                 <a href="{$option.url|safetext}">{img modname=core src=$option.image set=icons/extrasmall title=$option.title alt=$option.title class='tooltips'}</a>


### PR DESCRIPTION
Entities "&#123" and "&#125" doesn't end in ";" this generate some warnings in html validation in /index.php?module=blocks&type=admin&func=view
