### PR TITLE
Menutree external dynamic link for Content updated

### DIFF
--- a/src/system/Zikula/Module/BlocksModule/Api/MenutreeApi.php
+++ b/src/system/Zikula/Module/BlocksModule/Api/MenutreeApi.php
@@ -347,8 +347,11 @@ class MenutreeApi extends \Zikula_AbstractApi
                 'orderBy' => 'setLeft',
                 'makeTree' => false,
                 'language' => $lang,
+                'includeContent' => false,
+                'includeLayout' => false,
+                'includeCategories' => false,
                 'filter' => array(
-                        'superParentId' => $extrainfo['parent']
+                    'superParentId' => $extrainfo['parent']
                 )
         );
         $pages = ModUtil::apiFunc('Content', 'page', 'getPages', $options);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | optimization of code |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

Including less API calls during Content_Page_getPages, otherwise too much API's get called where this is not necessary and increases load times ! Only titles and links are needed for Menutree to generate the menu.
