### PR TITLE
Updated Theme Module path in CSS/JS/TPL includes

### DIFF
--- a/src/lib/legacy/Zikula/Form/Block/ContextMenu.php
+++ b/src/lib/legacy/Zikula/Form/Block/ContextMenu.php
@@ -115,7 +115,7 @@ class Zikula_Form_Block_ContextMenu extends Zikula_Form_AbstractStyledPlugin
      */
     public function dataBound(Zikula_Form_View $view, &$params)
     {
-        PageUtil::AddVar('javascript', 'system/Theme/Resources/public/js/form/form.js');
+        PageUtil::AddVar('javascript', 'system/Zikula/Module/ThemeModule/Resources/public/js/form/form.js');
         PageUtil::AddVar('javascript', 'javascript/ajax/prototype.js');
     }
 

--- a/src/lib/legacy/Zikula/Form/Block/TabbedPanelSet.php
+++ b/src/lib/legacy/Zikula/Form/Block/TabbedPanelSet.php
@@ -32,7 +32,7 @@
  * {/formtabbedpanelset}
  * </code>
  * You can place any Zikula_Form_View plugins inside the individual panels. The tabs
- * require some special styling which is handled by the styles in system/Theme/Resources/public/css/form/style.css.
+ * require some special styling which is handled by the styles in system/Zikula/Module/ThemeModule/Resources/public/css/form/style.css.
  * If you want to override this styling then either copy the styles to another stylesheet in the
  * templates directory or change the cssClass attribute to something different than the default
  * class name.
@@ -94,7 +94,7 @@ class Zikula_Form_Block_TabbedPanelSet extends Zikula_Form_AbstractPlugin
         static $firstTime = true;
         if ($firstTime) {
             PageUtil::addVar('javascript', 'javascript/ajax/prototype.js');
-            PageUtil::addVar('javascript', 'system/Theme/Resources/public/js/form/form_tabbedpanelset.js');
+            PageUtil::AddVar('javascript', 'system/Zikula/Module/ThemeModule/Resources/public/js/form/form_tabbedpanelset.js');
             PageUtil::addVar('footer', "<script type=\"text/javascript\">$$('.tabsToHide').invoke('hide')</script>");
         }
         $firstTime = false;

--- a/src/lib/legacy/viewplugins/formplugins/block.form.php
+++ b/src/lib/legacy/viewplugins/formplugins/block.form.php
@@ -25,7 +25,7 @@
 function smarty_block_form($params, $content, $view)
 {
     if ($content) {
-        PageUtil::addVar('stylesheet', 'system/Theme/Resources/public/css/form/style.css');
+        PageUtil::AddVar('stylesheet', 'system/Zikula/Module/ThemeModule/Resources/public/css/form/style.css');
         $action = htmlspecialchars(System::getCurrentUri());
         $classString = '';
         if (isset($params['cssClass'])) {

--- a/src/lib/legacy/viewplugins/formplugins/block.formtabbedpanelset.php
+++ b/src/lib/legacy/viewplugins/formplugins/block.formtabbedpanelset.php
@@ -32,7 +32,7 @@
  * {/formtabbedpanelset}
  * </code>
  * You can place any Zikula_Form_View plugins inside the individual panels. The tabs
- * require some special styling which is handled by the styles in system/Theme/Resources/public/css/form/style.css.
+ * require some special styling which is handled by the styles in system/Zikula/Module/ThemeModule/Resources/public/css/form/style.css.
  * If you want to override this styling then either copy the styles to another stylesheet in the
  * templates directory or change the cssClass attribute to something different than the default
  * class name.

--- a/src/lib/legacy/viewplugins/function.pagesetvar.php
+++ b/src/lib/legacy/viewplugins/function.pagesetvar.php
@@ -64,7 +64,7 @@ function smarty_function_pagesetvar($params, Zikula_View $view)
 
     // handle Clip which is manually loading a Theme's stylesheets
     if ($name == 'stylesheet' && false !== strpos($value, 'system/Theme/style/')) {
-        $value = str_replace('system/Theme/style/', 'system/Theme/Resources/public/css/', $value);
+        $value = str_replace('system/Theme/style/', 'system/Zikula/Module/ThemeModule/Resources/public/css/', $value);
     }
 
     if (in_array($name, array('stylesheet', 'javascript'))) {

--- a/src/lib/legacy/viewplugins/function.zdebug.php
+++ b/src/lib/legacy/viewplugins/function.zdebug.php
@@ -54,7 +54,7 @@ function smarty_function_zdebug($params, Zikula_View $view)
         $_plugins_outputfilter = $view->_plugins['outputfilter'];
         $_compile_id_orig   = $view->_compile_id;
 
-        $view->template_dir = 'system/Theme/Resources/views';
+        $view->template_dir = 'system/Zikula/Module/ThemeModule/Resources/views';
         $view->default_resource_type = 'file';
         $view->_plugins['outputfilter'] = null;
         $view->_compile_id  = null;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | #904, #903 |
| License | MIT |
| Doc PR | - |

In various files of the Form legacy classes includes of css/js of the Theme Module are being done. These were referring to the old location before the Symfony Bundle folder location update.
This is corrected here.
