### PR TITLE
Added missing "$bundle" parameter to version class constructor, closes #990

### DIFF
--- a/src/lib/legacy/Zikula/AbstractInstaller.php
+++ b/src/lib/legacy/Zikula/AbstractInstaller.php
@@ -38,7 +38,7 @@ abstract class Zikula_AbstractInstaller extends Zikula_AbstractBase
             $this->domain = ZLanguage::getModuleDomain($this->name);
             $this->baseDir = $bundle->getPath();
             $versionClass =  $bundle->getVersionClass();
-            $this->version = new $versionClass;
+            $this->version = new $versionClass($bundle);
         } else {
             $className = $this->getReflection()->getName();
             $separator = (false === strpos($className, '_')) ? '\\' : '_';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | --- |
| Fixed tickets | #990 |
| License | MIT |
| Doc PR | --- |
