### PR TITLE
Update src/lib/dbobject/DBObject.php

### DIFF
--- a/src/lib/dbobject/DBObject.php
+++ b/src/lib/dbobject/DBObject.php
@@ -381,7 +381,6 @@ class DBObject
             }
 
             $this->_objKey = $where;
-            $this->_objField = 'WHERE';
         } else {
             // generic key=>value lookup
             if ($this->_objJoin) {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Tests pass: yes
Fixes tickets: 
References: 
License of the code: LGPLv3+
Documentation PR: Fixes the case where a single object which is retrieved 
by a where-clause then overwrites the _objField property which then can 
break subsequent selects or save() calls.
