### PR TITLE
added save options to Imagine plugin presets

### DIFF
--- a/src/plugins/Imagine/lib/Imagine/Manager.php
+++ b/src/plugins/Imagine/lib/Imagine/Manager.php
@@ -405,6 +405,10 @@ class SystemPlugin_Imagine_Manager extends Zikula_Controller_AbstractPlugin
      */
     private function createThumbnail(SystemPlugin_Imagine_Image $image, SystemPlugin_Imagine_Preset $preset)
     {
+        $options = array();
+        if (isset($preset['options']) || !is_array($preset['options'])) {
+            $options = $preset['options'];
+        }
 
         if (isset($preset['mode']) && $preset['mode'] === 'inset') {
             $mode = \Imagine\Image\ImageInterface::THUMBNAIL_INSET;
@@ -417,7 +421,7 @@ class SystemPlugin_Imagine_Manager extends Zikula_Controller_AbstractPlugin
             $this->getTransformation()
                 ->apply($this->getImagine()->open($image->getRealPath()))
                 ->thumbnail($size, $mode)
-                ->save($image->getThumbRealPath());
+                ->save($image->getThumbRealPath(), $preset['options']);
         } catch (Exception $exception) {
             throw $exception;
         }

--- a/src/plugins/Imagine/lib/Imagine/Preset.php
+++ b/src/plugins/Imagine/lib/Imagine/Preset.php
@@ -104,6 +104,7 @@ class SystemPlugin_Imagine_Preset extends ArrayObject
             'height' => 100,
             'mode' => null,
             'extension' => null,
+            'options' => array(),
             '__module' => null,
             '__imagine' => null,
             '__transformation' => null

--- a/src/plugins/Imagine/templates/plugins/function.thumb.php
+++ b/src/plugins/Imagine/templates/plugins/function.thumb.php
@@ -80,6 +80,7 @@ function smarty_function_thumb($params, Zikula_View $view)
         $preset['height'] = isset($params['height']) ? $params['height'] : null;
         $preset['mode'] = isset($params['mode']) ? $params['mode'] : null;
         $preset['extension'] = isset($params['extension']) ? $params['extension'] : null;
+        $preset['options'] = isset($params['options']) ? $params['options'] : array();
         $preset = array_filter($preset);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I needed to change the save quality settings of thumbnails. With this you can set the save options in the preset.

See: http://imagine.readthedocs.org/en/latest/usage/introduction.html#save-images
