### PR TITLE
Update the plugin img to support the new core elements

### DIFF
--- a/src/lib/viewplugins/function.img.php
+++ b/src/lib/viewplugins/function.img.php
@@ -96,15 +96,6 @@ function smarty_function_img($params, Zikula_View $view)
 
     // if the module name is 'core'
     if ($modname == 'core') {
-        if (!$osset) {
-            if (!$nostoponerror) {
-                $view->trigger_error(__f('Error! in %1$s: the %2$s parameter must be specified.', array('img', 'set')));
-                return;
-            } else {
-                return false;
-            }
-        }
-
         if (System::isLegacyMode() && (strpos($osset, 'icons/') !== false || strpos($osset, 'global/') !== false) && strpos($params['src'], '.gif')) {
             LogUtil::log(__f('Core image %s does not exist, please use the png format (called from %s).', array($params['src'], $view->getTemplatePath())), E_DEPRECATED);
             $params['src'] = str_replace('.gif', '.png', $params['src']);


### PR DESCRIPTION
Core and Module Plugins were out of consideration on the `{img}` plugin.

Also, I've reviewed it to improve it and enable the use of the `set` parameter not for `modname=core` only, as it's cool to be able to use any subfolder on the other image paths.
