### PR TITLE
remove stray legacy logging code

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/HttpKernel/ZikulaKernel.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/HttpKernel/ZikulaKernel.php
@@ -77,11 +77,6 @@ abstract class ZikulaKernel extends Kernel
 
         // relocate ztemp to cache dir (nasty BC, sorry)
         $GLOBALS['ZConfig']['System']['temp'] = $this->getRootDir()."/cache/{$this->environment}/".$GLOBALS['ZConfig']['System']['temp'];
-        $GLOBALS['ZConfig']['Log']['log_dir'] = $this->getRootDir()."/cache/{$this->environment}/".$GLOBALS['ZConfig']['Log']['log_dir'];
-        $GLOBALS['ZConfig']['Log']['log_file'] = $this->getRootDir()."/cache/{$this->environment}/".$GLOBALS['ZConfig']['Log']['log_file'];
-        foreach ($GLOBALS['ZConfig']['Log']['log_level_files'] as $key => $path) {
-            $GLOBALS['ZConfig']['Log']['log_level_files'][$key] = $this->getRootDir()."/cache/{$this->environment}/".$GLOBALS['ZConfig']['Log']['log_level_files'][$key];
-        }
     }
 
     public function boot()


### PR DESCRIPTION
This PR fixes some left over legacy logging code that triggers an error when development is on.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #1154 |
| Refs tickets | #1150 |
| License | MIT |
| Doc PR |  |

-Mark
