### PR TITLE
Set frontpage module to static frontpage if it is deactivated, closes #104

### DIFF
--- a/src/docs/CHANGELOG.md
+++ b/src/docs/CHANGELOG.md
@@ -59,7 +59,7 @@ Features:
 - The password reminder can be turned off now.
 - The password reminder is turned of if a third-party auth-module is used.
 - 1.2.x to 1.3.x migration script converted to pure php script.
-
+- Reset start page module to static frontpage if it is deactivated, #104.
 
 CHANGELOG - ZIKULA 1.3.5
 ------------------------

--- a/src/docs/en/dev/events.rst
+++ b/src/docs/en/dev/events.rst
@@ -79,6 +79,10 @@ Receives `$modinfo` as args
 Called after a module is successfully upgraded.
 Receives `$modinfo` as args
 
+#### `installer.module.deactivated`
+Called after a module is successfully deactivated.
+Receives `$modinfo` as args
+
 #### `installer.module.uninstalled`
 Called after a module is successfully uninstalled.
 Receives `$modinfo` as args

--- a/src/system/Zikula/Module/ExtensionsModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/ExtensionsModule/Controller/AdminController.php
@@ -14,6 +14,7 @@
 
 namespace Zikula\Module\ExtensionsModule\Controller;
 
+use Zikula\Core\Event\GenericEvent;
 use Zikula_View;
 use ModUtil;
 use FormUtil;
@@ -800,11 +801,6 @@ class AdminController extends \Zikula_AbstractController
             return LogUtil::registerError($this->__('Error! No such module ID exists.'), 404, ModUtil::url('ZikulaExtensionsModule', 'admin', 'view'));
         }
 
-        $startmod = System::getVar('startpage');
-        if ($startmod == $modinfo['name']) {
-            return LogUtil::registerError($this->__('Error! This module is currently set as the site\'s home page. You must choose another module for the home page before you can deactivate this one.'), null, ModUtil::url('ZikulaExtensionsModule', 'admin', 'view'));
-        }
-
         if (ModUtil::apiFunc('ZikulaExtensionsModule', 'admin', 'iscoremodule',array('modulename' => $modinfo['name']))) {
             return LogUtil::registerError($this->__('Error! You cannot deactivate this module. It is a mandatory core module, and is needed by the system.'), null, ModUtil::url('ZikulaExtensionsModule', 'admin', 'view'));
         }
@@ -813,6 +809,10 @@ class AdminController extends \Zikula_AbstractController
         $setstate = ModUtil::apiFunc('ZikulaExtensionsModule', 'admin', 'setstate', array('id' => $id, 'state' => ModUtil::STATE_INACTIVE));
         if ($setstate) {
             // Success
+            
+            $event = new GenericEvent(null, $modinfo);
+            $this->getDispatcher()->dispatch('installer.module.deactivated', $event);
+            
             LogUtil::registerStatus($this->__('Done! Deactivated module.'));
         }
 

--- a/src/system/Zikula/Module/SettingsModule/Api/AdminApi.php
+++ b/src/system/Zikula/Module/SettingsModule/Api/AdminApi.php
@@ -17,6 +17,7 @@ namespace Zikula\Module\SettingsModule\Api;
 use ZLanguage;
 use ModUtil;
 use SecurityUtil;
+use System;
 use Zikula_View_Theme;
 use Zikula_View;
 
@@ -53,6 +54,21 @@ class AdminApi extends \Zikula_AbstractApi
         Zikula_View_Theme::getInstance()->clear_cssjscombinecache();
         Zikula_View::getInstance()->clear_all_cache();
         Zikula_View::getInstance()->clear_compiled();
+
+        return true;
+    }
+
+    /**
+     * Resets the startmodule to static frontpage.
+     *
+     * @return boolean true.
+     */
+    public function resetStartModule()
+    {
+        System::setVar('startpage', '');
+        System::setVar('starttype', '');
+        System::setVar('startfunc', '');
+        System::setVar('startargs', '');
 
         return true;
     }

--- a/src/system/Zikula/Module/SettingsModule/Listener/ModuleListener.php
+++ b/src/system/Zikula/Module/SettingsModule/Listener/ModuleListener.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright Zikula Foundation 2013 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Zikula
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+namespace Zikula\Module\SettingsModule\Listener;
+
+use LogUtil;
+use ModUtil;
+use System;
+use Zikula_Event;
+use ZLanguage;
+
+/**
+ * EventHandlers class.
+ */
+class ModuleListener
+{
+    /**
+     * Handle module deactivated event "installer.module.deactivated".
+     * Receives $modinfo as $args
+     *
+     * @param Zikula_Event $event
+     *
+     * @return void
+     */
+    public static function moduleDeactivated(Zikula_Event $event)
+    {
+        $modname = $event['name'];
+        $dom = ZLanguage::getModuleDomain('ZikulaSettingsModule');
+
+        if ($modname == System::getVar('startpage')) {
+            ModUtil::apiFunc('ZikulaSettingsModule', 'admin', 'resetStartModule');
+            LogUtil::registerStatus(__('The start module was resetted to a static frontpage.', $dom));
+        }
+    }
+}

--- a/src/system/Zikula/Module/SettingsModule/SettingsModuleInstaller.php
+++ b/src/system/Zikula/Module/SettingsModule/SettingsModuleInstaller.php
@@ -20,6 +20,7 @@ use ModUtil;
 use ZLanguage;
 use DBUtil;
 use DoctrineHelper;
+use EventUtil;
 
 /**
  * Settings_Installer class.
@@ -112,6 +113,9 @@ class SettingsModuleInstaller extends \Zikula_AbstractInstaller
             return false;
         }
 
+        // register event handler to remove the startpage module if it is deactivated.
+        EventUtil::registerPersistentModuleHandler($this->name, 'installer.module.deactivated', array('Zikula\Module\SettingsModule\Listener\ModuleListener', 'moduleDeactivated'));
+
         // Initialisation successful
         return true;
     }
@@ -125,8 +129,10 @@ class SettingsModuleInstaller extends \Zikula_AbstractInstaller
 
         // Upgrade dependent on old version number
         switch ($oldversion) {
-            // future upgrade routines
             case '2.9.7':
+                EventUtil::registerPersistentModuleHandler($this->name, 'installer.module.deactivated', array('Zikula\Module\SettingsModule\Listener\ModuleListener', 'moduleDeactivated'));
+            // future upgrade routines
+            case '2.9.8':
         }
 
         // Update successful

--- a/src/system/Zikula/Module/SettingsModule/SettingsModuleVersion.php
+++ b/src/system/Zikula/Module/SettingsModule/SettingsModuleVersion.php
@@ -23,7 +23,7 @@ class SettingsModuleVersion extends \Zikula_AbstractVersion
         $meta['description']    = $this->__('General site configuration interface.');
         //! module name that appears in URL
         $meta['url']            = $this->__('settings');
-        $meta['version']        = '2.9.7';
+        $meta['version']        = '2.9.8';
         $meta['core_min'] = '1.3.6';
         $meta['securityschema'] = array('ZikulaSettingsModule::' => '::');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | -- |
| Fixed tickets | #103 |
| Referenced tickets | #760 |
| License | MIT |
| Doc PR | -- |

I did not test upgrading from 1.3.5 to 1.3.6. I only tested upgrading the SettingsModule from _before_ this PR to _after_ this PR.
