### PR TITLE
add global unknown user

### DIFF
--- a/src/docs/CHANGELOG.md
+++ b/src/docs/CHANGELOG.md
@@ -90,6 +90,8 @@ Features:
 - Removed events: systemerror, setup.errorreporting, frontcontroller.exception event.
 - Development mode is now controlled by editing app/config/kernel.yml `kernel = dev` or `kernel = prod`
 - Removed old legacy (Smarty plugins, hooks etc, old module types).
+- Added 'Unknown user' to allow orphaned data to be attached somewhere. use:
+    `$unknownUser = $this->entityManager->getRepository('Zikula\Module\UsersModule\Entity\UserEntity')->findOneBy(array('uname' => \Users_Constant::UNKNOWN_USER));`
 
 
 CHANGELOG - ZIKULA 1.3.5

--- a/src/system/Zikula/Module/UsersModule/Constant.php
+++ b/src/system/Zikula/Module/UsersModule/Constant.php
@@ -397,5 +397,9 @@ namespace Zikula\Module\UsersModule
          * The PCRE regular expression fragment used to validate e-mail address domains.
          */
         const EMAIL_DOMAIN_VALIDATION_PATTERN = '(?:[^\\s\\000-\\037\\177\\(\\)<>@,;:\\\\"\\[\\]]\\.?)+\\.[a-z]{2,6}';
+        /**
+         * The name of the global unknown user
+         */
+        const UNKNOWN_USER = 'UNKNOWN-lLaNw6kWkx4lO9hdj';
     }
 }

--- a/src/system/Zikula/Module/UsersModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/UsersModule/Controller/AdminController.php
@@ -168,11 +168,12 @@ class AdminController extends \Zikula_AbstractController
             $isCurrentUser = ($userObj['uid'] == $currentUid);
             $isGuestAccount = ($userObj['uid'] == 1);
             $isAdminAccount = ($userObj['uid'] == 2);
+            $isUnknownUserAccount = ($userObj['uname'] == \Users_Constant::UNKNOWN_USER);
             $hasUsersPassword = (!empty($userObj['pass']) && ($userObj['pass'] != UsersConstant::PWD_NO_USERS_AUTHENTICATION));
-            $currentUserHasReadAccess = !$isGuestAccount && SecurityUtil::checkPermission($this->name . '::', "{$userObj['uname']}::{$userObj['uid']}", ACCESS_READ);
-            $currentUserHasModerateAccess = !$isGuestAccount && SecurityUtil::checkPermission($this->name . '::', "{$userObj['uname']}::{$userObj['uid']}", ACCESS_MODERATE);
-            $currentUserHasEditAccess = !$isGuestAccount && SecurityUtil::checkPermission($this->name . '::', "{$userObj['uname']}::{$userObj['uid']}", ACCESS_EDIT);
-            $currentUserHasDeleteAccess = !$isGuestAccount && !$isAdminAccount && !$isCurrentUser && SecurityUtil::checkPermission($this->name . '::', "{$userObj['uname']}::{$userObj['uid']}", ACCESS_DELETE);
+            $currentUserHasReadAccess = !$isGuestAccount && !$isUnknownUserAccount && SecurityUtil::checkPermission($this->name . '::', "{$userObj['uname']}::{$userObj['uid']}", ACCESS_READ);
+            $currentUserHasModerateAccess = !$isGuestAccount && !$isUnknownUserAccount && SecurityUtil::checkPermission($this->name . '::', "{$userObj['uname']}::{$userObj['uid']}", ACCESS_MODERATE);
+            $currentUserHasEditAccess = !$isGuestAccount && !$isUnknownUserAccount && SecurityUtil::checkPermission($this->name . '::', "{$userObj['uname']}::{$userObj['uid']}", ACCESS_EDIT);
+            $currentUserHasDeleteAccess = !$isGuestAccount && !$isUnknownUserAccount && !$isAdminAccount && !$isCurrentUser && SecurityUtil::checkPermission($this->name . '::', "{$userObj['uname']}::{$userObj['uid']}", ACCESS_DELETE);
 
             $userList[$key]['options'] = array(
                 'lostUsername' => $currentUserHasModerateAccess,

--- a/src/system/Zikula/Module/UsersModule/Entity/UserEntity.php
+++ b/src/system/Zikula/Module/UsersModule/Entity/UserEntity.php
@@ -230,6 +230,9 @@ class UserEntity extends EntityAccess
      */
     public function getUname()
     {
+        if ($this->uname == \Users_Constant::UNKNOWN_USER) {
+            return __('Unknown user');
+        }
         return $this->uname;
     }
 

--- a/src/system/Zikula/Module/UsersModule/UsersModuleVersion.php
+++ b/src/system/Zikula/Module/UsersModule/UsersModuleVersion.php
@@ -30,7 +30,7 @@ class UsersModuleVersion extends \Zikula_AbstractVersion
     public function getMetaData()
     {
         return array(
-            'version' => '2.2.1',
+            'version' => '2.2.2',
             'displayname' => $this->__('Users'),
             'description' => $this->__('Provides an interface for configuring and administering registered user accounts. Incorporates all needed functionality, but can work in close unison with the third party profile module configured in the general settings of the site.'),
             'url' => $this->__('users'),


### PR DESCRIPTION
The point of this is to add a user to the DB that any orphaned data can be assigned to. this orphaned data may be as a result of a user being deleted or some other action. When this is done, the `user.account.delete` event is fired and modules can take appropriate action to reassign their data to the `unknown user`.

It is better to have this already done in the core because otherwise each module will create their own solution and there will be multiple 'unknown users' in the db. 

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets |  |
| Refs tickets | #1322 |
| License | MIT |
| Doc PR |  |
