### PR TITLE
Do not delete flash bag messages on get.

### DIFF
--- a/src/lib/legacy/Zikula/Session.php
+++ b/src/lib/legacy/Zikula/Session.php
@@ -150,7 +150,7 @@ class Zikula_Session extends Session
      */
     public function getMessages($type, $default = array())
     {
-        return $this->getFlashBag()->get($type, $default);
+        return $this->getFlashBag()->peek($type, $default);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | -- |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | -- |

I.e. LogUtil::getErrorMessages() relys on flashbag messages not being deleted on get. Otherwise this is a BC-break.
