### PR TITLE
[Imagine plugin] Changed outset into outbound in plugin

### DIFF
--- a/src/plugins/Imagine/README
+++ b/src/plugins/Imagine/README
@@ -221,7 +221,7 @@ Both types of presets are handled by SystemPlugin_Imagine_Preset class.
 Preset allows to define:
 - width - thumbnail width in pixels
 - height - thumbnail height in pixels
-- mode - "inset" or "outset"
+- mode - "inset" or "outbound"
 - extension - file extension for thumbnails (jpg, png, gif; null for original file type)
 
 There are also special options  which allows to store in preset additional settings for thumbnail manager:
@@ -240,7 +240,7 @@ There are also special options  which allows to store in preset additional setti
     $data = array(
         'width' => 100,
         'heigth' => 100,
-        'mode' => 'outset',
+        'mode' => 'outbound',
         '__module' => 'Foo',
         '__transformation' => $your_custom_transformations
     );

--- a/src/plugins/Imagine/lib/Imagine/Configuration.php
+++ b/src/plugins/Imagine/lib/Imagine/Configuration.php
@@ -35,7 +35,7 @@ class SystemPlugin_Imagine_Configuration extends Zikula_Controller_AbstractPlugi
     {
         $modVars = $this->plugin->getVars();
         $options = array(
-            'mode' => array('inset', 'outset'),
+            'mode' => array('inset', 'outbound'),
             'extension' => array('jpg', 'png', 'gif'),
         );
 

--- a/src/plugins/Imagine/locale/systemplugin_imagine.pot
+++ b/src/plugins/Imagine/locale/systemplugin_imagine.pot
@@ -129,7 +129,7 @@ msgid "Inset mode - thumbnails are scale down to not exceed dimensions."
 msgstr ""
 
 #: templates/configuration.tpl:73
-msgid "Outset mode - thumbnails are cut out to exactly fit dimmensions."
+msgid "Outbound mode - thumbnails are cut out to exactly fit dimmensions."
 msgstr ""
 
 #: templates/configuration.tpl:78

--- a/src/plugins/Imagine/templates/configuration.tpl
+++ b/src/plugins/Imagine/templates/configuration.tpl
@@ -83,7 +83,7 @@
                     <p class="help-block sub">
                         {gt text='Thumbnail generation mode.'}<br />
                         {gt text='Inset mode - thumbnails are scale down to not exceed dimensions.'}<br />
-                        {gt text='Outset mode - thumbnails are cut out to exactly fit dimmensions.'}
+                        {gt text='Outbound mode - thumbnails are cut out to exactly fit dimmensions.'}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets |  |
| Refs tickets | zikula@cc9c57b |
| License | MIT |
| Doc PR | - |

In the Imagine plugin now also everywhere outbound is being used for THUMBNAIL_OUTBOUND mode instead of outset. We have inset and outbound now in the plugin.
