### PR TITLE
Use the way better Symfony exception dumper.

### DIFF
--- a/src/app/Resources/TwigBundle/views/layout.html.twig
+++ b/src/app/Resources/TwigBundle/views/layout.html.twig
@@ -1,0 +1,7 @@
+<!--
+    {% block head %}{% endblock %}
+-->
+
+<div class="sf-reset">
+    {% block body %}{% endblock %}
+</div>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | -- |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | -- |

Turns this:
![image](https://f.cloud.github.com/assets/2145092/1096074/d5f527b0-16f7-11e3-9438-f0c7779aa3ca.png)
into this if Zikula development mode is on.
![image](https://f.cloud.github.com/assets/2145092/1096079/08087f36-16f8-11e3-9823-0ff958bf6d71.png)
I really love :heart: the syntax-highlighted stack trace!

I know calling the Twig Exception Controller is hacky. But as this only happens in dev-mode I really think it is worth it. And this can be removed when we switch to Symfony Routing and Twig.
