### PR TITLE
Fixed password recovery process when using your email adress. $uname that only is available using the $userObj, closes #750.

### DIFF
--- a/src/docs/CHANGELOG.md
+++ b/src/docs/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG - ZIKULA 1.3.6
 
 Fixes:
 - Fixed Zikula_Doctrine2_Entity_Category::toArray fails when used on proxied category
+- Fixed not working password recovery process if using your email adress
 
 Features:
 - Added garbage collection to CSRF token generator

--- a/src/system/Zikula/Module/UsersModule/Controller/UserController.php
+++ b/src/system/Zikula/Module/UsersModule/Controller/UserController.php
@@ -1015,7 +1015,7 @@ class UserController extends \Zikula_AbstractController
                     ->fetch('User/lostpasswordcode.tpl'));
         } elseif ($formStage == 'setpass') {
             $templateVariables = array(
-                'uname'             => $uname,
+                'uname'             => $userObj['uname'],
                 'passreminder'      => $passreminder,
                 'newpassreminder'   => $newpassreminder,
                 'errormessages'     => (isset($errorInfo['errorMessages']) && !empty($errorInfo['errorMessages'])) ? $errorInfo['errorMessages'] : array(),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #750 |
| License | MIT |
| Doc PR | -- |

@Portugao Could you please check if that solves your problem? For me it works now.
