### PR TITLE
Correct result from SecurityUtil if passed unregistered user (uid=0)

### DIFF
--- a/src/lib/util/SecurityUtil.php
+++ b/src/lib/util/SecurityUtil.php
@@ -140,7 +140,7 @@ class SecurityUtil
             throw new \Exception(__f('Invalid security level [%1$s] received in %2$s', array($level, 'SecurityUtil::checkPermission')));
         }
 
-        if (!$user) {
+        if (!isset($user)) {
             $user = UserUtil::getVar('uid');
         }
 
@@ -352,12 +352,10 @@ class SecurityUtil
             return $groupperms;
         }
 
-        static $usergroups = array();
-        if (!$usergroups) {
-            $usergroups[] = -1;
-            if (!UserUtil::isLoggedIn()) {
-                $usergroups[] = 0; // Unregistered GID
-            }
+        $usergroups = array();
+        $usergroups[] = -1;
+        if ($user == 0 || !UserUtil::isLoggedIn()) {
+            $usergroups[] = 0; // Unregistered GID
         }
 
         $allgroups = array_merge($usergroups, $fldArray);


### PR DESCRIPTION
SecurityUtil::checkPermission is rare used with passed UserId as 4-th parameter. One such place is check permissions in System permissions module. In this form now can be added possibility to check empty (uid=0) user.

In practice unregistered users are not with user Id=1 (userid=1 is member by default to Users group).

With changing 3 lines in SecurityUtil it is possible now to specify unregistered user, by passing 0 as 4-th parameter.

Particularly this change is needed to be possible current user (admin) to provide proper results when generating Newsletter in Newsletter module.

```
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no
```
