### PR TITLE
declare array var to avoid errors when neither function exists.

### DIFF
--- a/src/lib/util/ModUtil.php
+++ b/src/lib/util/ModUtil.php
@@ -680,6 +680,7 @@ class ModUtil
             // If not gets here, the module has no tables to load
             $tablefunc = $modname . '_tables';
             $tablefuncOld = $modname . '_pntables';
+            $data = array();
             if (function_exists($tablefunc)) {
                 $data = call_user_func($tablefunc);
             } elseif (function_exists($tablefuncOld)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets | na |
| License | MIT |
| Doc PR | na |
