### PR TITLE
Special treatment for modules' admin icons on {img}

### DIFF
--- a/src/lib/viewplugins/function.img.php
+++ b/src/lib/viewplugins/function.img.php
@@ -156,6 +156,9 @@ function smarty_function_img($params, Zikula_View $view)
             // form the array of paths
             if ($modname == 'core') {
                 $paths = array($themepath, $corethemepath, $modpath);
+            } elseif (preg_match('/^admin.(png|gif|jpg)$/', $params['src'])) {
+                // special processing for modules' admin icon
+                $paths = array($modlangpath, $modpath, $modlangpathOld, $modpathOld);
             } else {
                 $paths = array($themelangpath, $themepath, $corethemepath, $modlangpath, $modpath, $modlangpathOld, $modpathOld);
             }


### PR DESCRIPTION
Do not let the theme to override module's admin icons on the admin panel.
