### PR TITLE
[JavaScript] Add basic ajax setup for jQuery to pass csrf token checks

### DIFF
--- a/src/docs/CHANGELOG
+++ b/src/docs/CHANGELOG
@@ -8,7 +8,7 @@ Fixes:
 
 Features:
 - Added development/debug email mode
-
+- Added basic setup for jQuery ajax to pass csfr token checks
 
 CHANGELOG - ZIKULA 1.3.4
 ------------------------

--- a/src/javascript/jquery/noconflict.js
+++ b/src/javascript/jquery/noconflict.js
@@ -1,1 +1,17 @@
 jQuery.noConflict();
+// setup ajax for jQuery
+(function($) {
+    var defaultOptions = {
+        type: 'POST',
+        timeout: Zikula.Config.ajaxtimeout || 5000
+    };
+    if (Zikula.Config.sessionName) {
+        var sessionId = new RegExp(Zikula.Config.sessionName + '=(.*?)(;|$)').exec(document.cookie);
+        if (sessionId && sessionId[1]) {
+            defaultOptions.headers = {
+                'X-ZIKULA-AJAX-TOKEN': sessionId[1]
+            };
+        }
+    }
+    $.ajaxSetup(defaultOptions);
+})(jQuery);


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Tests pass: na
Fixes tickets: -
References: -
License of the code: LGPLv3+
Documentation PR: -
Todo: -

This is small addition for jQuery, which will allow to use jQuery ajax methods inside Zikula.
Without this jQuery ajax calls to ajax controllers won't pass csrf check (as such request don't have http header with csrf token).

Does anybody has something against this commit?
