### PR TITLE
Updated Zikula_Form_Block_ContextMenu::renderBegin to get the hidden for...

### DIFF
--- a/src/lib/Zikula/Form/Block/ContextMenu.php
+++ b/src/lib/Zikula/Form/Block/ContextMenu.php
@@ -132,7 +132,7 @@ class Zikula_Form_Block_ContextMenu extends Zikula_Form_AbstractStyledPlugin
             $cssClass = ($this->cssClass == null ? "contextMenu" : $this->cssClass);
             $attributes = $this->renderAttributes($view);
             $hiddenName = "contentMenuArgument" . $this->id;
-            $html = "<div id=\"{$this->id}\" class=\"{$cssClass}\"{$attributes}><input type=\"hidden\" name=\"{$hiddenName}\" id=\"{$hiddenName}\" /><ul>";
+            $html = "<input type=\"hidden\" name=\"{$hiddenName}\" id=\"{$hiddenName}\" /><div id=\"{$this->id}\" class=\"{$cssClass}\"{$attributes}><ul>";
 
             return $html;
         } else {


### PR DESCRIPTION
...m field with the CommandArgument outside the div of the ContextMenu itself. This field is not submitted from within a hidden div in IE browsers. I think Content is the only module (or one of the few) using this Form Contextmenu a lot and it is quite annoying that it does not work in IE browsers.

See also https://github.com/zikula-modules/Content/issues/94 where this issue is being described.
