### PR TITLE
Permissions module: test permissions for unregistered user

### DIFF
--- a/src/system/Zikula/Module/PermissionsModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/PermissionsModule/Controller/AjaxController.php
@@ -205,7 +205,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
         } else {
             $result .= '<span id="permissiontestinfogreen">';
             if ($uid == 0) {
-                $result .= 'unregistered user';
+                $result .= $this->__('unregistered user');
             } else {
                 $result .= $uname;
             }


### PR DESCRIPTION
It is obvious next step after PR #761. Now results from this PR can be tested.

Changes make possible to test permissions for unregistered users.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |
