### PR TITLE
Move BC layer to make sure it is always loaded.

### DIFF
--- a/src/system/Zikula/Module/UsersModule/Constant.php
+++ b/src/system/Zikula/Module/UsersModule/Constant.php
@@ -395,23 +395,3 @@ namespace Zikula\Module\UsersModule
         const EMAIL_DOMAIN_VALIDATION_PATTERN = '(?:[^\\s\\000-\\037\\177\\(\\)<>@,;:\\\\"\\[\\]]\\.?)+\\.[a-z]{2,6}';
     }
 }
-/**
- * BC layer till for <=1.3.5
- */
-namespace {
-    class Users_Constant extends Zikula\Module\UsersModule\Constant
-    {
-    }
-
-    class Users_Helper_AuthenticationMethod extends \Zikula\Module\UsersModule\Helper\AuthenticationMethodHelper
-    {
-    }
-
-    class Users_Helper_AuthenticationMethodList extends \Zikula\Module\UsersModule\Helper\AuthenticationMethodListHelper
-    {
-    }
-
-    class Users_Helper_HasMethodList extends \Zikula\Module\UsersModule\Helper\HashMethodListHelper
-    {
-    }
-}

--- a/src/system/Zikula/Module/UsersModule/ZikulaUsersModule.php
+++ b/src/system/Zikula/Module/UsersModule/ZikulaUsersModule.php
@@ -1,9 +1,31 @@
 <?php
 
-namespace Zikula\Module\UsersModule;
 
-use Zikula\Bundle\CoreBundle\Bundle\AbstractCoreModule;
+namespace Zikula\Module\UsersModule {
+    use Zikula\Bundle\CoreBundle\Bundle\AbstractCoreModule;
 
-class ZikulaUsersModule extends AbstractCoreModule
-{
+    class ZikulaUsersModule extends AbstractCoreModule
+    {
+    }
+}
+
+/**
+ * BC layer till for <=1.3.5
+ */
+namespace {
+    class Users_Constant extends Zikula\Module\UsersModule\Constant
+    {
+    }
+
+    class Users_Helper_AuthenticationMethod extends \Zikula\Module\UsersModule\Helper\AuthenticationMethodHelper
+    {
+    }
+
+    class Users_Helper_AuthenticationMethodList extends \Zikula\Module\UsersModule\Helper\AuthenticationMethodListHelper
+    {
+    }
+
+    class Users_Helper_HasMethodList extends \Zikula\Module\UsersModule\Helper\HashMethodListHelper
+    {
+    }
 }


### PR DESCRIPTION
The Constant file is not always loaded (I had problems being on the startpage, clicking onto the OpenID modules select-google-as-method button in the login block, which executes ajax ending up with the OpenID's Authentication api which uses the `Users_Helper_AuthenticationMethod` class which was not loaded).

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | -- |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | -- |
