### PR TITLE
Fixed wrong return statement, closes #756.

### DIFF
--- a/src/system/Zikula/Module/CategoriesModule/Controller/UserController.php
+++ b/src/system/Zikula/Module/CategoriesModule/Controller/UserController.php
@@ -137,7 +137,7 @@ class UserController extends \Zikula_AbstractController
 
         $this->view->setCaching(Zikula_View::CACHE_DISABLED);
 
-        return $this->view->assign('rootCat', $rootCat)
+        $this->view->assign('rootCat', $rootCat)
                     ->assign('category', $editCat)
                     ->assign('attributes', $attributes)
                     ->assign('allCats', $allCats)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | -- |
| Fixed tickets | #756 |
| License | MIT |
| Doc PR | -- |

This bug came at Zikula 1.3.6, so this needs no changelog.
