### PR TITLE
fixes #1063, updated hooks.tpl to expand all hook areas

### DIFF
--- a/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/HookUi/hooks.tpl
+++ b/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/HookUi/hooks.tpl
@@ -21,7 +21,7 @@
         initAreasDraggables();
         initAreasDroppables();
 
-        new Zikula.UI.Panels('hooks_provider_areas', {
+        provider_panel = new Zikula.UI.Panels('hooks_provider_areas', {
             active: [0],
             effectDuration: 0.5
         });
@@ -44,6 +44,9 @@
                 headerClassName: 'subscriberarea-header'
             });
         }
+		// Expand all hook panels
+		subscriber_panel.expandAll();
+		provider_panel.expandAll();
     });
 </script>
 {/pageaddvarblock}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Refs tickets | - |
| Fixed tickets | #1063 |
| License | MIT |
| Doc PR | - |

Updated the hooks display template to expand all hook areas. This makes it easier to pick the right subscriber hook and attach the correct provider. Especially for modules with several hook areas.
