### PR TITLE
Dynamically add routes

### DIFF
--- a/src/app/config/routing.yml
+++ b/src/app/config/routing.yml
@@ -1,0 +1,2 @@
+_main:
+    resource: @CoreBundle/Resources/config/routing.php

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/routing.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/routing.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright Zikula Foundation 2013 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPv3 (or at your option any later version).
+ * @package Zikula
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+use Symfony\Component\Config\Exception\FileLoaderLoadException;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\DependencyInjection\Loader;
+
+/** @var ZikulaKernel $kernel */
+$kernel = $container->get('kernel');
+$bundles = $kernel->getModules();
+$bundles = array_merge($bundles, $kernel->getThemes());
+
+$collection = new RouteCollection();
+
+/** @var Zikula\Core\AbstractBundle $bundle */
+foreach ($bundles as $bundle) {
+    try {
+        $collection->addCollection(
+            /** @var \Symfony\Component\Routing\Loader\PhpFileLoader $loader */
+            $loader->import($module->getRoutingConfig()),
+            '/'
+        );
+    } catch (FileLoaderLoadException $e) {
+        // Fail silently if routing config file does not exist.
+    }
+}
+return $collection;

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/services.xml
@@ -6,11 +6,17 @@
 
     <parameters>
         <parameter key="event_dispatcher.class">Zikula_EventManager</parameter>
+        <parameter key="routing.loader.php.class">Zikula\Bundle\CoreBundle\Routing\Loader\PhpFileLoader</parameter>
     </parameters>
 
     <services>
         <service id="data_collector.zikula_version" class="Zikula\Bundle\CoreBundle\DataCollector\ZikulaVersionDataCollector" public="false">
             <tag name="data_collector" template="CoreBundle:Collector:ZikulaVersion.html.twig" id="zikula_version" priority="300" />
+        </service>
+        <service id="routing.loader.php" class="%routing.loader.php.class%" public="false">
+            <tag name="routing.loader" />
+            <argument type="service" id="service_container" />
+            <argument type="service" id="file_locator" />
         </service>
     </services>
 </container>

--- a/src/lib/Zikula/Bundle/CoreBundle/Routing/Loader/PhpFileLoader.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/Routing/Loader/PhpFileLoader.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright Zikula Foundation 2013 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPv3 (or at your option any later version).
+ * @package Zikula
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+namespace Zikula\Bundle\CoreBundle\Routing\Loader;
+
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Routing\Loader\PhpFileLoader as BasePhpFileLoader;
+
+/**
+ * Customized PHP routing file loader exposing the container to the PHP file.
+ */
+class PhpFileLoader extends BasePhpFileLoader
+{
+    protected $container;
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     * @param FileLocatorInterface      $locator   A FileLocator instance
+     */
+    public function __construct(ContainerBuilder $container, FileLocatorInterface $locator)
+    {
+        $this->container = $container;
+
+        parent::__construct($locator);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load($file, $type = null)
+    {
+        // the loader variable is exposed to the included file below
+        $container = $this->container;
+        $loader = $this;
+
+        $path = $this->locator->locate($file);
+        $this->setCurrentDir(dirname($path));
+
+        $collection = include $path;
+        $collection->addResource(new FileResource($path));
+
+        return $collection;
+    }
+}

--- a/src/lib/Zikula/Core/AbstractBundle.php
+++ b/src/lib/Zikula/Core/AbstractBundle.php
@@ -55,6 +55,11 @@ abstract class AbstractBundle extends Bundle
         return $class;
     }
 
+    public function getRoutingConfig()
+    {
+         return "@{$this->name}/Resources/config/routing.yml";
+    }
+
     public function getTranslationDomain()
     {
         return strtolower($this->getName());
@@ -78,6 +83,16 @@ abstract class AbstractBundle extends Bundle
     public function getViewsPath()
     {
         return $this->getPath().'/Resources/views';
+    }
+
+    /**
+     * Gets the config path.
+     *
+     * @return string
+     */
+    public function getConfigPath()
+    {
+        return $this->getPath().'/Resources/config';
     }
 
     /**

--- a/src/modules/acme-example/Acme/ExampleModule/Controller/UserController.php
+++ b/src/modules/acme-example/Acme/ExampleModule/Controller/UserController.php
@@ -4,9 +4,17 @@ namespace Acme\ExampleModule\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 use Zikula\Core\Controller\AbstractController;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
 class UserController extends AbstractController
 {
+    /**
+     * @Route("/{name}")
+     *
+     * @param string $name
+     *
+     * @return Response
+     */
     public function indexAction($name = 'no name')
     {
         return $this->render('AcmeExampleModule:User:index.html.twig', array('name' => $name));

--- a/src/modules/acme-example/Acme/ExampleModule/Resources/config/routing.yml
+++ b/src/modules/acme-example/Acme/ExampleModule/Resources/config/routing.yml
@@ -1,0 +1,4 @@
+acmeexamplemodule:
+    resource: "@AcmeExampleModule/Controller"
+    prefix:   /acmeexample
+    type:     annotation


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | --- |
| Fixed tickets | --- |
| Refs tickets | --- |
| License | MIT |
| Doc PR | --- |

This is how we can dynamically add routes. This imports routes from all modules providing a `routing.*` file. If you give it a try, you'll notice an exception when trying to use the route by visiting `index.php/acmeexample/`, but this is not related to routing but controller resolving.
