### PR TITLE
Improve readability of Block assignments form in Blocks, Blocks position

### DIFF
--- a/src/system/Blocks/templates/blocks_admin_modifyposition.tpl
+++ b/src/system/Blocks/templates/blocks_admin_modifyposition.tpl
@@ -37,17 +37,21 @@
         <h4>{gt text="Blocks assigned to this position"}</h4>
         <ol id="assignedblocklist" class="z-itemlist">
             <li id="assignedblocklistheader" class="z-itemheader z-itemsortheader z-clearfix">
-                <span class="z-itemcell z-w25">{gt text="Title"}</span>
-                <span class="z-itemcell z-w25">{gt text="Module"}</span>
-                <span class="z-itemcell z-w25">{gt text="Name"}</span>
-                <span class="z-itemcell z-w25">{gt text="State"}</span>
+                <span class="z-itemcell z-w10">{gt text="Block ID"}</span>
+                <span class="z-itemcell z-w30">{gt text="Title, Description"}</span>
+                <span class="z-itemcell z-w15">{gt text="Module"}</span>
+                <span class="z-itemcell z-w15">{gt text="Name"}</span>
+                <span class="z-itemcell z-w15">{gt text="Language"}</span>
+                <span class="z-itemcell z-w15">{gt text="State"}</span>
             </li>
             {foreach item=block from=$assignedblocks}
             <li id="block_{$block.bid}" class="{cycle name=assignedblocklist values="z-odd,z-even"} z-sortable z-clearfix">
-                <span id="blockdrag_{$block.bid}" class="z-itemcell z-w25">{$block.title|safetext|default:"&nbsp;"}</span>
-                <span class="z-itemcell z-w25">{$block.modname|safetext}</span>
-                <span class="z-itemcell z-w25">{$block.bkey|safetext}</span>
-                <span class="z-itemcell z-w25">
+                <span class="z-itemcell z-w10">{$block.bid|safetext}</span>
+                <span id="blockdrag_{$block.bid}" class="z-itemcell z-w30">{$block.title|safehtml|default:"&nbsp;"}{if $block.title && $block.description},&nbsp;{/if}{$block.description|safehtml}</span>
+                <span class="z-itemcell z-w15">{$block.modname|safetext}</span>
+                <span class="z-itemcell z-w15">{$block.bkey|safetext}</span>
+                <span class="z-itemcell z-w15">{$block.language|safetext|default:"&nbsp;"}</span>
+                <span class="z-itemcell z-w15">
                     {if $block.active}
                     <a class="activationbutton" href="javascript:void(0);" onclick="toggleblock({$block.bid})" title="{gt text="Click to deactivate this block"}">{img src=greenled.png modname=core set=icons/extrasmall __alt="Active" id="active_`$block.bid`"}{img src=redled.png modname=core set=icons/extrasmall __alt="Inactive" style="display: none;" id="inactive_`$block.bid`"}</a>
                     <noscript><div>{img src=greenled.png modname=core set=icons/extrasmall __alt="Active"}</div></noscript>
@@ -66,17 +70,21 @@
         <h4>{gt text="Blocks not assigned to this position"}</h4>
         <ol id="unassignedblocklist" class="z-itemlist">
             <li id="unassignedblocklistheader" class="z-itemheader z-itemsortheader z-clearfix">
-                <span class="z-itemcell z-w25">{gt text="Title"}</span>
-                <span class="z-itemcell z-w25">{gt text="Module"}</span>
-                <span class="z-itemcell z-w25">{gt text="Name"}</span>
-                <span class="z-itemcell z-w25">{gt text="State"}</span>
+                <span class="z-itemcell z-w10">{gt text="Block ID"}</span>
+                <span class="z-itemcell z-w30">{gt text="Title, Description"}</span>
+                <span class="z-itemcell z-w15">{gt text="Module"}</span>
+                <span class="z-itemcell z-w15">{gt text="Name"}</span>
+                <span class="z-itemcell z-w15">{gt text="Language"}</span>
+                <span class="z-itemcell z-w15">{gt text="State"}</span>
             </li>
             {foreach item=block from=$unassignedblocks}
             <li id="block_{$block.bid}" class="{cycle name=unassignedblocklist values="z-odd,z-even"} z-sortable z-clearfix">
-                <span id="blockdrag_{$block.bid}" class="z-itemcell z-w25">{$block.title|safetext|default:"&nbsp;"}</span>
-                <span class="z-itemcell z-w25">{$block.modname|safetext}</span>
-                <span class="z-itemcell z-w25">{$block.bkey|safetext}</span>
-                <span class="z-itemcell z-w25">
+                <span class="z-itemcell z-w10">{$block.bid|safetext}</span>
+                <span id="blockdrag_{$block.bid}" class="z-itemcell z-w30">{$block.title|safehtml|default:"&nbsp;"}{if $block.title && $block.description},&nbsp;{/if}{$block.description|safehtml}</span>
+                <span class="z-itemcell z-w15">{$block.modname|safetext}</span>
+                <span class="z-itemcell z-w15">{$block.bkey|safetext}</span>
+                <span class="z-itemcell z-w15">{$block.language|safetext|default:"&nbsp;"}</span>
+                <span class="z-itemcell z-w15">
                     {if $block.active}
                     <a class="activationbutton" href="javascript:void(0);" onclick="toggleblock({$block.bid})" title="{gt text="Click to deactivate this block"}">{img src=greenled.png modname=core set=icons/extrasmall __alt="Active" id="active_`$block.bid`"}{img src=redled.png modname=core set=icons/extrasmall __alt="Inactive" style="display: none;" id="inactive_`$block.bid`"}</a>
                     <noscript><div>{img src=greenled.png modname=core set=icons/extrasmall __alt="Active"}</div></noscript>


### PR DESCRIPTION
Improvements:
1. Allowed title and description fields to have simple html (links, images).
2. Added Block ID column.
Added block language column.
3. Added description column (appended to title).

Now blocks without tile can more easily be managed, and simple html now don't destroy the table.
