### PR TITLE
Adding autoloading back to the Core->init function.

### DIFF
--- a/src/lib/legacy/Zikula/Core.php
+++ b/src/lib/legacy/Zikula/Core.php
@@ -466,6 +466,13 @@ class Zikula_Core
             ModUtil::dbInfoLoad('ZikulaPermissionsModule', 'ZikulaPermissionsModule');
             ModUtil::dbInfoLoad('ZikulaCategoriesModule', 'ZikulaCategoriesModule');
 
+            // Add AutoLoading for non-symfony 1.3 modules in /modules
+            // isLegacyMode check added to avoid this call being done when somebody
+            // only has Symfony structure modules installed. Check if this is ok.
+            if (!System::isInstalling() && System::isLegacyMode()) {
+                ModUtil::registerAutoloaders();
+            }
+
             $coreInitEvent->setArg('stage', self::STAGE_TABLES);
             $this->dispatcher->dispatch('core.init', $coreInitEvent);
         }

--- a/src/lib/util/ModUtil.php
+++ b/src/lib/util/ModUtil.php
@@ -1762,6 +1762,26 @@ class ModUtil
     }
 
     /**
+     * Register all autoloaders for all modules in /modules
+     * modules in /system should be Symfony structure based, so no manual autoloading needed
+     *
+     * @internal
+     *
+     * @return void
+     */
+    public static function registerAutoloaders()
+    {
+        $modules = self::getModsTable();
+        unset($modules[0]);
+        foreach ($modules as $module) {
+            if ($module['type'] == self::TYPE_MODULE) {
+                $path = "modules/$module[directory]/lib";
+                ZLoader::addAutoloader($module['directory'], $path);
+            }
+        }
+    }
+
+    /**
      * Get the base directory for a module.
      *
      * Example: If the webroot is located at


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | #899, probably also #883 |
| License | MIT |
| Doc PR | - |

Added registerAutoloaders method back to ModUtil and added a call to this method in lib/legacy/Zikula/Core->init.
Adding hooks to a modules works again after this update.
I can install News and add Scribite as a hook fine !
