### PR TITLE
add moduleInstance to templates for 1.3.6-type modules

### DIFF
--- a/src/docs/CHANGELOG.md
+++ b/src/docs/CHANGELOG.md
@@ -74,7 +74,7 @@ Features:
 - Do not register hooks twice, #484.
 - Do not register eventhandlers twice, #727.
 - Added a `reason` key to module dependendies array in module version file.
-- add 'moduleInstance' template variable for 1.3.6-type modules (is NULL for legacy mods)
+- add 'moduleBundle' template variable for 1.3.6-type modules (is NULL for legacy mods)
   instance of `\Zikula\Core\AbstractModule` for current module
 
 CHANGELOG - ZIKULA 1.3.5

--- a/src/lib/legacy/Zikula/View.php
+++ b/src/lib/legacy/Zikula/View.php
@@ -316,7 +316,7 @@ class Zikula_View extends Smarty implements Zikula_TranslatableInterface
              ->assign('themepath', $this->baseurl . 'themes/' . $theme)
              ->assign('baseurl', $this->baseurl)
              ->assign('baseuri', $this->baseuri)
-             ->assign('moduleInstance', ModUtil::getModule($moduleName)); // is NULL for pre-1.3.6-type modules
+             ->assign('moduleBundle', ModUtil::getModule($moduleName)); // is NULL for pre-1.3.6-type modules
 
         if (System::isLegacyMode()) {
             $this->assign('stylepath', $this->baseurl . 'themes/' . $theme . '/style')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets | na |
| Refs tickets | na |
| License | MIT |
| Doc PR | changelog entry |

I couldn't think of a better variable name (module is already taken). This allows access to module paths in template.
