### PR TITLE
fixes #977, blocks module name was incorrent in modifyblockposition

### DIFF
--- a/src/system/Zikula/Module/BlocksModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/BlocksModule/Controller/AdminController.php
@@ -656,7 +656,7 @@ class AdminController extends \Zikula_AbstractController
                    ->assign('description', $position['description']);
 
         // get all blocks in the position
-        $block_placements = ModUtil::apiFunc('blocks', 'user', 'getblocksinposition', array('pid' => $pid));
+        $block_placements = ModUtil::apiFunc('ZikulaBlocksModule', 'user', 'getblocksinposition', array('pid' => $pid));
 
         // get all defined blocks
         $allblocks = ModUtil::apiFunc('ZikulaBlocksModule', 'user', 'getall', array('active_status' => 0));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Refs tickets | - |
| Fixed tickets | #977 |
| License | MIT |
| Doc PR | - |

The old blocks name was used instead of ZikulaBlocksModule
