### PR TITLE
Allow modules to upgrade from old style to ns-style modules 

### DIFF
--- a/src/lib/legacy/Zikula/AbstractVersion.php
+++ b/src/lib/legacy/Zikula/AbstractVersion.php
@@ -247,6 +247,7 @@ abstract class Zikula_AbstractVersion implements ArrayAccess
         $meta['securityschema'] = $this->securityschema;
         $meta['core_min'] = $this->core_min;
         $meta['core_max'] = $this->core_max;
+        $meta['oldnames'] = $this->oldnames;
 
         return $meta;
     }

--- a/src/system/Zikula/Module/ExtensionsModule/Api/AdminApi.php
+++ b/src/system/Zikula/Module/ExtensionsModule/Api/AdminApi.php
@@ -525,7 +525,7 @@ class AdminApi extends \Zikula_AbstractApi
             $array['dependencies'] = serialize($array['dependencies']);
 
             $filemodules[$bundle->getName()] = $array;
-            $filemodules[$bundle->getName()]['oldnames'] = serialize(array());
+            $filemodules[$bundle->getName()]['oldnames'] = isset($array['oldnames']) ? $array['oldnames'] : '';
         }
 
         // set the paths to search
@@ -721,21 +721,23 @@ class AdminApi extends \Zikula_AbstractApi
                     if (isset($dbmodinfo['name']) && in_array($dbmodinfo['name'], (array)$modinfo['oldnames'])) {
                         // migrate its modvars
                         $query = $this->entityManager->createQueryBuilder()
-                                                     ->update('UPDATE Zikula\Core\Doctrine\Entity\ExtensionVarEntity', 'v')
-                                                     ->set('v.modname', $modinfo['name'])
-                                                     ->where('v.modname = :dbname')
-                                                     ->setParameter('dbanme', $dbname)
-                                                     ->getQuery();
-                        $query->getResult();
+                             ->update('Zikula\Core\Doctrine\Entity\ExtensionVarEntity', 'v')
+                             ->set('v.modname', ':modname')
+                             ->setParameter('modname', $modinfo['name'])
+                             ->where('v.modname = :dbname')
+                             ->setParameter('dbname', $dbname)
+                             ->getQuery();
+                        $query->execute();
 
                         // rename the module register
                         $query = $this->entityManager->createQueryBuilder()
-                                                     ->update('Zikula\Core\Doctrine\Entity\ExtensionEntity', 'e')
-                                                     ->set('e.name', $modinfo['name'])
-                                                     ->where('e.id = :dbname')
-                                                     ->setParameter('dbanme', $dbmodules[$dbname]['id'])
-                                                     ->getQuery();
-                        $query->getResult();
+                             ->update('Zikula\Core\Doctrine\Entity\ExtensionEntity', 'e')
+                             ->set('e.name', ':modname')
+                             ->setParameter('modname', $modinfo['name'])
+                             ->where('e.id = :dbname')
+                             ->setParameter('dbname', $dbmodules[$dbname]['id'])
+                             ->getQuery();
+                        $query->execute();
 
                         // replace the old module with the new one in the dbmodules array
                         $newmodule = $dbmodules[$dbname];


### PR DESCRIPTION
Allow modules to upgrade from old style to ns-style modules using 'oldnames' array key. Correct querymanager build and format.

refs https://github.com/zikula-modules/Legal/issues/30

/cc @shefik - you may not be able to replicate the process now, but I think this solves your issue. I was able to upgrade from an older install of Legal to the newest version after this correction.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | https://github.com/zikula-modules/Legal/issues/30 |
| License | MIT |
| Doc PR | - |
