### PR TITLE
Invert `class_exists()` check to look for new class instead of old.

### DIFF
--- a/src/lib/util/BlockUtil.php
+++ b/src/lib/util/BlockUtil.php
@@ -323,7 +323,7 @@ class BlockUtil
             $className = ucwords($modinfo['name']).'\\'.'Block\\'.ucwords($block);
             $className = preg_match('/.*Block$/', $className) ? $className : $className.'Block';
             $classNameOld = ucwords($modinfo['name']) . '_' . 'Block_' . ucwords($block);
-            $className = class_exists($classNameOld) ? $classNameOld :$className;
+            $className = class_exists($className) ? $className :$classNameOld;
             $r = new ReflectionClass($className);
             $blockInstance = $r->newInstanceArgs(array($sm));
             try {


### PR DESCRIPTION
Fixes #688.

looking for the old class causes problems when it didn't exist. @drak Please test before finally merging.
