### PR TITLE
Wrapper for each hook called by notifydisplayhooks plugin

### DIFF
--- a/src/lib/viewplugins/function.notifydisplayhooks.php
+++ b/src/lib/viewplugins/function.notifydisplayhooks.php
@@ -62,7 +62,7 @@ function smarty_function_notifydisplayhooks($params, Zikula_View $view)
 
     $output = '';
     foreach ($responses as $result) {
-        $output .= "$result\n";
+        $output .= "<div class=\"z-displayhook\">$result</div>\n";
     }
 
     return $output;


### PR DESCRIPTION
Adds layout control for the display hooks as mentioned in zikula/core#326
