### PR TITLE
Admin breadcrumbs does not work with system plugins fixed, closes #1056.

### DIFF
--- a/src/docs/CHANGELOG.md
+++ b/src/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixes:
 - Fixed Extensions module pager, #961.
 - Pass-meter was hidden, because no height was set, #997.
 - Do not show multi-lingual user settings if multi-lingual is disabled, #1050.
+- Fixed Admin breadcrumbs does not work with system plugins, #1056.
 
 Features:
 - Show an error message if version number of a module is incorrect.

--- a/src/lib/legacy/Zikula/View.php
+++ b/src/lib/legacy/Zikula/View.php
@@ -236,9 +236,10 @@ class Zikula_View extends Smarty implements Zikula_TranslatableInterface
         $this->addPluginDir($mpluginPathNew); // Plugins for current module
         $this->addPluginDir($mpluginPath); // Plugins for current module
 
-        // check if the 'type' parameter in the URL is admin and if yes,
-        // include system/Admin/templates/plugins to the plugins_dir array
-        if ($type === 'admin') {
+        // check if the 'type' parameter in the URL is admin or adminplugin and 
+        // if yes, include system/Admin/templates/plugins to the plugins_dir 
+        // array
+        if ($type === 'admin' || $type === 'adminplugin') {
             if (!$this instanceof Zikula_View_Theme) {
                 $this->addPluginDir('system/Zikula/Module/AdminModule/Resources/views/plugins');
             } else {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Fixed tickets | #1056 |
| Refs tickets |  |
| License | MIT |
