### PR TITLE
override bootstrap legend width

### DIFF
--- a/src/style/core.css
+++ b/src/style/core.css
@@ -85,6 +85,8 @@ ul.navbar-modulelinks ul > li > a {
 }
 
 .form-horizontal legend {
+    width: auto;
+    padding: 0 .2em;
     font-size: 1.25em;
     font-weight: normal;
     color: #000;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets |  |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |

turns this: 
![shot_before](https://f.cloud.github.com/assets/350048/1274818/d3ca2190-2dcf-11e3-81d0-c634a010e755.png)

into this:
![shot_after](https://f.cloud.github.com/assets/350048/1274819/d7e6c97c-2dcf-11e3-8fb9-ce51076349b3.png)

look carefully at the top border of the `fieldset`
