### PR TITLE
Ticket 168

### DIFF
--- a/src/system/Groups/lib/Groups/Api/User.php
+++ b/src/system/Groups/lib/Groups/Api/User.php
@@ -51,8 +51,7 @@ class Groups_Api_User extends Zikula_AbstractApi
         $orderBy = "ORDER BY $groupcolumn[name]";
         $permFilter = array(array('realm' => 0,
                         'component_left' => 'Groups',
-                        'instance_left' => 'name',
-                        'instance_right' => 'gid',
+                        'instance_left' => 'gid',
                         'level' => ACCESS_READ));
         $objArray = DBUtil::selectObjectArray('groups', '', $orderBy, $args['startnum'] - 1, $args['numitems'], '', $permFilter);
 


### PR DESCRIPTION
Fixes #168

Small fix to src/system/Groups/lib/Groups/Api/User.php to make getall() comply with the permission instance structure of the rest of the Groups module.

@drak - When I created this pull request, the branch on zikula/core that was automatically selected was 'master'. I had to change it to 'release-1.3' manually. I only noticed it because I was specifically looking for it. Otherwise, it is easy to miss. I think @tfotis is correct about the "default" branch situation. If you want PRs to default to release-1.3, then you might want to see if there is a setting for that.
