### PR TITLE
Corrections to search results formatting

### DIFF
--- a/src/lib/util/StringUtil.php
+++ b/src/lib/util/StringUtil.php
@@ -158,7 +158,7 @@ class StringUtil
     {
         // Strip HTML tags and special chars completely
         $text = strip_tags($text);
-        $text = html_entity_decode($text);
+        $text = html_entity_decode($text, null, 'UTF-8');
 
         // Split words into word array
         $words = preg_split('/ /', $wordStr, -1, PREG_SPLIT_NO_EMPTY);

--- a/src/system/Search/templates/search_user_results.tpl
+++ b/src/system/Search/templates/search_user_results.tpl
@@ -19,7 +19,7 @@
 
     </dt>
     <dd>
-        {$result.text|google_highlight:$q:$limitsummary|strip_tags|truncate:$limitsummary:'&hellip;'}
+        {$result.text|google_highlight:$q:$limitsummary|truncate:$limitsummary:'&hellip;'}
         {if !empty($result.created)}
         <div class="search_created">{gt text="Created on %s." tag1=$result.created|dateformat:'datelong' domain='zikula'}</div>
         {/if}


### PR DESCRIPTION
- Removed dublicate usage of strip_tags in template, which removes google_highlight effect from displayed results (strip_tags is also used in google_highlight function);
- Correct 3-th argument (UTF-8) for php function html_entity_decode in method highlightWords in class StringUtil.php. This prevents to be displayed ugly characters in PHP 5.3 for entities like &nbsp; (space) in search results.
