### PR TITLE
Adding old hacks (not included into 1.3.6) into release-1.3 branch

### DIFF
--- a/src/lib/Zikula/EntityAccess.php
+++ b/src/lib/Zikula/EntityAccess.php
@@ -73,7 +73,9 @@ class Zikula_EntityAccess implements ArrayAccess
                 }
 
                 $method = "get" . ucfirst($property->name);
-                $array[$property->name] = $this->$method();
+                if (method_exists($this, $method)) {
+                    $array[$property->name] = $this->$method();
+                }
             }
         }
 

--- a/src/lib/dbobject/DBObject.php
+++ b/src/lib/dbobject/DBObject.php
@@ -381,7 +381,6 @@ class DBObject
             }
 
             $this->_objKey = $where;
-            $this->_objField = 'WHERE';
         } else {
             // generic key=>value lookup
             if ($this->_objJoin) {
@@ -679,7 +678,7 @@ class DBObject
             return false;
         }
 
-        $res = DBUtil::updateObject($this->_objData, $this->_objType, '', $this->_objField);
+        $res = DBUtil::updateObject($this->_objData, $this->_objType, '', $this->_objField, $this->_objInsertPreserve);
         if ($res) {
             $this->updatePostProcess();
             return $this->_objData;

--- a/src/lib/dbobject/DBObjectArray.php
+++ b/src/lib/dbobject/DBObjectArray.php
@@ -648,7 +648,7 @@ class DBObjectArray
 
         $res = true;
         foreach ($this->_objData as $k => $v) {
-            $res = $res && DBUtil::insertObject($this->_objData[$k], $this->_objType, $this->_objField);
+            $res = $res && DBUtil::insertObject($this->_objData[$k], $this->_objType, $this->_objField, $this->_objInsertPreserve, $this->_objInsertForce); 
         }
 
         if ($res) {
@@ -702,7 +702,7 @@ class DBObjectArray
 
         $res = true;
         foreach ($this->_objData as $k => $v) {
-            $res = $res && DBUtil::updateObject($this->_objData[$k], $this->_objType, '', $this->_objField);
+            $res = $res && DBUtil::updateObject($this->_objData[$k], $this->_objType, '', $this->_objField, $this->_objInsertPreserve);
         }
 
         if ($res) {

--- a/src/lib/util/ModUtil.php
+++ b/src/lib/util/ModUtil.php
@@ -1944,4 +1944,44 @@ class ModUtil
         return $directory;
     }
 
+    /**
+* Determine the module admin image path.
+*
+* This function searches for the admin image of a module at several places.
+* If no image is found, a default image path is returned.
+*
+* @param string $moduleName Module name.
+*
+* @return string Returns module admin image path.
+*/
+    public static function getModuleImagePath($moduleName)
+    {
+        if($moduleName == '') {
+            return false;
+        }
+        
+        $modinfo = self::getInfoFromName($moduleName);
+        $modpath = ($modinfo['type'] == self::TYPE_SYSTEM) ? 'system' : 'modules';
+        
+        $osmoddir = DataUtil::formatForOS($modinfo['directory']);
+        
+        $paths = array(
+                $modpath . '/' . $osmoddir . '/images/admin.png',
+                $modpath . '/' . $osmoddir . '/images/admin.jpg',
+                $modpath . '/' . $osmoddir . '/images/admin.gif',
+                $modpath . '/' . $osmoddir . '/pnimages/admin.gif',
+                $modpath . '/' . $osmoddir . '/pnimages/admin.jpg',
+                $modpath . '/' . $osmoddir . '/pnimages/admin.jpeg',
+                $modpath . '/' . $osmoddir . '/pnimages/admin.png',
+                'system/Admin/images/default.gif'
+        );
+        
+        foreach ($paths as $path) {
+            if (is_readable($path)) {
+                break;
+            }
+        }
+        
+        return $path;
+    }
 }

--- a/src/lib/viewplugins/function.modgetimage.php
+++ b/src/lib/viewplugins/function.modgetimage.php
@@ -1,0 +1,50 @@
+<?php
+/**
+* Copyright Zikula Foundation 2012 - Zikula Application Framework
+*
+* This work is contributed to the Zikula Foundation under one or more
+* Contributor Agreements and licensed to You under the following license:
+*
+* @license GNU/LGPLv3 (or at your option, any later version).
+* @package Zikula_View
+* @subpackage Template_Plugins
+*
+* Please see the NOTICE file distributed with this source code for further
+* information regarding copyright and licensing.
+*/
+
+/**
+* Zikula_View function to the admin image path of a module
+*
+* This function returns the path to the admin image of the current top-level
+* module if $modname is not set. Otherwise it returns the path to the admin
+* image of the given module.
+*
+*
+* Available parameters:
+* - assign: If set, the results are assigned to the corresponding
+* variable instead of printed out
+* - modname: The module to return the image path for
+* (defaults to top-level module)
+*
+* Example
+* {modgetimage|safetext}
+*
+* @param array $params All attributes passed to this function from the template.
+* @param Zikula_View $view Reference to the Zikula_View object.
+*
+* @return string The path to the module's admin image
+*/
+function smarty_function_modgetimage($params, Zikula_View $view)
+{
+    $assign = isset($params['assign']) ? $params['assign'] : null;
+    $modname = isset($params['modname']) ? $params['modname'] : (ModUtil::getName());
+
+    $path = ModUtil::getModuleImagePath($modname);
+
+    if ($assign) {
+        $view->assign($assign, $path);
+    } else {
+        return $path;
+    }
+}

--- a/src/style/core.css
+++ b/src/style/core.css
@@ -390,6 +390,23 @@ table.z-admintable ul li {
     border: 1px solid #fafafa;
 }
 
+.z-form div.z-formrow input[type=file]{
+    display:inline;
+    cursor: pointer;
+    -webkit-appearance:none;
+}
+
+.z-form div.z-formrow input[type=file]::-webkit-file-upload-button{
+    -webkit-appearance: none;
+    cursor: pointer;
+    color: #444;
+    border-color: #CCCCCC #B9B9B9 #B9B9B9 #CCCCCC;
+    border-style: solid;
+    border-width: 1px;
+    background: -webkit-gradient(linear, left top, left bottom, from(#ffffff), to(#dfdfdf)); /*webkit*/
+    -webkit-border-radius: 3px;
+}
+
 .z-form .z-formrow select optgroup {
     font-style: normal;
     font-weight: bold;

--- a/src/system/Admin/javascript/admin_admin_ajax.js
+++ b/src/system/Admin/javascript/admin_admin_ajax.js
@@ -215,10 +215,12 @@ Object.extend(Zikula.AdminPanel.Tab, /** @lends Zikula.AdminPanel.Tab */{
         };
         Draggables.addObserver({
             onStart: function(name, draggable, event) {
-                draggable.element.down('a').stopObserving('click', preventDefault);
-                setTimeout(function() {
-                    draggable.element.down('a').observe('click', preventDefault);
-                }, 200);
+                if (draggable.element.down('a') != undefined) {
+                    draggable.element.down('a').stopObserving('click', preventDefault);
+                    setTimeout(function() {
+                        draggable.element.down('a').observe('click', preventDefault);
+                    }, 200);
+                }
             }
         });
         $('admintabs').select('li.admintab').each(function(tab) {

--- a/src/system/Admin/lib/Admin/Controller/Admin.php
+++ b/src/system/Admin/lib/Admin/Controller/Admin.php
@@ -332,21 +332,7 @@ class Admin_Controller_Admin extends Zikula_AbstractController
                     }
                     $menutexttitle = $modinfo['description'];
 
-                    $osmoddir = DataUtil::formatForOS($modinfo['directory']);
-                    $adminicons = array($modpath . '/' . $osmoddir . '/images/admin.png',
-                            $modpath . '/' . $osmoddir . '/images/admin.jpg',
-                            $modpath . '/' . $osmoddir . '/images/admin.gif',
-                            $modpath . '/' . $osmoddir . '/pnimages/admin.gif',
-                            $modpath . '/' . $osmoddir . '/pnimages/admin.jpg',
-                            $modpath . '/' . $osmoddir . '/pnimages/admin.jpeg',
-                            $modpath . '/' . $osmoddir . '/pnimages/admin.png',
-                            'system/Admin/images/default.gif');
-
-                    foreach ($adminicons as $adminicon) {
-                        if (is_readable($adminicon)) {
-                            break;
-                        }
-                    }
+                    $adminicon = ModUtil::getModuleImagePath($adminmodule['name']);
 
                     $adminlinks[] = array('menutexturl' => $menutexturl,
                             'menutext' => $menutext,

--- a/src/system/Admin/templates/admin_admin_developernotices.tpl
+++ b/src/system/Admin/templates/admin_admin_developernotices.tpl
@@ -1,4 +1,4 @@
-{checkpermissionblock component='::' instance='::' level=ACCESS_ADMIN}
+{checkpermissionblock component='Admin::' instance='::' level=ACCESS_ADMIN}
 {modurl modname=Theme type=admin func=modifyconfig assign=themeurl}
 {if $notices.developer.devmode}
 <div id="z-developernotices">

--- a/src/system/Admin/templates/admin_admin_header.tpl
+++ b/src/system/Admin/templates/admin_admin_header.tpl
@@ -1,7 +1,8 @@
 {admincategorymenu}
 <div class="z-admin-content z-clearfix">
     <div class="z-admin-content-modtitle">
-        {img modname=$toplevelmodule src='admin.png' height='36'}
-        <h2>{modgetinfo modname=$toplevelmodule info='displayname'}</h2>
+	{modgetinfo modname=$toplevelmodule info='displayname' assign='displayName'}
+	<img src="{modgetimage|safetext}" alt="{$displayName|safetext}" />
+	<h2>{$displayName}</h2>
     </div>
     {modulelinks modname=$toplevelmodule type='admin'}

--- a/src/system/Extensions/templates/extensions_hookui_hooks.tpl
+++ b/src/system/Extensions/templates/extensions_hookui_hooks.tpl
@@ -217,7 +217,7 @@
                     {/foreach}
 
                     {if $total_bindings eq 0}
-                    {if $connection_exists eq false}<span class="z-sub">{gt text="%1$s module can't connect to %2$s module. No connections are supported" tag1=$currentmodule tag2=$subscriber.name|safetext}</span>{/if}
+                    {if $connection_exists eq false}<span class="z-sub">{gt text='%1$s module can\'t connect to %2$s module. No connections are supported' tag1=$currentmodule tag2=$subscriber.name|safetext}</span>{/if}
                     {continue}
                     {/if}
 


### PR DESCRIPTION
# Adding old PRs and hacks of 1.3 branch, lost in 1.3.6 release.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #801,#598,#593,#616,#617,#618,#621,#564 |
| Refs tickets |  |
| License | MIT |
| Doc PR | - |

Some details:
#801 (incl #665) -> PR #924 - 'extmenu drag and drop1 -> /system/Admin/javascript/admin_admin_ajax.js
#598 -> 'EntityAccess::toArray - don't call non existing methods' -> lib/Zikula/EntityAccess.php
#593 -> PR #607 ->'Get modimage by ModUtil::getModuleImagePath()' -> lib/util/ModUtil.php, lib/viewplugins/function.modgetimage.php, system/Admin/lib/Admin/Controller/Admin.php, system/Admin/templates/admin_admin_header.tpl

https://github.com/zikula/core/commit/55a22f14ca40aadc046017d39bd664c142181eef -> 'replaced double quotes with single quotes in gettext string, because it gave E_NOTICE' ->system/Extensions/templates/extensions_hookui_hooks.tpl

PR #616,#617,#618  -> /lib/dbobject/DBObject.php I DBObjectArray.php
#621 -> PR #622 -> /style/core.css
#564 ->  /system/Admin/templates/admin_admin_developernotices.tpl
