### PR TITLE
Removed unused dbutil calls

### DIFF
--- a/src/system/Zikula/Module/AdminModule/AdminModuleInstaller.php
+++ b/src/system/Zikula/Module/AdminModule/AdminModuleInstaller.php
@@ -15,7 +15,6 @@
 namespace Zikula\Module\AdminModule;
 
 use DoctrineHelper;
-use DBUtil;
 use Zikula\Module\AdminModule\Entity\AdminCategoryEntity;
 
 class AdminModuleInstaller extends \Zikula_AbstractInstaller

--- a/src/system/Zikula/Module/BlocksModule/BlocksModuleInstaller.php
+++ b/src/system/Zikula/Module/BlocksModule/BlocksModuleInstaller.php
@@ -15,7 +15,6 @@
 namespace Zikula\Module\BlocksModule;
 
 use DoctrineHelper;
-use DBUtil;
 use ModUtil;
 use ZLanguage;
 use Doctrine;

--- a/src/system/Zikula/Module/GroupsModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/GroupsModule/Controller/AjaxController.php
@@ -19,7 +19,6 @@ use Zikula\Module\GroupsModule\Helper\CommonHelper;
 use SecurityUtil;
 use ModUtil;
 use LogUtil;
-use DBUtil;
 use Zikula_Exception_Fatal;
 
 /**

--- a/src/system/Zikula/Module/GroupsModule/GroupsModuleInstaller.php
+++ b/src/system/Zikula/Module/GroupsModule/GroupsModuleInstaller.php
@@ -15,7 +15,6 @@
 namespace Zikula\Module\GroupsModule;
 
 use DoctrineHelper;
-use DBUtil;
 
 class GroupsModuleInstaller extends \Zikula_AbstractInstaller
 {

--- a/src/system/Zikula/Module/PermissionsModule/PermissionsModuleInstaller.php
+++ b/src/system/Zikula/Module/PermissionsModule/PermissionsModuleInstaller.php
@@ -14,7 +14,6 @@
 
 namespace Zikula\Module\PermissionsModule;
 
-use DBUtil;
 use Zikula\Module\PermissionsModule\Entity\PermissionEntity;
 
 class PermissionsModuleInstaller extends \Zikula_AbstractInstaller

--- a/src/system/Zikula/Module/SearchModule/SearchModuleInstaller.php
+++ b/src/system/Zikula/Module/SearchModule/SearchModuleInstaller.php
@@ -14,7 +14,6 @@
 
 namespace Zikula\Module\SearchModule;
 
-use DBUtil;
 use EventUtil;
 use DoctrineHelper;
 

--- a/src/system/Zikula/Module/SecurityCenterModule/SecurityCenterModuleInstaller.php
+++ b/src/system/Zikula/Module/SecurityCenterModule/SecurityCenterModuleInstaller.php
@@ -14,7 +14,6 @@
 
 namespace Zikula\Module\SecurityCenterModule;
 
-use DBUtil;
 use System;
 use Zikula_Core;
 use CacheUtil;


### PR DESCRIPTION
This PR removes some unused dbutil calls from system modules.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |

-Mark
