### PR TITLE
Made Symfony routing possible for Symfony based modules still using the old base classes.

### DIFF
--- a/src/system/Zikula/Module/SettingsModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/SettingsModule/Controller/AdminController.php
@@ -270,7 +270,7 @@ class AdminController extends \Zikula_AbstractController
      * @todo Remove this hacky code in 1.4.0.
      * @return PlainResponse
      */
-    public function debugToolbar()
+    public function debugToolbarAction()
     {
         if (!System::isDevelopmentMode()) {
             return $this->throwForbidden();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | Guite/MostGenerator#403 |
| Refs tickets | #1271 |
| License | MIT |
| Doc PR | --- |
