### PR TITLE
Search block not considering custom search options

### DIFF
--- a/src/system/Search/lib/Search/Block/Search.php
+++ b/src/system/Search/lib/Search/Block/Search.php
@@ -67,13 +67,20 @@ class Search_Block_Search extends Zikula_Controller_AbstractBlock
             $vars['active'] = array();
         }
 
-        // assign the block vars array
-        $this->view->assign('vars', $vars);
-
         // set a title if one isn't present
         if (empty($blockinfo['title'])) {
             $blockinfo['title'] = __('Search');
         }
+
+        $plugin_options = array();
+
+        foreach(array_keys($vars['active']) as $mod) {
+            $plugin_options[$mod] = ModUtil::apiFunc($mod, 'search', 'options', $vars);
+        }
+
+        // assign the block vars and the plgin options
+        $this->view->assign('vars', $vars)
+                   ->assign('plugin_options', $plugin_options);
 
         // return the rendered block
         $blockinfo['content'] = $this->view->fetch('search_block_search.tpl');
@@ -92,9 +99,6 @@ class Search_Block_Search extends Zikula_Controller_AbstractBlock
         // Get current content
         $vars = BlockUtil::varsFromContent($blockinfo['content']);
 
-        // get all the search plugins
-        $search_modules = ModUtil::apiFunc('Search', 'user', 'getallplugins');
-
         // set some defaults
         if (!isset($vars['displaySearchBtn'])) {
             $vars['displaySearchBtn'] = 0;
@@ -103,6 +107,9 @@ class Search_Block_Search extends Zikula_Controller_AbstractBlock
         if (!isset($vars['active'])) {
             $vars['active'] = array();
         }
+
+        // get all the search plugins
+        $search_modules = ModUtil::apiFunc('Search', 'user', 'getallplugins');
 
         $searchmodules = array();
         if (is_array($search_modules)) {

--- a/src/system/Search/templates/search_block_search.tpl
+++ b/src/system/Search/templates/search_block_search.tpl
@@ -10,11 +10,11 @@
                 <input class="z-bt-ok z-bt-small" type="submit" value="{gt text="Search now" domain='zikula'}" />
             </div>
             {/if}
-            {if isset($vars.active) && is_array($vars.active)}
-            {foreach item="dummy" key="actives" from=$vars.active}
-            <input type="hidden" name="active[{$actives|safetext}]" value="1" />
+            <div style="display: none">
+            {foreach from=$plugin_options key='plugin' item='plugin_option'}
+            {$plugin_option}
             {/foreach}
-            {/if}
+            </div>
             
             {searchvartofieldnames data=$modvars.Search prefix="modvar" assign="modvariables"}
             {foreach item="value" key="name" from=$modvariables}


### PR DESCRIPTION
The block behaves differently than the form.
I've opted to hide the plugin options available in the main form,
as there's no method to fetch the hidden inputs from the search apis.
