### PR TITLE
Pre-selected authentication method in login form

### DIFF
--- a/src/system/Zikula/Module/UsersModule/Controller/UserController.php
+++ b/src/system/Zikula/Module/UsersModule/Controller/UserController.php
@@ -1047,6 +1047,7 @@ class UserController extends \Zikula_AbstractController
      * array   authentication_info   An array containing the authentication information entered by the user.
      * array   authentication_method An array containing two elements: 'modname', the authentication module name, and 'method', the
      *                                      selected authentication method as defined by the module.
+     * boolean firstmethodisdefault  If to display first of authentication methods as preselected in login form, when more then one are specified (default is true).
      * boolean rememberme            True if the user should remain logged in at that computer for future visits; otherwise false.
      * string  returnpage            The URL of the page to return to if the log-in attempt is successful. (This URL must not be urlencoded.)
      *
@@ -1085,6 +1086,7 @@ class UserController extends \Zikula_AbstractController
         $loggedIn = false;
         $isFunctionCall = false;
         $isReentry = false;
+        $firstmethodisdefault = isset($args['firstmethodisdefault']) ? $args['firstmethodisdefault'] : true;
 
         // Need to check for $args first, since isPost() and isGet() will have been set on the original call
         if (isset($args) && is_array($args) && !empty($args)) {
@@ -1329,7 +1331,7 @@ class UserController extends \Zikula_AbstractController
             // Either a GET request type to initially display the login form, or a failed login attempt
             // which means the login form should be displayed anyway.
             if ((!isset($selectedAuthenticationMethod) || empty($selectedAuthenticationMethod))
-                    && ($authenticationMethodList->countEnabledForAuthentication() <= 1)
+                    && ($firstmethodisdefault || $authenticationMethodList->countEnabledForAuthentication() <= 1)
                     ) {
                 /* @var AuthenticationMethodHelper $authenticationMethod */
                 $authenticationMethod = $authenticationMethodList->getAuthenticationMethodForDefault();

--- a/src/system/Zikula/Module/UsersModule/Helper/AuthenticationMethodListHelper.php
+++ b/src/system/Zikula/Module/UsersModule/Helper/AuthenticationMethodListHelper.php
@@ -175,30 +175,25 @@ class AuthenticationMethodListHelper extends \Zikula_AbstractHelper implements \
     /**
      * Determine whether a default authentication method is appropriate, and if it is, return it.
      *
-     * A default is valid if there is only one enabled authentication method in the list.
-     *
      * @return AuthenticationMethodHelper|void If a default authentication method is appropriate, then that definition; otherwise null.
      *
      * @throws Zikula_Exception_Fatal Thrown if the collection is in an inconsistent state.
      */
     public function getAuthenticationMethodForDefault()
     {
-        // If there is more than one authentication method in the list, then no "default" is possible.
+        // If there is more than one authentication method in the list, then first is selected.
         $authenticationMethodForDefault = null;
-        if ($this->countEnabledForAuthentication() <= 1) {
-            // There is only one (or there is none), so select it.
-            foreach ($this->authenticationMethods as $authenticationMethod) {
-                if ($authenticationMethod->isEnabledForAuthentication()) {
-                    $authenticationMethodForDefault = $authenticationMethod;
-                    break;
-                }
+        foreach ($this->authenticationMethods as $authenticationMethod) {
+            if ($authenticationMethod->isEnabledForAuthentication()) {
+                $authenticationMethodForDefault = $authenticationMethod;
+                break;
             }
+        }
 
-            if (!$authenticationMethodForDefault) {
-                // Nothing in the list at all! Because the constructor forces Users-uname if the list would otherwise be
-                // empty this should not happen.
-                throw new Zikula_Exception_Fatal($this->__('The authentication method list is in an inconsistent state. No authentication modules.'));
-            }
+        if (!$authenticationMethodForDefault) {
+            // Nothing in the list at all! Because the constructor forces Users-uname if the list would otherwise be
+            // empty this should not happen.
+            throw new Zikula_Exception_Fatal($this->__('The authentication method list is in an inconsistent state. No authentication modules.'));
         }
 
         return $authenticationMethodForDefault;


### PR DESCRIPTION
Note: this PR affects only the case when more then one authentication method is specified in configuration.

The PR propose to display to user in log-in form a pre-selected authentication method. Pictures below illustrate this.
First picture is before changes, second picture is after changes.
Also, to retain possibility to display "hard" method selection, a parameter to loginAction function is added.

---

![Image 1](https://f.cloud.github.com/assets/628801/275124/9b2210ae-907d-11e2-9e3c-4cdac88adfe3.png)

---

![Image 2](https://f.cloud.github.com/assets/628801/275125/9f0247ac-907d-11e2-8ce5-7aa76802c727.png)

---

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |
