### PR TITLE
"Blocks list" dropdown shows \" instead of " fixed, closes #1250.

### DIFF
--- a/src/system/Zikula/Module/BlocksModule/Api/AdminApi.php
+++ b/src/system/Zikula/Module/BlocksModule/Api/AdminApi.php
@@ -410,7 +410,7 @@ class AdminApi extends \Zikula_AbstractApi
         foreach ($blockspositions as $blocksposition) {
             $filter['blockposition_id'] = $blocksposition['pid'];
             $submenulinks[] = array('url' => ModUtil::url('ZikulaBlocksModule', 'admin', 'view', array('filter' => $filter)),
-                    'text' => $this->__f('Position \"%s\" ', $blocksposition['name']));
+                    'text' => $this->__f('Position "%s"', $blocksposition['name']));
         }
 
         if (SecurityUtil::checkPermission('ZikulaBlocksModule::', '::', ACCESS_EDIT)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Fixed tickets | #1250 |
| Refs tickets |  |
| License | MIT |
