### PR TITLE
fixes #442 Non-static method ZLanguage::getLanguageCodeLegacy()

### DIFF
--- a/src/lib/i18n/ZLanguage.php
+++ b/src/lib/i18n/ZLanguage.php
@@ -329,7 +329,7 @@ class ZLanguage
      *
      * @return string
      */
-    public function getLanguageCodeLegacy()
+    public static function getLanguageCodeLegacy()
     {
         return self::getInstance()->languageCodeLegacy;
     }


### PR DESCRIPTION
This method seems to be the only get method in ZLanguage that is not statically defined. All the other methods, including the legacy are. So the PR corrects this.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Tests pass: na
Fixes tickets: #442
References: -
License of the code: LGPLv3+
Documentation PR: -
Todo: -
