### PR TITLE
refer to #912 updated autoloading of modules

### DIFF
--- a/src/lib/legacy/Zikula/Core.php
+++ b/src/lib/legacy/Zikula/Core.php
@@ -467,9 +467,7 @@ class Zikula_Core
             ModUtil::dbInfoLoad('ZikulaCategoriesModule', 'ZikulaCategoriesModule');
 
             // Add AutoLoading for non-symfony 1.3 modules in /modules
-            // isLegacyMode check added to avoid this call being done when somebody
-            // only has Symfony structure modules installed. Check if this is ok.
-            if (!System::isInstalling() && System::isLegacyMode()) {
+            if (!System::isInstalling()) {
                 ModUtil::registerAutoloaders();
             }
 

--- a/src/lib/util/ModUtil.php
+++ b/src/lib/util/ModUtil.php
@@ -1756,7 +1756,7 @@ class ModUtil
     }
 
     /**
-     * Register all autoloaders for all modules in /modules
+     * Register all autoloaders for all modules in /modules containing a lib subdir
      * modules in /system should be Symfony structure based, so no manual autoloading needed
      *
      * @internal
@@ -1768,8 +1768,8 @@ class ModUtil
         $modules = self::getModsTable();
         unset($modules[0]);
         foreach ($modules as $module) {
-            if ($module['type'] == self::TYPE_MODULE) {
-                $path = "modules/$module[directory]/lib";
+            $path = "modules/$module[directory]/lib";
+            if ($module['type'] == self::TYPE_MODULE && is_dir($path)) {
                 ZLoader::addAutoloader($module['directory'], $path);
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | refers to #945 and Pull request #912 |
| License | MIT |
| Doc PR | - |

Removed the legacy check and added an is_dir check to do this only for modules that have a lib subfolder, so old module structure.
