### PR TITLE
Fixed php error

### DIFF
--- a/src/system/PageLock/Api/UserApi.php
+++ b/src/system/PageLock/Api/UserApi.php
@@ -11,13 +11,13 @@
  * Please see the NOTICE file distributed with this source code for further
  * information regarding copyright and licensing.
  */
+namespace PageLock\Api;
+
 /**
  * length of time to lock a page
  *
  */
 define('PageLockLifetime', 30);
-
-namespace PageLock\Api;
 
 use UserUtil;
 use PageUtil;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/Guite/MostGenerator/issues/318 |
| License | MIT |
| Doc PR | -- |

```
Fatal error: Namespace declaration statement has to be the very first statement in the script in /var/www/zk136/system/PageLock/Api/UserApi.php on line 20
```
