### PR TITLE
do not allow form submit on selector change in category new/edit form

### DIFF
--- a/src/system/Zikula/Module/CategoriesModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/CategoriesModule/Controller/AdminController.php
@@ -135,7 +135,6 @@ class AdminController extends \Zikula_AbstractController
             }
         }
 
-        $reloadOnCatChange = ($mode != 'edit');
         $allCats = CategoryUtil::getSubCategories($root_id, true, true, true, false, true);
 
         // now remove the categories which are below $editCat ...
@@ -158,7 +157,7 @@ class AdminController extends \Zikula_AbstractController
                                                          null,
                                                          0,
                                                          null,
-                                                         $reloadOnCatChange,
+                                                         false, // do not submit on selector change
                                                          false,
                                                          true,
                                                          1,


### PR DESCRIPTION
fixes #1241

I don't know why this would ever be useful in this situation, so I removed it entirely. I'm guessing it wasn't working before anyway.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | maybe? |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets | #1241 |
| Refs tickets | #1241 |
| License | MIT |
| Doc PR | na |
