### PR TITLE
add path to cookie so multiple installations on one root possible.

### DIFF
--- a/src/app/config/config.yml
+++ b/src/app/config/config.yml
@@ -19,6 +19,7 @@ framework:
     trusted_proxies: ~
     session:
         name: _zsid
+        save_path: "%kernel.root_dir%"
         handler_id: session.handler.legacy
         storage_id: session.storage.legacy
     fragments:       ~


### PR DESCRIPTION
Not sure this is correct but it appears to make the cookie have the same path as Core 1.3.5 did. I assume this is important when having multiple installations on the same root. 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Refs tickets | na |
| Fixed tickets | na |
| License | MIT |
| Doc PR | na |
