### PR TITLE
Fixed Zikula_View_Plugin domain resolution and removed deprecated var

### DIFF
--- a/src/lib/Zikula/View/Plugin.php
+++ b/src/lib/Zikula/View/Plugin.php
@@ -100,9 +100,9 @@ class Zikula_View_Plugin extends Zikula_View
 
         // for {gt} template plugin to detect gettext domain
         if ($view->module[$moduleName]['type'] == ModUtil::TYPE_MODULE || $view->module[$moduleName]['type'] == ModUtil::TYPE_SYSTEM) {
-            $view->renderDomain = ZLanguage::getModulePluginDomain($view->module[$moduleName]['name'], $view->pluginName);
+            $view->domain = ZLanguage::getModulePluginDomain($view->module[$moduleName]['name'], $view->getPluginName());
         } elseif ($view->module[$moduleName]['type'] == ModUtil::TYPE_CORE) {
-            $view->renderDomain = ZLanguage::getSystemPluginDomain($view->module[$moduleName]['name'], $view->pluginName);
+            $view->domain = ZLanguage::getSystemPluginDomain($view->getPluginName());
         }
 
         return $view;

--- a/src/lib/viewplugins/function.gt.php
+++ b/src/lib/viewplugins/function.gt.php
@@ -46,9 +46,6 @@
  */
 function smarty_function_gt($params, Zikula_View $view)
 {
-    // the check order here is important because:
-    // if we are calling from a theme both $view->themeDomain and $view->renderDomain are set.
-    // if the call was from a template only $view->renderDomain is set.
     if (isset($params['domain'])) {
         $domain = (strtolower($params['domain']) == 'zikula' ? null : $params['domain']);
     } else {

--- a/src/lib/viewplugins/function.modapifunc.php
+++ b/src/lib/viewplugins/function.modapifunc.php
@@ -44,7 +44,6 @@
  */
 function smarty_function_modapifunc($params, Zikula_View $view)
 {
-    //889$saveDomain = $view->renderDomain;
     $assign  = isset($params['assign'])                  ? $params['assign']  : null;
     $func    = isset($params['func']) && $params['func'] ? $params['func']    : 'main';
     $modname = isset($params['modname'])                 ? $params['modname'] : null;
@@ -67,9 +66,6 @@ function smarty_function_modapifunc($params, Zikula_View $view)
     }
 
     $result = ModUtil::apiFunc($modname, $type, $func, $params);
-
-    // ensure the renderDomain wasnt overwritten
-    //889$view->renderDomain = $saveDomain;
 
     if ($assign) {
         $view->assign($assign, $result);

--- a/src/lib/viewplugins/function.modfunc.php
+++ b/src/lib/viewplugins/function.modfunc.php
@@ -41,7 +41,6 @@
  */
 function smarty_function_modfunc($params, Zikula_View $view)
 {
-    //889$saveDomain = $view->renderDomain;
     $assign  = isset($params['assign'])                  ? $params['assign']  : null;
     $func    = isset($params['func']) && $params['func'] ? $params['func']    : 'main';
     $modname = isset($params['modname'])                 ? $params['modname'] : null;


### PR DESCRIPTION
There was a problem assigning the domain to the plugin, and to a `renderDomain`, which seems part of the initial gettext implementation. I've removed some references to it on some comments as it doesn't exists.
