### PR TITLE
refers to #69 category names multi lang empties

### DIFF
--- a/src/system/Categories/lib/Categories/Installer.php
+++ b/src/system/Categories/lib/Categories/Installer.php
@@ -88,9 +88,7 @@ class Categories_Installer extends Zikula_AbstractInstaller
             case '1.04':
                 $this->upgrade_fixSerializedData();
                 $this->upgrade_MigrateLanguageCodes();
-
             case '1.1':
-                $this->upgrade_MigrateLanguageCodes();
             case '1.2':
                 // new column used in doctrine categorisable template
                 DoctrineUtil::createColumn('categories_mapobj', 'reg_property', array('type' => 'string',


### PR DESCRIPTION
During upgrading the cat_names and cat_desc are empties for a multi lang install. This PR removes this line, which is not needed for zk12x installs.
