### PR TITLE
fixed doublicate key issue with categories

### DIFF
--- a/src/lib/legacy/Zikula/Form/Plugin/CategorySelector.php
+++ b/src/lib/legacy/Zikula/Form/Plugin/CategorySelector.php
@@ -255,12 +255,20 @@ class Zikula_Form_Plugin_CategorySelector extends Zikula_Form_Plugin_DropdownLis
             } else {
                 $selectedValues[] = $this->getSelectedValue();
             }
+            $selectedValues = array_combine($selectedValues, $selectedValues);
 
-           foreach ($collection->getKeys() as $key) {
-               $categoryId = $collection->get($key)->getCategoryRegistryId();
-               if ($categoryId == $this->registryId) {
-                    $collection->remove($key);
-               }
+            foreach ($collection->getKeys() as $key) {
+                $entityCategory = $collection->get($key);
+
+                if ($entityCategory->getCategoryRegistryId() == $this->registryId) {
+                    $categoryId = $entityCategory->getCategory()->getId();
+
+                    if (isset($selectedValues[$categoryId])) {
+                        unset($selectedValues[$categoryId]);
+                    } else {
+                        $collection->remove($key);
+                    }
+                }
             }
 
             // we do NOT flush here, as the calling module is responsible for that (Guite)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/Guite/MostGenerator/issues/472 |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

PR #1561 added the problem, that the category entities cannot deleted an added in the same flush process.
This PR deletes only nonselected from and adds only new categorys to the entity.
