### PR TITLE
enable main link in modulelinks list

### DIFF
--- a/src/lib/legacy/viewplugins/function.modulelinks.php
+++ b/src/lib/legacy/viewplugins/function.modulelinks.php
@@ -241,15 +241,10 @@ function smarty_function_modulelinks($params, Zikula_View $view)
                 if (!empty($menuitem['icon'])) {
                     $icon = '<span class="fa fa-'.$menuitem['icon'].'"></span> ';
                 }
-                $html .= '<a href="'.DataUtil::formatForDisplay($menuitem['url']).'"'.$attr;
+                $html .= '<a href="'.DataUtil::formatForDisplay($menuitem['url']).'"'.$attr.'>'.$icon.$menuitem['text'].'</a>';
                 if (isset($menuitem['links'])) {
-                    $html .= ' class="dropdown-toggle" data-toggle="dropdown"';
+                    $html .= '<a href="#" class="dropdown-toggle" data-toggle="dropdown" style="text-decoration: none;">&nbsp;<b class="caret"></b></a>';
                 }
-                $html .= '>'.$icon.$menuitem['text'];
-                if (isset($menuitem['links'])) {
-                    $html .= '<b class="caret"></b>';
-                }
-                $html .= '</a>';
             } else {
                 $html .= '<span'.$attr.'>'.$menuitem['text'].'</span>';
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

this PR returns to previous functionality of <1.3.7 - in previous versions, the link that appeared in the module links list was functional as an independent link and then the drop menu provided additional links. Recent refactoring disabled the link in the menu and only made it a toggle trigger. Here, I've moved the toggle trigger only to the caret and allowed the menu item to function as a link again.

@phaidon - ok with you?
