### PR TITLE
Another parenthesis oddity on FilterUtil with Doctrine

### DIFF
--- a/src/lib/util/FilterUtil/Filter/Default.php
+++ b/src/lib/util/FilterUtil/Filter/Default.php
@@ -273,11 +273,11 @@ class FilterUtil_Filter_Default extends FilterUtil_AbstractPlugin implements Fil
                 break;
 
             case 'null':
-                $where = "$column = '' OR $column IS NULL";
+                $where = "($column = '' OR $column IS NULL)";
                 break;
 
             case 'notnull':
-                $where = "$column <> '' OR $column IS NOT NULL";
+                $where = "($column <> '' OR $column IS NOT NULL)";
                 break;
         }
 


### PR DESCRIPTION
The query was built wrong without the parenthesis, available on the `getSQL` method but not in `getDQL`.
