### PR TITLE
Allow upper and mixed case in images and other files in userdata directory

### DIFF
--- a/src/userdata/.htaccess
+++ b/src/userdata/.htaccess
@@ -3,7 +3,7 @@
 #                  stored under the userdata/ directory
 # ----------------------------------------------------------------------
 deny from all
-<FilesMatch "\.(css|js|rss|png|gif|jpg|psd|svg|txt|rtf|xml|pdf|sdt|odt|doc|docx|pps|ppt|pptx|xls|xlsx|mp3|wav|wma|avi|flv|mov|mp4|rm|vob|wmv|gz|rar|tar.gz|zip)$">
+<FilesMatch "(?i)\.(css|js|rss|png|gif|jpg|psd|svg|txt|rtf|xml|pdf|sdt|odt|doc|docx|pps|ppt|pptx|xls|xlsx|mp3|wav|wma|avi|flv|mov|mp4|rm|vob|wmv|gz|rar|tar.gz|zip)$">
 order allow,deny
 allow from all
 </filesmatch>


### PR DESCRIPTION
It is often to upload images with upper case file extension, such as JPG. Then they are not visible in the browser With this small change this is possible.
