### PR TITLE
remove bootstrap-theme ?

### DIFF
--- a/src/themes/Zikula/Theme/Andreas08Theme/Resources/views/includes/header.tpl
+++ b/src/themes/Zikula/Theme/Andreas08Theme/Resources/views/includes/header.tpl
@@ -5,7 +5,6 @@
         <title>{pagegetvar name='title'}</title>
         <meta name="description" content="{$metatags.description}" />
         <meta name="keywords" content="{$metatags.keywords}" />
-        {pageaddvar name="stylesheet" value="web/bootstrap/css/bootstrap-theme.min.css"}
         {pageaddvar name="stylesheet" value="$stylepath/fluid960gs/reset.css"}
         {pageaddvar name="stylesheet" value="$stylepath/fluid960gs/$layout.css"}
         {pageaddvar name="stylesheet" value="$stylepath/style.css"}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets |  |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |

I submit this only as a discussion point to begin with. @phaidon is doing **_AMAZING**_ +:100:^:100: work. I think we should should talk about whether we want the newer "flatter" design of "pure" Bootstrap 3 or the more 3D look of Bootstrap 2. While we currently are using Bootstrap 3, we are also loading `bootstrap-theme.css` (at least in the Andreas08 theme) which adds a more 3D feel to many of the components. 

The most noticeable changes are in the buttons and the navbar. you may have to click the images to see the full effect.

Personally, **I prefer** the flatter look of pure Bootstrap without the additional css. I think it looks more modern (like iOS7, for ex). 

Here are some images to compare:
First 2 **include** bootstrap-theme.css
![shot_w1](https://f.cloud.github.com/assets/350048/1232278/767a05b0-28a1-11e3-846e-a6d1a5671fd2.png)
![shot_w2](https://f.cloud.github.com/assets/350048/1232279/78f28d94-28a1-11e3-9b52-058392fdcfdb.png)

The next two are **without** bootstrap-theme.css
![shot_wo1](https://f.cloud.github.com/assets/350048/1232280/84d86674-28a1-11e3-98bf-586e5da8bf5b.png)
![shot_wo2](https://f.cloud.github.com/assets/350048/1232281/866dcb82-28a1-11e3-9b5e-a840489732b3.png)
