### PR TITLE
Added a third level of messages: LogUtil::registerWarning().

### DIFF
--- a/src/docs/CHANGELOG.md
+++ b/src/docs/CHANGELOG.md
@@ -69,6 +69,8 @@ Features:
 - Added "hybrid" login option. The user can either provide his email address or user name and will be logged in.
 - Added system information page using `phpinfo()` to the settings module.
 - Params delivery from zikula html_select_* to smarty_function_html_options, #1031.
+- Added a third level of warning messages: LogUtil::registerWarning(). These override status messages and are
+  overridden by error messages.
 
 CHANGELOG - ZIKULA 1.3.5
 ------------------------

--- a/src/lib/legacy/Zikula/Session.php
+++ b/src/lib/legacy/Zikula/Session.php
@@ -28,6 +28,13 @@ class Zikula_Session extends Session
     const MESSAGE_STATUS = 'status';
 
     /**
+     * The message type for warning messages, to use with, for example, {@link hasMessages()}.
+     *
+     * @var string
+     */
+    const MESSAGE_WARNING = 'warning';
+
+    /**
      * The message type for error messages, to use with, for example, {@link hasMessages()}.
      *
      * @var string

--- a/src/lib/legacy/viewplugins/insert.getstatusmsg.php
+++ b/src/lib/legacy/viewplugins/insert.getstatusmsg.php
@@ -56,9 +56,14 @@ function smarty_insert_getstatusmsg($params, $view)
     $session = $view->getContainer()->get('session');
     $msgStatus = $session->getFlashBag()->get(Zikula_Session::MESSAGE_STATUS);
     $msgtype   = ($class ? $class : 'alert alert-success');
+    $msgWarning = $session->getFlashBag()->get(Zikula_Session::MESSAGE_WARNING);
     $msgError = $session->getFlashBag()->get(Zikula_Session::MESSAGE_ERROR);
 
-    // Error message overrides status message
+    if (!empty($msgWarning)) {
+        $msgStatus = $msgWarning;
+        $msgtype = ($class ? $class : 'alert alert-warning');
+    }
+    // Error message overrides status and warning message
     if (!empty($msgError)) {
         $msgStatus = $msgError;
         $msgtype   = ($class ? $class : 'alert alert-danger');


### PR DESCRIPTION
 These override status messages and are overridden by error messages.

Warning messages are not meant to "stop" something. These are just warnings, but no critical erros. That's why it returns `true` as `LogUtil::registerStatus()` and not false as `LogUtil::registerError()`.
