### PR TITLE
[Mobile theme] Added some css out of core.css

### DIFF
--- a/src/themes/Mobile/style/style.css
+++ b/src/themes/Mobile/style/style.css
@@ -85,3 +85,43 @@ h3 {
     margin: 0.5em 0 !important;
     padding: 0 !important;
 }
+
+/******************************************************************************
+* Special styles for the Zikula Form Handler
+******************************************************************************/
+
+.z-form .z-formrow .z-mandatorysym, /* mandatorysym will be removed in future version */
+.z-form-mandatory-flag {
+    color: #f00;
+    font-weight: bold;
+    padding-left: 3px;
+    display: inline;
+}
+
+.z-form div.z-formrow input[type=text].z-form-mandatory,
+.z-form div.z-formrow select.z-form-mandatory,
+.z-form div.z-formrow textarea.z-form-mandatory {
+    width: 66%;
+}
+
+.z-form .z-formrow input.z-form-float,
+.z-form .z-formrow input.z-form-int {
+    text-align: right;
+    max-width: 15%;
+    display: inline;
+}
+
+.z-form .z-formrow .z-form-readonly {
+    background: #FAFAFA;
+    color: #AAAAAA;
+    cursor: not-allowed;
+}
+
+.z-form .z-formrow .z-form-error {
+    background: #ffe1da;
+    border: 1px solid #f34f4f;
+}
+
+.z-form-validationSummary label {
+    cursor: pointer;
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Tests pass: yes
Fixes tickets: ---
References: ---
License of the code: LGPLv3+
Documentation PR: ---
Todo: --

I added css for error-/warning-/status-messages, because they where not formatted.
I added css for form handlers, because invalid fields where not shown without the css.
Later, this has to be replaced by jquerymobile css, but currently jquerymobile does not suppoert error-/warning-/status-messages. So I used a part of core.css to make them look right.
