### PR TITLE
added exception docs for recent throwif removal

### DIFF
--- a/src/system/Zikula/Module/AdminModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/AdminModule/Controller/AjaxController.php
@@ -31,6 +31,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @return \Zikula_Response_Ajax Ajax response containg the moduleid on success.
      *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      * @throws FatalErrorException Thrown if the supplied module ID doesn't exist or
      *                                     if the module couldn't be added to the category
      */
@@ -78,6 +79,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @return \Zikula_Response_Ajax Ajax response containing the new cid on sucess
      *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module or if
+     *                                          if the user doesn't have add permission over the category name
      * @throws FatalErrorException Thrown if the supplied category name already exists or
      *                                     if the the category couldn't be created
      */
@@ -133,6 +136,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @return \Zikula_Response_Ajax Ajax response containing the category id on success
      *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have delete access to the category
      * @throws FatalErrorException Thrown if the supplied category doesn't exist or
      *                                     if the category couldn't be deleted
      */
@@ -178,6 +182,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @return \Zikula_Response_Ajax Ajax response containing the name of the edited category
      *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit access to the category or
+     *                                          if the user doesn't have admin access to the module
      * @throws \InvalidArgumentException Thrown if either the category id or name are not supplied or null
      * @throws FatalErrorException Thrown if the new category name already exists or
      *                                     if the category id couldn't be found or
@@ -251,6 +257,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @return \Zikula_Response_Ajax Ajax response containg a sucess message
      *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      * @throws FatalErrorException Thrown if the category couldn't be found or 
      *                                     if the category couldn't be set as the default
      */
@@ -290,6 +297,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Sort the admin categories 
      *
      * @return \Zikula_Response_Ajax Ajax response containing a null array on success.
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function sortCategoriesAction()
     {
@@ -317,6 +326,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Sort the modules
      *
      * @return \Zikula_Response_Ajax Ajax response containing a null array on success.
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function sortModulesAction()
     {

--- a/src/system/Zikula/Module/BlocksModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/BlocksModule/Controller/AjaxController.php
@@ -34,6 +34,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * @param position int zone id
      *
      * @return Zikula_Response_Ajax true or Ajax error
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function changeblockorderAction()
     {
@@ -76,6 +78,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @return Zikula_Response_Ajax true or Ajax error
      *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      * @throws FatalErrorException Thrown if no block id is supplied or
      *                                     if the requested block isn't valid
      */

--- a/src/system/Zikula/Module/CategoriesModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/CategoriesModule/Controller/AjaxController.php
@@ -34,6 +34,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Resequence categories
      *
      * @return void
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit access to the module
      */
     public function resequenceAction()
     {
@@ -72,6 +74,9 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *                       }
      *
      * @return AjaxResponse ajax response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit or add (depending mode) access to the module
+     * @throws NotFoundHttpException Thrown if category cannot be found
      */
     public function editAction($args = array())
     {
@@ -131,6 +136,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Copy a category
      *
      * @return AjaxResponse ajax response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have add access to the module
      */
     public function copyAction()
     {
@@ -182,6 +189,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Delete a category
      *
      * @return AjaxResponse ajax response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have delete access to the module
      */
     public function deleteAction()
     {
@@ -207,6 +216,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Delete a category and move any existing subcategories
      *
      * @return AjaxResponse ajax response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have delete access to the module
      */
     public function deleteandmovesubsAction()
     {
@@ -260,6 +271,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Display a dialog to get the category to move subcategories to once the parent has been deleted
      *
      * @return AjaxResponse ajax response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have delete access to the module
      */
     public function deletedialogAction()
     {
@@ -288,6 +301,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Activate a category
      *
      * @return AjaxResponse ajax response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit access to the module
      */
     public function activateAction()
     {
@@ -313,6 +328,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Deactivate a category
      *
      * @return AjaxResponse ajax response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit access to the module
      */
     public function deactivateAction()
     {
@@ -338,6 +355,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Save a category
      *
      * @return AjaxResponse ajax response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit or add (depending on mode) access to the module
      */
     public function saveAction()
     {

--- a/src/system/Zikula/Module/ExtensionsModule/Controller/AdminpluginController.php
+++ b/src/system/Zikula/Module/ExtensionsModule/Controller/AdminpluginController.php
@@ -55,7 +55,9 @@ class AdminpluginController extends \Zikula_AbstractController
      *
      * @return mixed
      * 
-     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module or
+     *                                          if the plugin isn't configurable
+     * @throws NotFoundHttpException Thrown if the plugin doesn't have the requested service or action methods
      */
     public function dispatchAction()
     {

--- a/src/system/Zikula/Module/ExtensionsModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/ExtensionsModule/Controller/AjaxController.php
@@ -35,6 +35,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @throws \InvalidArgumentException Thrown if either the subsriber, provider or subsriberArea parameters are empty
      * @throws \RuntimeException Thrown if either the subscriber or provider module isn't available
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to either the subscriber or provider modules
      */
     public function togglesubscriberareastatusAction()
     {
@@ -114,6 +115,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @throws \InvalidArgumentException Thrown if the subscriber or subscriberarea parameters aren't valid
      * @throws \RuntimeException Thrown if the subscriber module isn't available
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the subscriber module
      */
     public function changeproviderareaorderAction()
     {

--- a/src/system/Zikula/Module/GroupsModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/GroupsModule/Controller/AdminController.php
@@ -188,6 +188,8 @@ class AdminController extends \Zikula_AbstractController
      * Display a form to add a new group.
      *
      * @return Response symfony response object.
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have add access to the module
      */
     public function newgroupAction()
     {
@@ -271,6 +273,7 @@ class AdminController extends \Zikula_AbstractController
      * @return Response symfony response object.
      *
      * @throws \NotFoundHttpException Thrown if the requested group isn't found
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit access to the group
      */
     public function modifyAction(array $args = array())
     {
@@ -354,6 +357,7 @@ class AdminController extends \Zikula_AbstractController
      * @return Response|void response object if no confirmation, void otherwise
      *
      * @throws \InvalidArgumentException Thrown if the requested group is the current default group
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have delete access to the group
      */
     public function deleteAction(array $args = array())
     {
@@ -417,6 +421,8 @@ class AdminController extends \Zikula_AbstractController
      *                      }
      *
      * @return Response symfony response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit access to the group
      */
     public function groupmembershipAction(array $args = array())
     {
@@ -601,6 +607,7 @@ class AdminController extends \Zikula_AbstractController
      * @return mixed Response|void symfony repsonse object if confirmation isn't provided, void otherwise
      *
      * @throws \RuntimeException Throw if the user couldn't be removed from the requested group
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit access to the group
      */
     public function removeuserAction(array $args = array())
     {
@@ -762,6 +769,8 @@ class AdminController extends \Zikula_AbstractController
      * Display a form to modify configuration parameters of the module.
      *
      * @return Response symfony response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function modifyconfigAction()
     {

--- a/src/system/Zikula/Module/GroupsModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/GroupsModule/Controller/AjaxController.php
@@ -37,6 +37,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * @param string $description the group description.
      *
      * @return AjaxResponse ajax response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit access to the group
      */
     public function updategroupAction()
     {
@@ -105,6 +107,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * @return AjaxResponse ajax response object
      *
      * @throws FatalErrorException Thrown if the group id isn't a valid group
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have add access to the module
      */
     public function creategroupAction()
     {
@@ -157,6 +160,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @throws FatalErrorException Thrown if the requested group is the default group or
      *                                    if the requested group cannot be deleted
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have delete access to the group
      */
     public function deletegroupAction()
     {
@@ -192,6 +196,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * @return AjaxResponse ajax response object
      *
      * @throws FatalErrorException Thrown if the user cannot be deleted from the group
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have edit access to the group
      */
     public function removeuserAction()
     {

--- a/src/system/Zikula/Module/GroupsModule/Controller/UserController.php
+++ b/src/system/Zikula/Module/GroupsModule/Controller/UserController.php
@@ -46,6 +46,8 @@ class UserController extends \Zikula_AbstractController
      * Display items
      *
      * @return Response symfony response object
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have overview access to the module
      */
     public function viewAction()
     {
@@ -124,7 +126,8 @@ class UserController extends \Zikula_AbstractController
      *
      * @throws \InvalidArgumentException Thrown if the group isn't set or isn't numeric or
      *                                          if the action isn't one of subscribe|unsubscribe|cancel
-     * @throws AccessDeniedHttpException Thrown if the user isn't logged in
+     * @throws AccessDeniedHttpException Thrown if the user isn't logged in or 
+     *                                          if the user doesn't have overview access to the module
      * @throws NotFoundHttpException Thrown if the group cannot be found
      * @throws \RuntimeException Thrown if the user is already a member of the group or
      *                                  if the group cannot be applied for or
@@ -246,6 +249,7 @@ class UserController extends \Zikula_AbstractController
      * @return Response symfony response object
      *
      * @throws \InvalidArgumentException Thrown if the startnum parameter isn't numeric
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have overview access to the memberslist component of the module
      */
     public function memberslistAction()
     {

--- a/src/system/Zikula/Module/MailerModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/MailerModule/Controller/AdminController.php
@@ -54,6 +54,8 @@ class AdminController extends \Zikula_AbstractController
      * module
      *
      * @return mixed False on errors, true on redirects, and otherwise it returns the HTML output for the page.
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function modifyconfigAction()
     {
@@ -71,6 +73,8 @@ class AdminController extends \Zikula_AbstractController
      * This function displays a form to sent a test mail
      *
      * @return mixed False on errors, true on redirects, and otherwise it returns the HTML output for the page.
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function testconfigAction()
     {

--- a/src/system/Zikula/Module/PermissionsModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/PermissionsModule/Controller/AjaxController.php
@@ -37,6 +37,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * @param level the permission level
      *
      * @return \Zikula_Response_Ajax Ajax repsonse with updated permissions
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function updatepermissionAction()
     {
@@ -101,6 +103,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * @param permorder array of sorted permissions (value = permission id)
      *
      * @return \Zikula_Response_Ajax ajax response containing true
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function changeorderAction()
     {
@@ -125,6 +129,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Create a blank permission and return it
      *
      * @return \Zikula_Response_Ajax array with new permission
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function createpermissionAction()
     {
@@ -165,6 +171,7 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      *
      * @thrown FatalErrorException Thrown if the requested permission rule is the default admin rule or if
      *                                    if the permission rule couldn't be deleted
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function deletepermissionAction()
     {
@@ -197,6 +204,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * Test a permission rule for a given username
      *
      * @return \Zikula_Response_Ajax Ajax response containing string with test result for display
+     *
+     * @throws AccessDeniedHttpException Thrown if the user doesn't have admin access to the module
      */
     public function testpermissionAction()
     {

--- a/src/system/Zikula/Module/ThemeModule/Controller/AjaxController.php
+++ b/src/system/Zikula/Module/ThemeModule/Controller/AjaxController.php
@@ -25,6 +25,8 @@ class AjaxController extends \Zikula_Controller_AbstractAjax
      * dispatch a theme.ajax_request event
      *
      * @return mixed results of the event request
+     *
+     * @throws NotFoundHttpException Thrown if the no event handlers responsed to the event
      */
     public function dispatchAction()
     {


### PR DESCRIPTION
This PR adds the documentation for exception calls that were introduced during the recent removal of the various throwif calls.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |
