### PR TITLE
Edited security token validation message to provide more information.

### DIFF
--- a/src/lib/legacy/Zikula/AbstractBase.php
+++ b/src/lib/legacy/Zikula/AbstractBase.php
@@ -785,8 +785,7 @@ abstract class Zikula_AbstractBase implements Zikula_TranslatableInterface, Cont
             return;
         }
 
-        // Should we expire the session also? drak.
-        throw new Zikula_Exception_Forbidden(__('Security token validation failed'));
+        throw new Zikula_Exception_Forbidden(__f('Oops, something went wrong: security token validation failed. You might want to go to the <a href="%s">startpage</a>.', $this->request->getBaseUrl()));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | --- |
| Fixed tickets | #995 |
| License | MIT |
| Doc PR | --- |

@drak I removed the "should we expire the session also" comment. It is really easy to produce such a csrf error (when working with "Open in new Tab" functionality and Extensions module) and I don't think a user should be logged out.
