### PR TITLE
prevent duplicate rendering of css class in form checkbox plugin

### DIFF
--- a/src/lib/legacy/Zikula/Form/Plugin/Checkbox.php
+++ b/src/lib/legacy/Zikula/Form/Plugin/Checkbox.php
@@ -251,9 +251,6 @@ class Zikula_Form_Plugin_Checkbox extends Zikula_Form_AbstractStyledPlugin
         $checkedHtml = ($this->checked ? " checked=\"checked\"" : '');
 
         $class = $this->getStyleClass();
-        if ($this->cssClass != null) {
-            $class .= ' ' . $this->cssClass;
-        }
 
         $attributes = $this->renderAttributes($view);
 


### PR DESCRIPTION
the provided `cssClass` is added in the `->getStyleClass()` method on the previous line.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets |  |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |
