### PR TITLE
correct issue with useravatar where the `size` parameter was being left ...

### DIFF
--- a/src/lib/legacy/viewplugins/function.useravatar.php
+++ b/src/lib/legacy/viewplugins/function.useravatar.php
@@ -68,6 +68,8 @@ function smarty_function_useravatar($params, Zikula_View $view)
                 } else {
                     $params['size'] = 80;
                 }
+            } else {
+                $params['size'] = 80;
             }
         }
         $params['width']  = $params['size'];


### PR DESCRIPTION
...completely unset if neither `width` nor `height` was set.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets | na |
| License | MIT |
| Doc PR | na |
