### PR TITLE
Update src/lib/dbobject/DBObject.php

### DIFF
--- a/src/lib/dbobject/DBObject.php
+++ b/src/lib/dbobject/DBObject.php
@@ -678,7 +678,7 @@ class DBObject
             return false;
         }
 
-        $res = DBUtil::updateObject($this->_objData, $this->_objType, '', $this->_objField);
+        $res = DBUtil::updateObject($this->_objData, $this->_objType, '', $this->_objField, $this->_objInsertPreserve);
         if ($res) {
             $this->updatePostProcess();
             return $this->_objData;


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Tests pass: yes
Fixes tickets: 
References: 
License of the code: LGPLv3+
Documentation PR: This makes DBObject correctly handle the _objInsertPreserve flag.
