### PR TITLE
gracefully handle incorrect form input. fixes #1425 and refs #1413

### DIFF
--- a/src/system/Zikula/Module/UsersModule/Controller/UserController.php
+++ b/src/system/Zikula/Module/UsersModule/Controller/UserController.php
@@ -978,11 +978,14 @@ class UserController extends \Zikula_AbstractController
         if (($formStage == 'code') && ($this->request->isMethod('POST') || !empty($uname) || !empty($email) || !empty($code))) {
             // Got something to process from either GET or POST
             if (empty($uname) && empty($email)) {
-                throw new \InvalidArgumentException($this->__('Error! User name and e-mail address fields are empty.'));
+                LogUtil::registerError($this->__('Error! User name and e-mail address fields are empty.'));
+                $formStage = 'code';
             } elseif (!empty($email) && !empty($uname)) {
-                throw new \InvalidArgumentException($this->__('Error! Please enter either a user name OR an e-mail address, but not both of them.'));
+                LogUtil::registerError($this->__('Error! Please enter either a user name OR an e-mail address, but not both of them.'));
+                $formStage = 'code';
             } elseif (empty($code)) {
-                throw new \InvalidArgumentException($this->__('Error! Please enter the confirmation code you received in the e-mail message.'));
+                LogUtil::registerError($this->__('Error! Please enter the confirmation code you received in the e-mail message.'));
+                $formStage = 'code';
             } else {
                 if (!empty($uname)) {
                     $idfield = 'uname';
@@ -1004,7 +1007,7 @@ class UserController extends \Zikula_AbstractController
                         $passreminder = isset($userObj['passreminder']) ? $userObj['passreminder'] : '';
                         $formStage = 'setpass';
                     } else {
-                        throw new NotFoundHttpException($this->__('Sorry! Could not load that user account.'));
+                        LogUtil::registerError($this->__('Sorry! Could not load that user account.'));
                         $formStage = 'error';
                     }
                 } else {
@@ -1037,14 +1040,14 @@ class UserController extends \Zikula_AbstractController
                         }
                         $formStage = 'login';
                     } else {
-                        throw new \RuntimeException($this->__('Error! Your new password could not be saved.'));
+                        LogUtil::registerError($this->__('Error! Your new password could not be saved.'));
                         $formStage = 'error';
                     }
                 } else {
                     $errorInfo = ModUtil::apiFunc($this->name, 'user', 'processRegistrationErrorsForDisplay', array('registrationErrors' => $passwordErrors));
                 }
             } else {
-                throw new \NotFoundHttpException($this->__('Sorry! Could not load that user account.'));
+                LogUtil::registerError($this->__('Sorry! Could not load that user account.'));
                 $formStage = 'error';
             }
         }


### PR DESCRIPTION
controllers should not throw exceptions when handling form input.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1425 |
| Refs tickets | #1413 |
| License | MIT |
| Doc PR | - |
