### PR TITLE
Show more blockpossitions in blocks modify

### DIFF
--- a/src/system/Blocks/Resources/views/blocks_admin_modify.tpl
+++ b/src/system/Blocks/Resources/views/blocks_admin_modify.tpl
@@ -35,7 +35,8 @@
             <div class="z-formrow">
                 <label for="blocks_position">{gt text="Position(s)"}</label>
                 <span>
-                    <select id="blocks_position" name="positions[]" multiple="multiple">
+                    {assign var="selectsize" value=$block_positions|@count}{if $selectsize gt 20}{assign var="selectsize" value=20}{/if}{if $selectsize lt 4}{assign var="selectsize" value=4}{/if}
+                    <select id="blocks_position" name="positions[]" multiple="multiple" size="{$selectsize}">
                         {html_options options=$block_positions selected=$placements}
                     </select>
                 </span>


### PR DESCRIPTION
This is small UI tweak in Blocks modify screen.

Current status: Blockpossitions select is fixed to 4 rows in size. Even default theme Andreas08 have 7 blockpositions, Multiselect is difficult, and not visible in many cases.

Proposed changes in this PR: Now select and multiselect is easy and visible.
![Image 2](https://f.cloud.github.com/assets/628801/134939/243c443e-7104-11e2-99a0-009de441a4b0.png)

| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | 
| Doc PR        | 
