### PR TITLE
Added styles for z-menutexttitle to handle long descriptions

### DIFF
--- a/src/style/core.css
+++ b/src/style/core.css
@@ -79,6 +79,12 @@ img.z-floatright {
     background-color: blue;
 }
 
+.z-menutexttitle {
+    word-wrap: break-word;
+    margin-left: 63px;
+    margin-right: 5px;
+}
+
 /******************************************************************************
 * Class to show a sortable li or div. Has to be set in the js code to avoid
 * wrong css in non javascript environments


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | -- |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | -- |

This is how it looks like before (Take a look at the `MiniPlan` module):
![image](https://f.cloud.github.com/assets/2145092/758048/9d689348-e70c-11e2-8fdb-577fddd35c60.png)
And this is how it looks like with the changes:
![image](https://f.cloud.github.com/assets/2145092/758045/880aaa9a-e70c-11e2-9eab-415d081f17b4.png)
