### PR TITLE
allow paths to begin with ../ so that relative paths can be used.

### DIFF
--- a/src/lib/util/DataUtil.php
+++ b/src/lib/util/DataUtil.php
@@ -412,9 +412,16 @@ class DataUtil
                 if ($current == '.') {
                     // current path element is a dot, so we don't do anything
                 } elseif ($current == '..') {
-                    // current path element is .., so we remove the last path in case of relative paths
+                    // current path element is .. and path is relative
                     if (!$absolutepathused) {
-                        array_pop($clean_array);
+                        // if the array isn't empty
+                        if (!empty($clean_array)) {
+                            // we remove the last path
+                            array_pop($clean_array);
+                        } else {
+                            // if it is empty, we allow the path to begin with '../'
+                            $clean_array[] = $current;
+                        }
                     }
                 } else {
                     // current path element is valid, so we add it to the path


### PR DESCRIPTION
I encountered this with the Downloads module. If I set the upload path to be above the document root by using a path like '../myspecial_upload_dir' then the FormatForOS() method would eliminate the '../' part. This made using the desired directory impossible. These changes allow for that possibility. Since I do not fully understand the ramifications of these changes, I cannot be sure that I have done this correctly. I've tried to document my intentions, but I would appreciate your thoughts on the matter.
