### PR TITLE
Updated Imagine thumb plugin description

### DIFF
--- a/src/plugins/Imagine/templates/plugins/function.thumb.php
+++ b/src/plugins/Imagine/templates/plugins/function.thumb.php
@@ -16,7 +16,7 @@
  *  - image         (string)        Path to source image (required)
  *  - width         (int)           Thumbnail width in pixels (optional, default value based on 'default' preset)
  *  - height        (int)           Thumbnail width in pixels (optional, default value based on 'default' preset)
- *  - mode          (string)        Thumbnail mode; 'inset' or 'outset' (optional, default 'inset')
+ *  - mode          (string)        Thumbnail mode; 'inset' or 'outbound' (optional, default 'inset')
  *  - extension     (string)        File extension for thumbnails: jpg, png, gif; null for original file type
  *                                  (optional, default value based on 'default' preset)
  *  - objectid      (string)        Unique signature for object, which owns this thumbnail (optional)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

In https://github.com/zikula/core/blob/1.3/src/plugins/Imagine/lib/Imagine/Manager.php#L416

the thumbnail modes that can be chosen are inset or outbound, not outset. It is also described quite poorly in the Imagine docs, see also https://github.com/avalanche123/Imagine/issues/91

The working can be seen on slide 28-30 of https://speakerdeck.com/avalanche123/introduction-to-imagine
