### PR TITLE
fixed various typo's and duplicated use statements

### DIFF
--- a/src/system/Zikula/Module/AdminModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/AdminModule/Controller/AdminController.php
@@ -249,7 +249,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @throws AccessDeniedHttpException Thrown if the user doesn't have permission to delete the category
      * @throws NotFoundHttpException Thrown if the category cannot be found
-     * @throws \InvalidArugmentException thrown if the category id cannot be found
+     * @throws \InvalidArgumentException thrown if the category id cannot be found
      */
     public function deleteAction($args)
     {

--- a/src/system/Zikula/Module/AdminModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/AdminModule/Controller/AjaxController.php
@@ -29,7 +29,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
     /**
      * Change the category a module belongs to by ajax.
      *
-     * @return \Zikula_Response_Ajax Ajax response containg the moduleid on success.
+     * @return \Zikula_Response_Ajax Ajax response containing the moduleid on success.
      *
      * @throws FatalErrorException Thrown if the supplied module ID doesn't exist or
      *                                     if the module couldn't be added to the category
@@ -76,7 +76,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
     /**
      * Add a new admin category by ajax.
      *
-     * @return \Zikula_Response_Ajax Ajax response containing the new cid on sucess
+     * @return \Zikula_Response_Ajax Ajax response containing the new cid on success
      *
      * @throws FatalErrorException Thrown if the supplied category name already exists or
      *                                     if the the category couldn't be created
@@ -249,7 +249,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
     /**
      * Make a category the initially selected one (by ajax).
      *
-     * @return \Zikula_Response_Ajax Ajax response containg a sucess message
+     * @return \Zikula_Response_Ajax Ajax response containing a success message
      *
      * @throws FatalErrorException Thrown if the category couldn't be found or 
      *                                     if the category couldn't be set as the default

--- a/src/system/Zikula/Module/ExtensionsModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/ExtensionsModule/Controller/AdminController.php
@@ -76,7 +76,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return Response symfony response object
      *
-     * @throws \InvalidArgumentException Thrown if the id paraemter is not provided or not numeric
+     * @throws \InvalidArgumentException Thrown if the id parameter is not provided or not numeric
      * @throws NotFoundHttpException Thrown if the requested module id doesn't exist
      * @throws AccessDeniedHttpException Thrown if the user doesn't have admin permission to the requested module
      */
@@ -642,7 +642,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return void
      *
-     * @throws \InvalidArgumentException Thrown if the id paraemter is not provided or not numeric
+     * @throws \InvalidArgumentException Thrown if the id parameter is not provided or not numeric
      * @throws \RuntimeException Thrown if the module state doesn't allow this action
      */
     public function activateAction()
@@ -688,7 +688,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return void
      *
-     * @throws \InvalidArgumentException Thrown if the id paraemter is not provided or not numeric
+     * @throws \InvalidArgumentException Thrown if the id parameter is not provided or not numeric
      */
     public function upgradeAction()
     {
@@ -773,7 +773,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return void
      *
-     * @throws \InvalidArgumentException Thrown if the id paraemter is not provided or not numeric
+     * @throws \InvalidArgumentException Thrown if the id parameter is not provided or not numeric
      * @throws \RuntimeException Thrown if the requested module is a core module and cannot be deactivated
      * @throws NotFoundHttpException Thrown if the requested module id doesn't exist
      */
@@ -826,7 +826,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return void
      *
-     * @throws \InvalidArgumentException Thrown if the id paraemter is not provided or not numeric
+     * @throws \InvalidArgumentException Thrown if the id parameter is not provided or not numeric
      * @throws \RuntimeException Thrown if any blocks associated with the module cannot be deleted
      */
     public function removeAction()
@@ -1257,7 +1257,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return void
      *
-     * @throws \InvalidArgumentException Thrown if the plugin paraemter is not provided
+     * @throws \InvalidArgumentException Thrown if the plugin parameter is not provided
      * @throws AccessDeniedHttpException Thrown if the user doesn't have admin permission to the module
      */
     public function initialisePluginAction()
@@ -1302,7 +1302,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return void
      *
-     * @throws \InvalidArgumentException Thrown if the plugin paraemter is not provided
+     * @throws \InvalidArgumentException Thrown if the plugin parameter is not provided
      * @throws AccessDeniedHttpException Thrown if the user doesn't have admin permission to the module
      */
     public function deactivatePluginAction()
@@ -1347,7 +1347,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return void
      *
-     * @throws \InvalidArgumentException Thrown if the plugin paraemter is not provided
+     * @throws \InvalidArgumentException Thrown if the plugin parameter is not provided
      * @throws AccessDeniedHttpException Thrown if the user doesn't have admin permission to the module
      */
     public function activatePluginAction()
@@ -1392,7 +1392,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return void
      *
-     * @throws \InvalidArgumentException Thrown if the plugin paraemter is not provided
+     * @throws \InvalidArgumentException Thrown if the plugin parameter is not provided
      * @throws AccessDeniedHttpException Thrown if the user doesn't have admin permission to the module
      */
     public function removePluginAction()
@@ -1437,7 +1437,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @return void
      *
-     * @throws \InvalidArgumentException Thrown if the plugin paraemter is not provided
+     * @throws \InvalidArgumentException Thrown if the plugin parameter is not provided
      * @throws AccessDeniedHttpException Thrown if the user doesn't have admin permission to the module
      */
     public function upgradePluginAction()

--- a/src/system/Zikula/Module/ExtensionsModule/Controller/AdminpluginController.php
+++ b/src/system/Zikula/Module/ExtensionsModule/Controller/AdminpluginController.php
@@ -19,7 +19,6 @@ use PluginUtil;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Zikula_Plugin_ConfigurableInterface;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * Extensions_Plugin controller.
@@ -47,7 +46,7 @@ class AdminpluginController extends \Zikula_AbstractController
      */
     protected function initialize()
     {
-        // Do not setupt a view for this controller.
+        // Do not setup a view for this controller.
     }
 
     /**

--- a/src/system/Zikula/Module/GroupsModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/GroupsModule/Controller/AdminController.php
@@ -13,7 +13,6 @@
 
 namespace Zikula\Module\GroupsModule\Controller;
 
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Zikula_View;
 use ModUtil;
 use SecurityUtil;

--- a/src/system/Zikula/Module/GroupsModule/Controller/UserController.php
+++ b/src/system/Zikula/Module/GroupsModule/Controller/UserController.php
@@ -15,7 +15,6 @@ namespace Zikula\Module\GroupsModule\Controller;
 
 use ModUtil;
 use SecurityUtil;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use UserUtil;
 use Zikula_View;
 use Zikula\Module\GroupsModule\Helper\CommonHelper;

--- a/src/system/Zikula/Module/PermissionsModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/PermissionsModule/Controller/AjaxController.php
@@ -161,7 +161,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
     /**
      * Delete a permission
      *
-     * @return \Zikula_Response_Ajax Ajax response containg the id of the permission that has been deleted
+     * @return \Zikula_Response_Ajax Ajax response containing the id of the permission that has been deleted
      *
      * @thrown FatalErrorException Thrown if the requested permission rule is the default admin rule or if
      *                                    if the permission rule couldn't be deleted

--- a/src/system/Zikula/Module/SettingsModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/SettingsModule/Controller/AdminController.php
@@ -256,7 +256,7 @@ class AdminController extends \Zikula_AbstractController
     /**
      * Displays the content of {@link phpinfo()}.
      *
-     * @return \Symfony\Component\HttpFoundation\Response The html output.
+     * @return Response symfony response object
      *
      * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
@@ -276,6 +276,4 @@ class AdminController extends \Zikula_AbstractController
 
         return $this->response($this->view->fetch('Admin/phpinfo.tpl'));
     }
-
-
 }

--- a/src/system/Zikula/Module/UsersModule/Api/AuthenticationApi.php
+++ b/src/system/Zikula/Module/UsersModule/Api/AuthenticationApi.php
@@ -419,9 +419,9 @@ class AuthenticationApi extends \Zikula_Api_AbstractAuthentication
 
         if (!$passwordAuthenticates && !LogUtil::hasErrors()) {
             if ($authenticationMethod['method'] == 'email') {
-                throw new \InvalidArugmentException($this->__('Sorry! The e-mail address or password you entered was incorrect.'));
+                throw new \InvalidArgumentException($this->__('Sorry! The e-mail address or password you entered was incorrect.'));
             } else {
-                throw new \InvalidArugmentException($this->__('Sorry! The user name or password you entered was incorrect.'));
+                throw new \InvalidArgumentException($this->__('Sorry! The user name or password you entered was incorrect.'));
             }
         }
 
@@ -599,9 +599,9 @@ class AuthenticationApi extends \Zikula_Api_AbstractAuthentication
 
             if (!$authenticatedUid) {
                 if ($args['authentication_method']['method'] == 'email') {
-                    throw new \InvalidArugmentException($this->__('Sorry! The e-mail address or password you entered was incorrect.'));
+                    throw new \InvalidArgumentException($this->__('Sorry! The e-mail address or password you entered was incorrect.'));
                 } else {
-                    throw new \InvalidArugmentException($this->__('Sorry! The user name or password you entered was incorrect.'));
+                    throw new \InvalidArgumentException($this->__('Sorry! The user name or password you entered was incorrect.'));
                 }
             }
         }

--- a/src/system/Zikula/Module/UsersModule/Api/RegistrationApi.php
+++ b/src/system/Zikula/Module/UsersModule/Api/RegistrationApi.php
@@ -1413,7 +1413,7 @@ class RegistrationApi extends \Zikula_AbstractApi
                 throw new NotFoundHttpException($this->__f('Error! Unable to retrieve registration record with uid \'%1$s\'', $uid));
             }
             if (!isset($reginfo['email'])) {
-                throw new \InvalidArugmentException($this->__f('Error! The registration record with uid \'%1$s\' does not contain an e-mail address.', $uid));
+                throw new \InvalidArgumentException($this->__f('Error! The registration record with uid \'%1$s\' does not contain an e-mail address.', $uid));
             }
         }
 

--- a/src/system/Zikula/Module/UsersModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/UsersModule/Controller/AdminController.php
@@ -1298,7 +1298,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @throws AccessDeniedHttpException Thrown if the current user does not have moderate access
      * @throws FatalErrorException Thrown if the method of accessing this function is improper
-     * @throws \InvalidArugmentException Thrown if the user id isn't set or numeric
+     * @throws \InvalidArgumentException Thrown if the user id isn't set or numeric
      * @throws \RuntimeException Thrown if the registration record couldn't be retrieved
      */
     public function displayRegistrationAction()
@@ -1317,7 +1317,7 @@ class AdminController extends \Zikula_AbstractController
         }
 
         if (empty($uid) || !is_numeric($uid)) {
-            throw new \InvalidArugmentException(LogUtil::getErrorMsgArgs());
+            throw new \InvalidArgumentException(LogUtil::getErrorMsgArgs());
         }
 
         $reginfo = ModUtil::apiFunc($this->name, 'registration', 'get', array('uid' => $uid));
@@ -1374,7 +1374,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @throws AccessDeniedHttpException Thrown if the current user does not have edit access
      * @throws FatalErrorException Thrown if the method of accessing this function is improper
-     * @throws \InvalidArugmentException Thrown if the user id isn't set or numeric
+     * @throws \InvalidArgumentException Thrown if the user id isn't set or numeric
      * @throws \RuntimeException Thrown if the registration record couldn't be retrieved
      */
     public function modifyRegistrationAction()
@@ -1556,7 +1556,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @throws AccessDeniedHttpException Thrown if the current user does not have moderate access
      * @throws FatalErrorException Thrown if the method of accessing this function is improper
-     * @throws \InvalidArugmentException Thrown if the user id isn't set or numeric
+     * @throws \InvalidArgumentException Thrown if the user id isn't set or numeric
      * @throws NotFoundHttpException Thrown if the registration record couldn't be retrieved
      * @throws \RuntimeException Thrown if there was a problem sending the verification code
      */
@@ -1582,7 +1582,7 @@ class AdminController extends \Zikula_AbstractController
         }
 
         if (!isset($uid) || !is_numeric($uid) || ((int)$uid != $uid)) {
-            throw new \InvalidArugmentException(LogUtil::getErrorMsgArgs());
+            throw new \InvalidArgumentException(LogUtil::getErrorMsgArgs());
         }
 
         // Got just a uid.
@@ -1668,7 +1668,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @throws AccessDeniedHttpException Thrown if the current user does not have moderate access
      * @throws FatalErrorException Thrown if the method of accessing this function is improper
-     * @throws \InvalidArugmentException Thrown if the user id isn't set or numeric
+     * @throws \InvalidArgumentException Thrown if the user id isn't set or numeric
      * @throws NotFoundHttpException Thrown if the registration record couldn't be retrieved
      * @throws \RuntimeException Thrown if the registration record has already been approved or
      *                                  if the user hasn't set a password yet or
@@ -1793,7 +1793,7 @@ class AdminController extends \Zikula_AbstractController
      *
      * @throws AccessDeniedHttpException Thrown if the current user does not have delete access
      * @throws FatalErrorException Thrown if the method of accessing this function is improper
-     * @throws \InvalidArugmentException Thrown if the user id isn't set or numeric
+     * @throws \InvalidArgumentException Thrown if the user id isn't set or numeric
      * @throws NotFoundHttpException Thrown if the registration record couldn't be retrieved
      * @throws \RuntimeException Thrown if there was a problem deleting the registration
      */


### PR DESCRIPTION
This PR fixes a few typo's and some duplicated use statements in the recent exceptions related PR's

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| Refs tickets | #1413 |
| License | MIT |
| Doc PR |  |
