### PR TITLE
set default to gravitar when no avatar is present

### DIFF
--- a/src/lib/legacy/viewplugins/function.useravatar.php
+++ b/src/lib/legacy/viewplugins/function.useravatar.php
@@ -47,11 +47,11 @@ function smarty_function_useravatar($params, Zikula_View $view)
     }
 
     $email           = UserUtil::getVar('email', $params['uid']);
-    $avatar          = UserUtil::getVar('avatar', $params['uid']);
+    $gravatarimage   = ModUtil::getVar(UsersConstant::MODNAME, UsersConstant::MODVAR_GRAVATAR_IMAGE, UsersConstant::DEFAULT_GRAVATAR_IMAGE);
+    $avatar          = UserUtil::getVar('avatar', $params['uid'], $gravatarimage);
     $uname           = UserUtil::getVar('uname', $params['uid']);
     $avatarpath      = ModUtil::getVar(UsersConstant::MODNAME, UsersConstant::MODVAR_AVATAR_IMAGE_PATH, UsersConstant::DEFAULT_AVATAR_IMAGE_PATH);
     $allowgravatars  = ModUtil::getVar(UsersConstant::MODNAME, UsersConstant::MODVAR_GRAVATARS_ENABLED, UsersConstant::DEFAULT_GRAVATARS_ENABLED);
-    $gravatarimage   = ModUtil::getVar(UsersConstant::MODNAME, UsersConstant::MODVAR_GRAVATAR_IMAGE, UsersConstant::DEFAULT_GRAVATAR_IMAGE);
 
     if (isset($avatar) && !empty($avatar) && $avatar != $gravatarimage && $avatar != 'blank.gif') {
         $avatarURL = System::getBaseUrl() . $avatarpath . '/' . $avatar;


### PR DESCRIPTION
This changes the default behavior of zikula. I think the original intent was to only allow gravitars if the avatar mod was installed but the user selected gravitar. This changes that behavior to use the gravitar always. Refs zikula/core#707

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes? |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets | #707 |
| License | MIT |
| Doc PR | na |
