### PR TITLE
Fixed wrong pager, fixes #655

### DIFF
--- a/src/system/Users/Controller/AdminController.php
+++ b/src/system/Users/Controller/AdminController.php
@@ -124,7 +124,7 @@ class AdminController extends \Zikula_AbstractController
         }
 
         $getAllArgs = array(
-            'startnum' => $this->request->query->get('startnum', isset($args['startnum']) ? $args['startnum'] : null),
+            'startnum' => $this->request->query->get('startnum', isset($args['startnum']) ? $args['startnum'] : null) - 1,
             'numitems' => $itemsPerPage,
             'letter' => $letter,
             'sort' => $sortArgs,


### PR DESCRIPTION
$startnum returned by the pager starts with 1, but it needs to be 0 instead.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #655 |
| License | MIT |
| Doc PR | -- |
