### PR TITLE
Give the profile module the possibility to change the profilelink.

### DIFF
--- a/src/docs/CHANGELOG
+++ b/src/docs/CHANGELOG
@@ -8,6 +8,7 @@ Features:
 - Update jQuery-UI to 1.9.2
 - Zikula Form - automatically set proper form enctype when upload input is used
 - Added ModUtil::getModuleImagePath() for getting the admin image of a module
+- Give the profile module the possibility to change the profilelink.
 
 CHANGELOG - ZIKULA 1.3.5
 ------------------------

--- a/src/lib/viewplugins/modifier.profilelinkbyuid.php
+++ b/src/lib/viewplugins/modifier.profilelinkbyuid.php
@@ -45,38 +45,44 @@ function smarty_modifier_profilelinkbyuid($uid, $class = '', $image = '', $maxLe
     }
 
     $uid        = (float)$uid;
-    $uname      = UserUtil::getVar('uname', $uid);
-    $showUname  = DataUtil::formatForDisplay($uname);
-
+    
     $profileModule = System::getVar('profilemodule', '');
 
-    if ($uname && $uid && ($uid > 1) && !empty($profileModule) && ModUtil::available($profileModule)) {
+    if ($uid && ($uid > 1) && !empty($profileModule) && ModUtil::available($profileModule)) {
+        $userDisplayName = ModUtil::apiFunc($profileModule, 'user', 'getUserDisplayName', array('uid' => $uid));
+        
+        if (empty($userDisplayName)) {
+            $userDisplayName = UserUtil::getVar('uname', $uid);
+        }
+
+        
         if (!empty($class)) {
             $class = ' class="' . DataUtil::formatForDisplay($class) . '"';
         }
 
         if (!empty($image)) {
+            $userDisplayName = $DataUtil::formatForDisplay($userDisplayName);
             if (is_array($image)) {
                 // if it is an array we assume that it is an pnimg array
                 $show = '<img src="' . DataUtil::formatForDisplay($image['src']) . '" alt="' . DataUtil::formatForDisplay($image['alt']) . '" width="' . DataUtil::formatForDisplay($image['width']) . '" height="' . DataUtil::formatForDisplay($image['height']) . '" />';
             } else {
-                $show = '<img src="' . DataUtil::formatForDisplay($image) . '" alt="' . $showUname . '" />';
+                $show = '<img src="' . DataUtil::formatForDisplay($image) . '" alt="' . $userDisplayName . '" />';
             }
         } elseif ($maxLength > 0) {
             // truncate the user name to $maxLength chars
-            $length     = strlen($uname);
+            $length     = strlen($userDisplayName);
             $truncEnd   = ($maxLength > $length) ? $length : $maxLength;
-            $showUname  = DataUtil::formatForDisplay(substr($uname, 0, $truncEnd));
-            $show       = $showUname;
+            $show  = DataUtil::formatForDisplay(substr($userDisplayName, 0, $truncEnd));
         } else {
-            $show = $showUname;
+            $show = DataUtil::formatForDisplay($userDisplayName);
         }
 
-        $profileLink = '<a' . $class . ' title="' . DataUtil::formatForDisplay(__('Personal information')) . ': ' . $showUname . '" href="' . DataUtil::formatForDisplay(ModUtil::url($profileModule, 'user', 'view', array('uid' => $uid), null, null, true)) . '">' . $show . '</a>';
+        $profileLink = '<a' . $class . ' title="' . DataUtil::formatForDisplay(__('Personal information')) . ': ' . $userDisplayName . '" href="' . DataUtil::formatForDisplay(ModUtil::url($profileModule, 'user', 'view', array('uid' => $uid), null, null, true)) . '">' . $show . '</a>';
     } elseif (!empty($image)) {
         $profileLink = ''; // image for anonymous user should be "empty"
     } else {
-        $profileLink = $showUname;
+        $uname    = UserUtil::getVar('uname', $uid);
+        $profileLink = DataUtil::formatForDisplay($uname);;
     }
 
     return $profileLink;

--- a/src/lib/viewplugins/modifier.profilelinkbyuname.php
+++ b/src/lib/viewplugins/modifier.profilelinkbyuname.php
@@ -44,12 +44,17 @@ function smarty_modifier_profilelinkbyuname($uname, $class = '', $image = '', $m
         return $uname;
     }
 
-    $uid        = UserUtil::getIdFromName($uname);
-    $showUname  = DataUtil::formatForDisplay($uname);
+    $uid = UserUtil::getIdFromName($uname);
 
     $profileModule = System::getVar('profilemodule', '');
 
     if ($uid && ($uid > 1) && !empty($profileModule) && ModUtil::available($profileModule)) {
+        $userDisplayName = ModUtil::apiFunc($profileModule, 'user', 'getUserDisplayName', array('uid' => $uid));
+        
+        if (empty($userDisplayName)) {
+            $userDisplayName = $uname;
+        }
+                            
         if (!empty($class)) {
             $class = ' class="' . DataUtil::formatForDisplay($class) . '"';
         }
@@ -59,23 +64,22 @@ function smarty_modifier_profilelinkbyuname($uname, $class = '', $image = '', $m
                 // if it is an array we assume that it is an img array
                 $show = '<img src="' . DataUtil::formatForDisplay($image['src']) . '" alt="' . DataUtil::formatForDisplay($image['alt']) . '" width="' . DataUtil::formatForDisplay($image['width']) . '" height="' . DataUtil::formatForDisplay($image['height']) . '" />';
             } else {
-                $show = '<img src="' . DataUtil::formatForDisplay($image) . '" alt="' . $showUname . '" />';
+                $show = '<img src="' . DataUtil::formatForDisplay($image) . '" alt="' . DataUtil::formatForDisplay($userDisplayName) . '" />';
             }
         } elseif ($maxLength > 0) {
             // truncate the user name to $maxLength chars
-            $length     = strlen($uname);
+            $length     = strlen($userDisplayName);
             $truncEnd   = ($maxLength > $length) ? $length : $maxLength;
-            $showUname  = DataUtil::formatForDisplay(substr($uname, 0, $truncEnd));
-            $show       = $showUname;
+            $show  = DataUtil::formatForDisplay(substr($userDisplayName, 0, $truncEnd));
         } else {
-            $show = $showUname;
+            $show = DataUtil::formatForDisplay($userDisplayName);
         }
 
-        $profileLink = '<a' . $class . ' title="' . DataUtil::formatForDisplay(__('Personal information')) . ': ' . $showUname . '" href="' . DataUtil::formatForDisplay(ModUtil::url($profileModule, 'user', 'view', array('uid' => $uid), null, null, true)) . '">' . $show . '</a>';
+        $profileLink = '<a' . $class . ' title="' . DataUtil::formatForDisplay(__('Personal information')) . ': ' . DataUtil::formatForDisplay($userDisplayName) . '" href="' . DataUtil::formatForDisplay(ModUtil::url($profileModule, 'user', 'view', array('uid' => $uid), null, null, true)) . '">' . $show . '</a>';
     } elseif (!empty($image)) {
         $profileLink = ''; // image for anonymous user should be "empty"
     } else {
-        $profileLink = $showUname;
+        $profileLink = DataUtil::formatForDisplay($uname);
     }
 
     return $profileLink;


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Tests pass:
Fixes tickets:
References:
License of the code: LGPLv3+
Documentation PR: -
Todo: -

This patch allows the profile module to show a own value for the profile link instead of uname. For example the first and last name of a user. The default value is still uname.
