### PR TITLE
Correcting error "ContextErrorException: Warning: call_user_func() expec...

### DIFF
--- a/src/system/Zikula/Module/UsersModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/UsersModule/Controller/AdminController.php
@@ -1468,7 +1468,7 @@ class AdminController extends \Zikula_AbstractController
                 }
 
                 $event = new GenericEvent($registration);
-                $this->getDispatcher()->dispatch($event->getName(), $event);
+                $this->getDispatcher()->dispatch('module.users.ui.process_edit.modify_registration', $event);
 
                 $hook = new ProcessHook($registration['uid']);
                 $this->dispatchHooks('users.ui_hooks.registration.process_edit', $hook);


### PR DESCRIPTION
Correcting error "ContextErrorException: Warning: call_user_func() expects parameter 1 to be a valid callback, array must have exactly two members in /src/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php line 164"

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |
