### PR TITLE
fixes #621, added fileupload input styling Webkit

### DIFF
--- a/src/style/core.css
+++ b/src/style/core.css
@@ -390,6 +390,23 @@ table.z-admintable ul li {
     border: 1px solid #fafafa;
 }
 
+.z-form div.z-formrow input[type=file]{
+    display:inline;
+    cursor: pointer;
+    -webkit-appearance:none;
+}
+
+.z-form div.z-formrow input[type=file]::-webkit-file-upload-button{
+    -webkit-appearance: none;
+    cursor: pointer;
+    color: #444;
+    border-color: #CCCCCC #B9B9B9 #B9B9B9 #CCCCCC;
+    border-style: solid;
+    border-width: 1px;
+    background: -webkit-gradient(linear, left top, left bottom, from(#ffffff), to(#dfdfdf)); /*webkit*/
+    -webkit-border-radius: 3px;
+}
+
 .z-form .z-formrow select optgroup {
     font-style: normal;
     font-weight: bold;


### PR DESCRIPTION
webkit browsers have a different way of showing input file upload fields. 
This is messed up with the current formrow styling with display: block. 
This is fixed here, Firefox still works ok. Not tested in all browsers yet.

Styling of the webkit button is chosen the same as the regular buttons in core.css.
