### PR TITLE
mo2json not detecting custom catalogs because a path error

### DIFF
--- a/src/mo2json.php
+++ b/src/mo2json.php
@@ -75,7 +75,7 @@ foreach ($_GET as $domain => $meta) {
             break;
     }
 
-    $override = "config/$lang/LC_MESSAGES/{$domain}.mo";
+    $override = "config/locale/$lang/LC_MESSAGES/{$domain}.mo";
     $path = "{$type}locale";
     if (file_exists($override)) {
         $path = 'config/locale';


### PR DESCRIPTION
Module catalogs inside config/locale were not loaded properly by mo2json.php
