### PR TITLE
add fix for undefined var `$message` in index.php

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -126,14 +126,14 @@ switch (true) {
         if (!LogUtil::hasErrors()) {
             LogUtil::registerError(__f('Could not load the \'%1$s\' module at \'%2$s\'.', array($module, $func)), 404, null);
         }
-        $response->setContent(ModUtil::func('Errors', 'user', 'main', array('message' => $message, 'exception' => $e)));
+        $response->setContent(ModUtil::func('Errors', 'user', 'main', array('message' => $e->getMessage(), 'exception' => $e)));
         break;
 
     case ($response->getStatusCode() == 500):
 
     default:
         LogUtil::registerError(__f('The \'%1$s\' module returned an error in \'%2$s\'.', array($module, $func)), 500, null);
-        $response = ModUtil::func('Errors', 'user', 'main', array('message' => $message, 'exception' => $e));
+        $response = ModUtil::func('Errors', 'user', 'main', array('message' => $e->getMessage(), 'exception' => $e));
         break;
 }
 


### PR DESCRIPTION
I don't know if this is the appropriate fix here. I tried to look into it further but got lost in the cyclical handling of the errors. I'm happy to close this if you would prefer to solve it another way. Basically, the `$message` var is undefined, so it is throwing errors in my log.

| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | n/a |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
