### PR TITLE
compensate for lazy-loaded associations using proxy classes.

### DIFF
--- a/src/lib/Zikula/EntityAccess.php
+++ b/src/lib/Zikula/EntityAccess.php
@@ -68,6 +68,11 @@ class Zikula_EntityAccess implements ArrayAccess
             $r = $r->getParentClass();
 
             foreach ($properties as $property) {
+                if ($this instanceof \Doctrine\ORM\Proxy\Proxy) {
+                    if (($property->name == '_entityPersister') || ($property->name == '_identifier') || ($property->name == '__isInitialized__')) {
+                        continue;
+                    }
+                }
                 if ($property->name == 'reflection') {
                     continue;
                 }


### PR DESCRIPTION
So, when an Entity is loaded and you try to convert it to an array, it can be a problem if you have associations in that Entity. It will cause errors like

```
[29-Jan-2013 19:13:55] PHP Fatal error:  Call to undefined method DoctrineProxy\__CG__\Dizkus_Entity_Topic::get_entityPersister() in /Applications/MAMP/htdocs/core.git/src/lib/Zikula/EntityAccess.php on line 76
```

because the properties of the **Proxy** are attempted to be converted in the Array. This is impossible since there are no `getters` for the proxy properties. 

This PR attempts to correct that. The double check `(if instanceof and if name)` may be overkill. Probably just `if (name)` would work, but just being thorough :smile:

| Q | A |
| --- | --- |
| Bug fix? | kinda |
| New feature? | kinda |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | n/a |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
