### PR TITLE
Corrections to UsersModule templates

### DIFF
--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/approveregistration.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/approveregistration.tpl
@@ -7,7 +7,7 @@
 {if !$reginfo.isverified}
 {if $force}
 <p class="z-warningmsg">{gt text="Warning! The e-mail address for this registration has not been verified. Approving this registration will create a new user record without completing the e-mail verification process."}</p>
-{elseif isset($modvars.ZikulaUsersModule.moderation_order) && ($modvars.ZikulaUsersModule.moderation_order == 'UsersModule\Constant::APPROVAL_AFTER'|const)}
+{elseif isset($modvars.ZikulaUsersModule.moderation_order) && ($modvars.ZikulaUsersModule.moderation_order == 'Zikula\Module\UsersModule\Constant::APPROVAL_AFTER'|const)}
 <p class="z-warningmsg">{gt text="Warning! The e-mail address for this registration has not been verified. You are pre-approving this registration, and a new user record will be created upon completion of the e-mail verification process."}</p>
 {/if}
 {/if}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/config.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/config.tpl
@@ -5,41 +5,41 @@
     Zikula.Users.Admin.Config.setup = function() {
         Zikula.Users.Admin.Config.formId = '{{$configData->getFormId()}}';
 
-        {{assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ENABLED'|constant}}
+        {{assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ENABLED'|const}}
         Zikula.Users.Admin.Config.registrationEnabledId = '{{$configData->getFieldId($fieldName)}}';
         Zikula.Users.Admin.Config.registrationEnabledWrapId = '{{$configData->getFieldId($fieldName)}}' + '_wrap';
         Zikula.Users.Admin.Config.registrationEnabledYesId = '{{$configData->getFieldId($fieldName)}}' + '_yes';
         Zikula.Users.Admin.Config.registrationEnabledNoId = '{{$configData->getFieldId($fieldName)}}' + '_no';
 
-        {{assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_REQUIRED'|constant}}
+        {{assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_REQUIRED'|const}}
         Zikula.Users.Admin.Config.registrationModeratedId = '{{$configData->getFieldId($fieldName)}}';
         Zikula.Users.Admin.Config.registrationModeratedYesId = '{{$configData->getFieldId($fieldName)}}' + '_yes';
         Zikula.Users.Admin.Config.registrationModeratedNoId = '{{$configData->getFieldId($fieldName)}}' + '_no';
 
-        {{assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_AUTO_LOGIN'|constant}}
+        {{assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_AUTO_LOGIN'|const}}
         Zikula.Users.Admin.Config.registrationAutoLoginWrapId = '{{$configData->getFieldId($fieldName)}}' + '_wrap';
 
-        {{assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_SEQUENCE'|constant}}
+        {{assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_SEQUENCE'|const}}
         Zikula.Users.Admin.Config.registrationApprovalOrderWrapId = '{{$configData->getFieldId($fieldName)}}' + '_wrap';
 
-        {{assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_VERIFICATION_MODE'|constant}}
+        {{assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_VERIFICATION_MODE'|const}}
         Zikula.Users.Admin.Config.registrationVerificationModeId = '{{$configData->getFieldId($fieldName)}}';
-        Zikula.Users.Admin.Config.registrationVerificationModeUserPwdId = '{{$configData->getFieldId($fieldName)}}' + '_' + '{{'UsersModule\Constant::VERIFY_USERPWD'|constant}}';
-        Zikula.Users.Admin.Config.registrationVerificationModeNoneId = '{{$configData->getFieldId($fieldName)}}' + '_' + '{{'UsersModule\Constant::VERIFY_NO'|constant}}';
+        Zikula.Users.Admin.Config.registrationVerificationModeUserPwdId = '{{$configData->getFieldId($fieldName)}}' + '_' + '{{'Zikula\Module\UsersModule\Constant::VERIFY_USERPWD'|const}}';
+        Zikula.Users.Admin.Config.registrationVerificationModeNoneId = '{{$configData->getFieldId($fieldName)}}' + '_' + '{{'Zikula\Module\UsersModule\Constant::VERIFY_NO'|const}}';
 
-        {{assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_QUESTION'|constant}}
+        {{assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_QUESTION'|const}}
         Zikula.Users.Admin.Config.registrationAntispamQuestionId = '{{$configData->getFieldId($fieldName)}}';
 
-        {{assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_ANSWER'|constant}}
+        {{assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_ANSWER'|const}}
         Zikula.Users.Admin.Config.registrationAntispamAnswerMandatoryId = '{{$configData->getFieldId($fieldName)}}' + '_mandatory';
 
-        {{assign var='fieldName' value='UsersModule\Constant::MODVAR_LOGIN_METHOD'|constant}}
+        {{assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_METHOD'|const}}
         Zikula.Users.Admin.Config.loginMethodId = '{{$configData->getFieldId($fieldName)}}';
         Zikula.Users.Admin.Config.loginMethodUserNameId = '{{$configData->getFieldId($fieldName)}}' + '_username';
         Zikula.Users.Admin.Config.loginMethodEmailId = '{{$configData->getFieldId($fieldName)}}' + '_email';
         Zikula.Users.Admin.Config.loginMethodEitherId = '{{$configData->getFieldId($fieldName)}}' + '_either';
 
-        {{assign var='fieldName' value='UsersModule\Constant::MODVAR_REQUIRE_UNIQUE_EMAIL'|constant}}
+        {{assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REQUIRE_UNIQUE_EMAIL'|const}}
         Zikula.Users.Admin.Config.requireUniqueEmailYesId = '{{$configData->getFieldId($fieldName)}}' + '_yes';
         Zikula.Users.Admin.Config.requireUniqueEmailNoId = '{{$configData->getFieldId($fieldName)}}' + '_no';
     }
@@ -59,27 +59,27 @@
         <fieldset>
             <legend>{gt text="General settings"}</legend>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_ANONYMOUS_DISPLAY_NAME'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ANONYMOUS_DISPLAY_NAME'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Name displayed for anonymous user"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safehtml}" size="20" maxlength="20" />
                 <em class="z-formnote z-sub">{gt text="Anonymous users are visitors to your site who have not logged in."}</em>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_ITEMS_PER_PAGE'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ITEMS_PER_PAGE'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Number of items displayed per page"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" size="3" value="{$configData->getFieldData($fieldName)|safetext}" />
                 <em class="z-formnote z-sub">{gt text="When lists are displayed (for example, lists of users, lists of registrations) this option controls how many items are displayed at one time."}</em>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_AVATAR_IMAGE_PATH'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_AVATAR_IMAGE_PATH'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Path to user's avatar images"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_GRAVATARS_ENABLED'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_GRAVATARS_ENABLED'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Allow globally recognized avatars"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div id="{$configData->getFieldId($fieldName)}">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -90,7 +90,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_GRAVATAR_IMAGE'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_GRAVATAR_IMAGE'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Default gravatar image"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
@@ -100,7 +100,7 @@
         <fieldset>
             <legend>{gt text="Account page settings"}</legend>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_ACCOUNT_DISPLAY_GRAPHICS'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ACCOUNT_DISPLAY_GRAPHICS'|const}
                 <label>{gt text="Display graphics on user's account page"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div id="{$configData->getFieldId($fieldName)}">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)}checked="checked" {/if} />
@@ -111,25 +111,25 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_ACCOUNT_PAGE_IMAGE_PATH'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ACCOUNT_PAGE_IMAGE_PATH'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Path to account page images"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_ACCOUNT_ITEMS_PER_PAGE'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ACCOUNT_ITEMS_PER_PAGE'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Number of links per page"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" size="3" value="{$configData->getFieldData($fieldName)|safetext}" />
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_ACCOUNT_ITEMS_PER_ROW'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ACCOUNT_ITEMS_PER_ROW'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Number of links per row"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" size="3" value="{$configData->getFieldData($fieldName)|safetext}" />
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_MANAGE_EMAIL_ADDRESS'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_MANAGE_EMAIL_ADDRESS'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Users module handles e-mail address maintenance"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div id="{$configData->getFieldId($fieldName)}">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -144,14 +144,14 @@
         <fieldset>
             <legend>{gt text="User credential settings"}</legend>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_LOGIN_METHOD'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_METHOD'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Credential required for user log-in"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div id="{$configData->getFieldId($fieldName)}">
-                    <input id="{$configData->getFieldId($fieldName)}_username" type="radio" name="{$fieldName}" value="{'UsersModule\Constant::LOGIN_METHOD_UNAME'|constant}" {if ($configData->getFieldData($fieldName) < constant('UsersModule\Constant::LOGIN_METHOD_EMAIL')) || ($configData->getFieldData($fieldName) > constant('UsersModule\Constant::LOGIN_METHOD_ANY'))}checked="checked" {/if}/>
+                    <input id="{$configData->getFieldId($fieldName)}_username" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::LOGIN_METHOD_UNAME'|const}" {if ($configData->getFieldData($fieldName) < constant('Zikula\Module\UsersModule\Constant::LOGIN_METHOD_EMAIL')) || ($configData->getFieldData($fieldName) > constant('Zikula\Module\UsersModule\Constant::LOGIN_METHOD_ANY'))}checked="checked" {/if}/>
                     <label for="{$configData->getFieldId($fieldName)}_username">{gt text="User name"}</label>
-                    <input id="{$configData->getFieldId($fieldName)}_email" type="radio" name="{$fieldName}" value="{'UsersModule\Constant::LOGIN_METHOD_EMAIL'|constant}" {if $configData->getFieldData($fieldName) == constant('UsersModule\Constant::LOGIN_METHOD_EMAIL')}checked="checked" {/if}/>
+                    <input id="{$configData->getFieldId($fieldName)}_email" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::LOGIN_METHOD_EMAIL'|const}" {if $configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::LOGIN_METHOD_EMAIL')}checked="checked" {/if}/>
                     <label for="{$configData->getFieldId($fieldName)}_email">{gt text="E-mail address"}</label>
-                    <input id="{$configData->getFieldId($fieldName)}_either" type="radio" name="{$fieldName}" value="{'UsersModule\Constant::LOGIN_METHOD_ANY'|constant}" {if $configData->getFieldData($fieldName) == constant('UsersModule\Constant::LOGIN_METHOD_ANY')}checked="checked" {/if}/>
+                    <input id="{$configData->getFieldId($fieldName)}_either" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::LOGIN_METHOD_ANY'|const}" {if $configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::LOGIN_METHOD_ANY')}checked="checked" {/if}/>
                     <label for="{$configData->getFieldId($fieldName)}_either">{gt text="Either user name or e-mail address"}</label>
                     <div class="z-formnote z-warningmsg">{gt text="Notice: If the 'Credential required for user log-in' is set to 'E-mail address' or to 'Either user name or e-mail address', then the 'New e-mail addresses must be unique' option below must be set to 'Yes'."}</div>
                     <div class="z-formnote z-warningmsg">{gt text="Notice: If the 'New e-mail addresses must be unique' option was set to 'no' at some point, then user accounts with duplicate e-mail addresses might exist in the system. They will experience difficulties logging in with their e-mail address."}</div>
@@ -159,7 +159,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REQUIRE_UNIQUE_EMAIL'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REQUIRE_UNIQUE_EMAIL'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="New e-mail addresses must be unique"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div id="{$configData->getFieldId($fieldName)}">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -172,14 +172,14 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_PASSWORD_MINIMUM_LENGTH'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_PASSWORD_MINIMUM_LENGTH'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Minimum length for user passwords"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safehtml}" size="2" maxlength="2" />
                 <em class="z-formnote z-sub">{gt text="This affects both passwords created during registration, as well as passwords modified by users or administrators."} {gt text="Enter an integer greater than zero."}</em>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_HASH_METHOD'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_HASH_METHOD'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Password hashing method"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <select id="{$configData->getFieldId($fieldName)}" name="{$fieldName}">
                     <option value="sha1" {if $configData->getFieldData($fieldName) == 'sha1'} selected="selected"{/if}>SHA1</option>
@@ -189,7 +189,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_PASSWORD_STRENGTH_METER_ENABLED'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_PASSWORD_STRENGTH_METER_ENABLED'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Show password strength meter"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div id="{$configData->getFieldId($fieldName)}">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)}checked="checked" {/if} />
@@ -200,7 +200,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_EXPIRE_DAYS_CHANGE_EMAIL'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_EXPIRE_DAYS_CHANGE_EMAIL'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="E-mail address verifications expire in"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div>
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|default:0}" maxlength="3" />
@@ -211,7 +211,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_EXPIRE_DAYS_CHANGE_PASSWORD'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_EXPIRE_DAYS_CHANGE_PASSWORD'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Password reset requests expire in"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div>
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|default:0}" maxlength="3" />
@@ -226,7 +226,7 @@
         <fieldset>
             <legend>{gt text="Registration settings"}</legend>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ENABLED'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ENABLED'|const}
                 <label>{gt text="Allow new user account registrations"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div id="{$configData->getFieldId($fieldName)}">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -237,20 +237,20 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow" id="{$configData->getFieldId($fieldName)}_wrap">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_DISABLED_REASON'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_DISABLED_REASON'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Statement displayed if registration disabled"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <textarea id="{$configData->getFieldId($fieldName)}" name="{$fieldName}" cols="45" rows="10">{$configData->getFieldData($fieldName)|safehtml}</textarea>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ADMIN_NOTIFICATION_EMAIL'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ADMIN_NOTIFICATION_EMAIL'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="E-mail address to notify of registrations"}</label>
                 <input id="{$configData->getFieldId($fieldName)}" type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                 <em class="z-formnote z-sub">{gt text="A notification is sent to this e-mail address for each registration. Leave blank for no notifications."}</em>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_REQUIRED'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_REQUIRED'|const}
                 <label>{gt text="User registration is moderated"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div id="{$configData->getFieldId($fieldName)}">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -260,20 +260,20 @@
                 </div>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
-            {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_VERIFICATION_MODE'|constant}
+            {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_VERIFICATION_MODE'|const}
             <div class="z-formrow" id="{$configData->getFieldId($fieldName)}">
                 <label>{gt text="Verify e-mail address during registration"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div class="z-formlist">
-                    <input id="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::VERIFY_USERPWD'|constant}" type="radio" name="{$fieldName}" value="{'UsersModule\Constant::VERIFY_USERPWD'|constant}" {if ($configData->getFieldData($fieldName) == constant('UsersModule\Constant::VERIFY_USERPWD')) || $configData->getFieldData($fieldName) == constant('UsersModule\Constant::VERIFY_SYSTEMPWD')} checked="checked"{/if} />
-                    <label for="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::VERIFY_USERPWD'|constant}">{gt text="Yes. User chooses password, then activates account via e-mail"}</label>
+                    <input id="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::VERIFY_USERPWD'|const}" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::VERIFY_USERPWD'|const}" {if ($configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::VERIFY_USERPWD')) || $configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::VERIFY_SYSTEMPWD')} checked="checked"{/if} />
+                    <label for="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::VERIFY_USERPWD'|const}">{gt text="Yes. User chooses password, then activates account via e-mail"}</label>
                 </div>
                 <div class="z-formlist">
-                    <input id="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::VERIFY_NO'|constant}" type="radio" name="{$fieldName}" value="{'UsersModule\Constant::VERIFY_NO'|constant}" {if $configData->getFieldData($fieldName) == constant('UsersModule\Constant::VERIFY_NO')} checked="checked"{/if}/>
-                    <label for="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::VERIFY_NO'|constant}">{gt text="No"}</label>
+                    <input id="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::VERIFY_NO'|const}" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::VERIFY_NO'|const}" {if $configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::VERIFY_NO')} checked="checked"{/if}/>
+                    <label for="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::VERIFY_NO'|const}">{gt text="No"}</label>
                 </div>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
-            {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_AUTO_LOGIN'|constant}
+            {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_AUTO_LOGIN'|const}
             <div class="z-formrow" id="{$configData->getFieldId($fieldName)}_wrap">
                 <label>{gt text="Log in new registrations automatically?"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div class="z-formlist">
@@ -288,25 +288,25 @@
                 <em class="z-sub z-formnote">{gt text="Newly registered users are redirected to the log-in screen, if appropriate. If there are other registration requirements to be met, then they are shown this information instead."}</em>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
-            {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_SEQUENCE'|constant}
+            {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_SEQUENCE'|const}
             <div class="z-formrow" id="{$configData->getFieldId($fieldName)}_wrap">
                 <label>{gt text="Order that approval and verification occur"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div class="z-formlist">
-                    <input id="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::APPROVAL_BEFORE'|constant}" type="radio" name="{$fieldName}" value="{'UsersModule\Constant::APPROVAL_BEFORE'|constant}" {if $configData->getFieldData($fieldName) == constant('UsersModule\Constant::APPROVAL_BEFORE')} checked="checked"{/if} />
-                    <label for="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::APPROVAL_BEFORE'|constant}">{gt text="Registration applications must be approved before users verify their e-mail address."}</label>
+                    <input id="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const}" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const}" {if $configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE')} checked="checked"{/if} />
+                    <label for="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const}">{gt text="Registration applications must be approved before users verify their e-mail address."}</label>
                 </div>
                 <div class="z-formlist">
-                    <input id="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::APPROVAL_AFTER'|constant}" type="radio" name="{$fieldName}" value="{'UsersModule\Constant::APPROVAL_AFTER'|constant}" {if $configData->getFieldData($fieldName) == constant('UsersModule\Constant::APPROVAL_AFTER')} checked="checked"{/if} />
-                    <label for="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::APPROVAL_AFTER'|constant}">{gt text="Users must verify their e-mail address before their application is approved."}</label>
+                    <input id="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::APPROVAL_AFTER'|const}" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::APPROVAL_AFTER'|const}" {if $configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::APPROVAL_AFTER')} checked="checked"{/if} />
+                    <label for="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::APPROVAL_AFTER'|const}">{gt text="Users must verify their e-mail address before their application is approved."}</label>
                 </div>
                 <div class="z-formlist">
-                    <input id="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::APPROVAL_ANY'|constant}" type="radio" name="{$fieldName}" value="{'UsersModule\Constant::APPROVAL_ANY'|constant}" {if $configData->getFieldData($fieldName) == constant('UsersModule\Constant::APPROVAL_ANY')} checked="checked"{/if} />
-                    <label for="{$configData->getFieldId($fieldName)}_{'UsersModule\Constant::APPROVAL_ANY'|constant}">{gt text="Application approval and e-mail address verification can occur in any order."}</label>
+                    <input id="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::APPROVAL_ANY'|const}" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::APPROVAL_ANY'|const}" {if $configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::APPROVAL_ANY')} checked="checked"{/if} />
+                    <label for="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::APPROVAL_ANY'|const}">{gt text="Application approval and e-mail address verification can occur in any order."}</label>
                 </div>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_EXPIRE_DAYS_REGISTRATION'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_EXPIRE_DAYS_REGISTRATION'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Registrations pending verification expire in"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div>
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|default:0}" maxlength="3" />
@@ -319,21 +319,21 @@
             </div>
 
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_QUESTION'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_QUESTION'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Spam protection question"}</label>
                 <input id="{$configData->getFieldId($fieldName)}" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safehtml}" size="50" maxlength="255" />
                 <em class="z-formnote z-sub">{gt text="You can set a question to be answered at registration time, to protect the site against spam automated registrations by bots and scripts."}</em>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_ANSWER'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_ANSWER'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Spam protection answer"}<span id="{$configData->getFieldId($fieldName)}_mandatory" class="z-form-mandatory-flag z-hide">{gt text="*"}</span></label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safehtml}" size="50" maxlength="255" />
                 <em class="z-formnote z-sub">{gt text="Registering users will have to provide this response when answering the spam protection question. It is required if a spam protection question is provided."}</em>
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ILLEGAL_UNAMES'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ILLEGAL_UNAMES'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Reserved user names"}</label>
                 <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                 <em class="z-formnote z-sub">
@@ -343,7 +343,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ILLEGAL_AGENTS'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ILLEGAL_AGENTS'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Banned user agents"}</label>
                 <textarea id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} name="{$fieldName}" cols="45" rows="2">{$configData->getFieldData($fieldName)|safehtml}</textarea>
                 <em class="z-formnote z-sub">
@@ -353,7 +353,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_REGISTRATION_ILLEGAL_DOMAINS'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ILLEGAL_DOMAINS'|const}
                 <label for="{$configData->getFieldId($fieldName)}">{gt text="Banned e-mail address domains"}</label>
                 <textarea id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} name="{$fieldName}" cols="45" rows="2">{$configData->getFieldData($fieldName)|safehtml}</textarea>
                 <em class="z-formnote z-sub">
@@ -367,7 +367,7 @@
         <fieldset>
             <legend>{gt text="User log-in settings"}</legend>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_LOGIN_WCAG_COMPLIANT'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_WCAG_COMPLIANT'|const}
                 <label>{gt text="WCAG-compliant log-in and log-out"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div id="{$configData->getFieldId($fieldName)}">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)}checked="checked" {/if}/>
@@ -379,7 +379,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_LOGIN_DISPLAY_INACTIVE_STATUS'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_DISPLAY_INACTIVE_STATUS'|const}
                 <label>{gt text="Failed login displays inactive status"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div class="z-formlist">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -392,7 +392,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_LOGIN_DISPLAY_VERIFY_STATUS'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_DISPLAY_VERIFY_STATUS'|const}
                 <label>{gt text="Failed login displays verification status"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div class="z-formlist">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -405,7 +405,7 @@
                 {if isset($errorFields.$fieldName)}<p class="z-formnote z-errormsg">{$errorFields.$fieldName}</p>{/if}
             </div>
             <div class="z-formrow">
-                {assign var='fieldName' value='UsersModule\Constant::MODVAR_LOGIN_DISPLAY_APPROVAL_STATUS'|constant}
+                {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_DISPLAY_APPROVAL_STATUS'|const}
                 <label>{gt text="Failed login displays approval status"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <div class="z-formlist">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/modify.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/modify.tpl
@@ -110,8 +110,8 @@
                 <input type="hidden" name="{$fieldName}" value="{$formData->getFieldData($fieldName)}" />
                 {/if}
                 <select id="{$formData->getFieldId($fieldName)}" name="{$fieldName}{if $editingSelf}_displayonly" disabled="disabled{/if}">
-                    <option value="{'UsersModule\Constant::ACTIVATED_INACTIVE'|constant}" {if $formData->getFieldData($fieldName) != 'UsersModule\Constant::ACTIVATED_ACTIVE'|constant}selected="selected"{/if}>{gt text="Inactive"}</option>
-                    <option value="{'UsersModule\Constant::ACTIVATED_ACTIVE'|constant}" {if $formData->getFieldData($fieldName) == 'UsersModule\Constant::ACTIVATED_ACTIVE'|constant}selected="selected"{/if}>{gt text="Active"}</option>
+                    <option value="{'Zikula\Module\UsersModule\Constant::ACTIVATED_INACTIVE'|const}" {if $formData->getFieldData($fieldName) != 'Zikula\Module\UsersModule\Constant::ACTIVATED_ACTIVE'|const}selected="selected"{/if}>{gt text="Inactive"}</option>
+                    <option value="{'Zikula\Module\UsersModule\Constant::ACTIVATED_ACTIVE'|const}" {if $formData->getFieldData($fieldName) == 'Zikula\Module\UsersModule\Constant::ACTIVATED_ACTIVE'|const}selected="selected"{/if}>{gt text="Active"}</option>
                 </select>
                 <p id="{$formData->getFieldId($fieldName)}_error" class="z-formnote z-errormsg{if !isset($errorFields.$fieldName)} z-hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
             </div>
@@ -127,7 +127,7 @@
         </fieldset>
         <fieldset>
             <legend>{gt text='Log-in information'}</legend>
-            {if ($formData->getFieldData('pass') == 'UsersModule\Constant::PWD_NO_USERS_AUTHENTICATION'|constant)}
+            {if ($formData->getFieldData('pass') == 'Zikula\Module\UsersModule\Constant::PWD_NO_USERS_AUTHENTICATION'|const)}
                 {assign var='usersAuth' value=false}
             {else}
                 {assign var='usersAuth' value=true}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/newuser.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/newuser.tpl
@@ -148,7 +148,7 @@
             </div>
             <div id="{$formData->getFormId()}_password_not_set_wrap" class="z-formrow z-hide">
 
-                {if $modvars.ZikulaUsersModule.reg_verifyemail == 'UsersModule\Constant::VERIFY_NO'|constant}
+                {if $modvars.ZikulaUsersModule.reg_verifyemail == 'Zikula\Module\UsersModule\Constant::VERIFY_NO'|const}
                 <p class="z-formnote z-warningmsg">{gt text="The user's e-mail address will be verified, even though e-mail address verification is turned off in 'Settings'. This is necessary because the user will create a password during the verification process."}</p>
                 {else}
                 <p class="z-formnote z-informationmsg">{gt text="The user's e-mail address will be verified. The user will create a password at that time."}</p>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/view.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/view.tpl
@@ -73,17 +73,17 @@
             {/if}
             <td class="users_activated">{strip}
                 {switch expr=$usersitems[usersitems].activated}
-                {case expr='UsersModule\Constant::ACTIVATED_ACTIVE'|const}
+                {case expr='Zikula\Module\UsersModule\Constant::ACTIVATED_ACTIVE'|const}
                 {img modname=core set=icons/extrasmall src='greenled.png' __title='Active' __alt='Active' class='tooltips'}
                 {/case}
-                {case expr='UsersModule\Constant::ACTIVATED_INACTIVE'|const}
+                {case expr='Zikula\Module\UsersModule\Constant::ACTIVATED_INACTIVE'|const}
                 {img modname=core set=icons/extrasmall src='yellowled.png' __title='Inactive' __alt='Inactive' class='tooltips'}
                 {/case}
-                {case expr='UsersModule\Constant::ACTIVATED_PENDING_DELETE'|const}
+                {case expr='Zikula\Module\UsersModule\Constant::ACTIVATED_PENDING_DELETE'|const}
                 {img modname=core set=icons/extrasmall src='14_layer_deletelayer.png' __title='Inactive, marked for deletion' __alt='Inactive, marked for deletion' class='tooltips'}
                 {/case}
                 {case}
-                {img modname=core set=icons/extrasmall src='error.png' __title='Status unknown' __alt='Status unknown' class='tooltips'}
+                {img modname='core' set='icons/extrasmall' src='error.png' __title='Status unknown' __alt='Status unknown' class='tooltips'}
                 {/case}
                 {/switch}
             {/strip}</td>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/viewregistrations.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/viewregistrations.tpl
@@ -47,7 +47,7 @@
                 {img modname='core' set='icons/extrasmall' src='greenled.png' __title='Verified' __alt='Verified' class='tooltips'}
                 {elseif !$reginfo.verificationsent}
 
-                {if ($modvars.ZikulaUsersModule.moderation_order != 'UsersModule\Constant::APPROVAL_BEFORE'|const) || (($modvars.ZikulaUsersModule.moderation_order == 'UsersModule\Constant::APPROVAL_BEFORE'|const) && ($reginfo.isapproved))}
+                {if ($modvars.ZikulaUsersModule.moderation_order != 'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const) || (($modvars.ZikulaUsersModule.moderation_order == 'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const) && ($reginfo.isapproved))}
                 {img modname='core' set='icons/extrasmall' src='flag.png' __title='E-mail verification not sent; must be resent' __alt='E-mail verification not sent; must be resent' class='tooltips'}
                 {else}
                 {img modname='core' set='icons/extrasmall' src='mail_delete.png' __title='E-mail verification not sent' __alt='E-mail verification not sent' class='tooltips'}
@@ -82,7 +82,7 @@
             {if isset($regactions.approve)}
             <td class="users_action">
                 {if $regactions.approve && !$reginfo.isverified}
-                {if isset($modvars.ZikulaUsersModule.moderation_order) && ($modvars.ZikulaUsersModule.moderation_order == 'UsersModule\Constant::APPROVAL_AFTER'|const)}
+                {if isset($modvars.ZikulaUsersModule.moderation_order) && ($modvars.ZikulaUsersModule.moderation_order == 'Zikula\Module\UsersModule\Constant::APPROVAL_AFTER'|const)}
                 <a href="{$regactions.approve|safetext}">{img src='button_ok.png' modname='core' set='icons/extrasmall' __title='Pre-approve (verification still required)' __alt='Pre-approve (verification still required)' class='tooltips'}</a>
                 {else}
                 <a href="{$regactions.approve|safetext}">{img src='button_ok.png' modname='core' set='icons/extrasmall' __title='Approve' __alt='Approve' class='tooltips'}</a>
@@ -169,7 +169,7 @@
         </tr>
         <tr>
             <td class="z-w45">
-                <div title="{gt text='Verification e-mail message not yet sent'}" class="z-sub user-icon-mail_delete">{gt text='A verification e-mail has not been sent to the registered e-mail address.'}{if $modvars.ZikulaUsersModule.moderation_order == 'UsersModule\Constant::APPROVAL_BEFORE'|const} {gt text='If it is not yet approved, then it will be sent on approval.'}{/if}</div>
+                <div title="{gt text='Verification e-mail message not yet sent'}" class="z-sub user-icon-mail_delete">{gt text='A verification e-mail has not been sent to the registered e-mail address.'}{if $modvars.ZikulaUsersModule.moderation_order == 'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const} {gt text='If it is not yet approved, then it will be sent on approval.'}{/if}</div>
             </td>
             <td class="z-w45">
                 <div title="{gt text='E-mail verification not sent; must be resent'}" class="z-sub user-icon-status_unknown">{gt text='A verification e-mail has not been sent to the registered e-mail address, but the registration is in a state where one should already have been sent.'}</div>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/register.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/register.tpl
@@ -42,15 +42,15 @@
     {gt text='During your visits, we recommended that you set your browser to accept cookies from this site. Various features of the site use cookies, and may not function properly (or may not function at all) if cookies are disabled.'}
 </p>
 
-{if $modvars.ZikulaUsersModule.moderation && ($modvars.ZikulaUsersModule.reg_verifyemail != 'UsersModule\Constant::VERIFY_NO'|constant)}
-    {if $modvars.ZikulaUsersModule.moderation_order == 'UsersModule\Constant::APPROVAL_BEFORE'|constant}
+{if $modvars.ZikulaUsersModule.moderation && ($modvars.ZikulaUsersModule.reg_verifyemail != 'Zikula\Module\UsersModule\Constant::VERIFY_NO'|const)}
+    {if $modvars.ZikulaUsersModule.moderation_order == 'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const}
     <p class="z-informationmsg">{gt text="Before you will be able to log in, an administrator must approve your registration request and you must verify your e-mail address. You will receive an e-mail asking to verify your e-mail address after an administrator has approved your request."}</p>
     {else}
-    <p class="z-informationmsg">{gt text="Before you will be able to log in, you must verify your e-mail address and an administrator must approve your registration request. You will receive an e-mail asking to verify your e-mail address after submitting the information below."}{if $modvars.ZikulaUsersModule.moderation_order == 'UsersModule\Constant::APPROVAL_AFTER'|constant} {gt text="You must verify your e-mail address before an administrator will approve your registration request."}{/if}</p>
+    <p class="z-informationmsg">{gt text="Before you will be able to log in, you must verify your e-mail address and an administrator must approve your registration request. You will receive an e-mail asking to verify your e-mail address after submitting the information below."}{if $modvars.ZikulaUsersModule.moderation_order == 'Zikula\Module\UsersModule\Constant::APPROVAL_AFTER'|const} {gt text="You must verify your e-mail address before an administrator will approve your registration request."}{/if}</p>
     {/if}
 {elseif $modvars.ZikulaUsersModule.moderation}
     <p class="z-informationmsg">{gt text="Before you will be able to log in, an administrator must approve your registration request. You will receive an e-mail after an administrator has reviewed the information you submit below."}</p>
-{elseif $modvars.ZikulaUsersModule.reg_verifyemail != 'UsersModule\Constant::VERIFY_NO'|constant}
+{elseif $modvars.ZikulaUsersModule.reg_verifyemail != 'Zikula\Module\UsersModule\Constant::VERIFY_NO'|const}
     <p class="z-informationmsg">{gt text="Before you will be able to log in, you must verify your e-mail address. You will receive an e-mail asking to verify your e-mail address after submitting the information below."}</p>
 {/if}
 
@@ -81,7 +81,7 @@
                 <input id="{$formData->getFieldId($fieldName)}" name="{$fieldName}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" size="25" maxlength="25" value="{$formData->getFieldData($fieldName)|safetext}" />
                 <em class="z-formnote z-sub">{gt text='User names can contain letters, numbers, underscores, periods and/or dashes.'}</em>
 
-                {if ($authentication_method.modname != 'ZikulaUsersModule') || (($authentication_method.modname == 'ZikulaUsersModule') && ($modvars.ZikulaUsersModule.loginviaoption == 'UsersModule\Constant::LOGIN_METHOD_EMAIL'|constant))}
+                {if ($authentication_method.modname != 'ZikulaUsersModule') || (($authentication_method.modname == 'ZikulaUsersModule') && ($modvars.ZikulaUsersModule.loginviaoption == 'Zikula\Module\UsersModule\Constant::LOGIN_METHOD_EMAIL'|const))}
                 <em class="z-formnote z-sub">{gt text='Your user name is used to identify you to other users on the site. You still need to set one up, even though you will not be using it to log in.'}</em>
                 {/if}
                 <p id="{$formData->getFieldId($fieldName)}_error" class="z-formnote z-errormsg{if !isset($errorFields.$fieldName)} z-hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
@@ -117,8 +117,8 @@
             </div>
         </fieldset>
         {else}
-            <input id="{$formData->getFieldId('pass')}" name="pass" type="hidden" value="{'UsersModule\Constant::PWD_NO_USERS_AUTHENTICATION'|constant}" />
-            <input id="{$formData->getFieldId('passagain')}" name="passagain" type="hidden" value="{'UsersModule\Constant::PWD_NO_USERS_AUTHENTICATION'|constant}" />
+            <input id="{$formData->getFieldId('pass')}" name="pass" type="hidden" value="{'Zikula\Module\UsersModule\Constant::PWD_NO_USERS_AUTHENTICATION'|const}" />
+            <input id="{$formData->getFieldId('passagain')}" name="passagain" type="hidden" value="{'Zikula\Module\UsersModule\Constant::PWD_NO_USERS_AUTHENTICATION'|const}" />
             <input id="{$formData->getFieldId('passreminder')}" name="passreminder" type="hidden" value="{$formData->getFieldData('passreminder')|safetext}" />
         {/if}
 {/capture}
@@ -130,7 +130,7 @@
                 <label for="{$formData->getFieldId($fieldName)}">{gt text="E-mail address"}<span class="z-form-mandatory-flag">{gt text="*"}</span></label>
                 <input id="{$formData->getFieldId($fieldName)}" name="{$fieldName}"{if isset($errorFields.$fieldName)} class="z-form-error"{/if} type="text" size="25" maxlength="60" value="{$formData->getFieldData($fieldName)|safetext}" />
 
-                {if (($authentication_method.modname == 'ZikulaUsersModule') && ($modvars.ZikulaUsersModule.loginviaoption == 'UsersModule\Constant::LOGIN_METHOD_EMAIL'|constant))}
+                {if (($authentication_method.modname == 'ZikulaUsersModule') && ($modvars.ZikulaUsersModule.loginviaoption == 'Zikula\Module\UsersModule\Constant::LOGIN_METHOD_EMAIL'|const))}
                 <em class="z-formnote z-sub">{gt text='You will use your e-mail address to identify yourself when you log in.'}</em>
                 {/if}
                 <p id="{$formData->getFieldId($fieldName)}_error" class="z-formnote z-errormsg{if !isset($errorFields.$fieldName)} z-hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
@@ -145,7 +145,7 @@
 {/capture}
 
         {* Order the fieldsets based on whether e-mail is the exclusive log-in id or not. *}
-        {if (($authentication_method.modname == 'ZikulaUsersModule') && ($modvars.ZikulaUsersModule.loginviaoption == 'UsersModule\Constant::LOGIN_METHOD_EMAIL'|constant))}
+        {if (($authentication_method.modname == 'ZikulaUsersModule') && ($modvars.ZikulaUsersModule.loginviaoption == 'Zikula\Module\UsersModule\Constant::LOGIN_METHOD_EMAIL'|const))}
             {$smarty.capture.email}
             {$smarty.capture.pass}
             {$smarty.capture.uname}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/users_email_regverifyemail_html.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/users_email_regverifyemail_html.tpl
@@ -8,7 +8,7 @@
 
 <p>{gt text="If you did request a new user account, then your request is waiting for you to verify your e-mail address with us."}
 {if !$reginfo.isapproved}{gt text="Your request is also waiting for administrator approval."}
-{if $approvalorder == 'UsersModule\Constant::APPROVAL_AFTER'|constant}{gt text="We will not be able to approve your request until after you have completed this verification step."}{/if}
+{if $approvalorder == 'Zikula\Module\UsersModule\Constant::APPROVAL_AFTER'|const}{gt text="We will not be able to approve your request until after you have completed this verification step."}{/if}
 {gt text="Once both this verification step is complete and an administrator has approved your request, you will be able to log in with your user name."}{/if}</p>
 
 <p>{gt text="Please click on the following link to complete the e-mail address check: "}<a href="{$verificationurl|safetext}">{gt text="Verify my e-mail address"}</a></p>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/users_email_regverifyemail_txt.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/users_email_regverifyemail_txt.tpl
@@ -8,7 +8,7 @@
 
 {gt text="If you did request a new user account, then your request is waiting for you to verify your e-mail address with us."}
 {if !$reginfo.isapproved}{gt text="Your request is also waiting for administrator approval."}
-{if $approvalorder == 'UsersModule\Constant::APPROVAL_AFTER'|constant}{gt text="We will not be able to approve your request until after you have completed this verification step."}{/if}
+{if $approvalorder == 'Zikula\Module\UsersModule\Constant::APPROVAL_AFTER'|const}{gt text="We will not be able to approve your request until after you have completed this verification step."}{/if}
 {gt text="Once both this verification step is complete and an administrator has approved your request, you will be able to log in with your user name."}{/if}
 
 {gt text="Please click on the following link to complete the e-mail address check: "}{$verificationurl}


### PR DESCRIPTION
Correct classname in the Users Module templates where aliases don't work (e.g. `UsersModule\Constant` -> `Zikula\Module\UsersModule\Constant`). Correct usage of `|const` modifier (was being used as `|constant` which is not available in the core as far as I can see.
