### PR TITLE
Default value for shorturlsstripentrypoint set to true

### DIFF
--- a/src/system/Settings/Installer.php
+++ b/src/system/Settings/Installer.php
@@ -65,7 +65,7 @@ class Settings_Installer extends Zikula_AbstractInstaller
         System::setVar('shorturls', false);
         System::setVar('shorturlstype', '0');
         System::setVar('shorturlsseparator', '-');
-        System::setVar('shorturlsstripentrypoint', false);
+        System::setVar('shorturlsstripentrypoint', true);
         System::setVar('shorturlsdefaultmodule', '');
         System::setVar('profilemodule', ModUtil::available('Profile') ? 'Profile' : '');
         System::setVar('messagemodule', '');


### PR DESCRIPTION
This value is recommended in the template, so we can place it to true for install right ? 
