### PR TITLE
Wrong new group error message fixed, closes #1180.

### DIFF
--- a/src/system/Zikula/Module/GroupsModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/GroupsModule/Controller/AdminController.php
@@ -226,7 +226,7 @@ class AdminController extends \Zikula_AbstractController
         $description = $this->request->request->get('description', isset($args['description']) ? $args['description'] : null);
 
         // The API function is called.
-        $check = ModUtil::apiFunc('ZikulaGroupsModule', 'admin', 'getgidbyname', array());
+        $check = ModUtil::apiFunc('ZikulaGroupsModule', 'admin', 'getgidbyname', array('name' => $name));
 
         if ($check != false) {
             // Group already exists


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Fixed tickets | #1180 |
| License | MIT |
