### PR TITLE
Default for StandardFields uid. Issue #240

### DIFF
--- a/src/plugins/DoctrineExtensions/lib/DoctrineExtensions/StandardFields/Mapping/Event/Adapter/ORM.php
+++ b/src/plugins/DoctrineExtensions/lib/DoctrineExtensions/StandardFields/Mapping/Event/Adapter/ORM.php
@@ -17,6 +17,6 @@ final class ORM extends BaseAdapterORM implements StandardFieldsAdapter
      */
     public function getUserIdValue(ClassMetadata $meta, $field)
     {
-        return \UserUtil::getVar('uid');
+        return \SessionUtil::getVar('uid', 0);
     }
 }


### PR DESCRIPTION
Provide a default value for uid "standard" fields, consistent with how ObjectUtil handles uid fields. Fixes #240
