### PR TITLE
Pass returnpage to authentication method selector form

### DIFF
--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/login.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/login.tpl
@@ -14,7 +14,7 @@
     <h5 id="users_login_h5_authentication_method"{if empty($selected_authentication_method)} class="z-hide"{/if}>{gt text="Log in below, or change how you would like to log in by clicking on one of the following..."}</h5>
     <h5 id="users_login_h5" class="z-hide"></h5>
     <div class="authentication_select_method_bigbutton">
-    {modurl modname='ZikulaUsersModule' type='user' func='login' assign='form_action'}
+    {modurl modname='ZikulaUsersModule' type='user' func='login' returnpage=$returnpage|urlencode assign='form_action'}
     {foreach from=$authentication_method_display_order item='authentication_method' name='authentication_method_display_order'}
         {if $smarty.foreach.authentication_method_display_order.iteration == 6}
             </div>


### PR DESCRIPTION
When more then one log-in methods are specified, then log-in screen is like:

![Image 1](https://f.cloud.github.com/assets/628801/274671/9e86e842-906d-11e2-8207-98c8a766681d.png)

If the user clicks on one, then form is refreshed and passed parameter "returnpage" is lost.

This PR resolves this bug.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |
