### PR TITLE
Refactored createXXXException() methods

### DIFF
--- a/src/lib/Zikula/Core/Controller/AbstractController.php
+++ b/src/lib/Zikula/Core/Controller/AbstractController.php
@@ -88,40 +88,41 @@ abstract class AbstractController extends Controller implements TranslatorAwareI
 
         return $parameters;
     }
+
     /**
      * Returns a NotFoundHttpException.
      *
      * This will result in a 404 response code. Usage example:
      *
-     *     throw $this->createNotFoundException('Page not found!');
+     *     throw $this->createNotFoundException();
      *
-     * @param string    $message  A message
-     * @param \Exception $previous The previous exception
+     * @param string     $message  A message.
+     * @param \Exception $previous The previous exception.
      *
      * @return NotFoundHttpException
      */
     public function createNotFoundException($message = null, \Exception $previous = null)
     {
-        $message = null === $message ? __('Not Found') : $message;
+        $message = null === $message ? __('Page not found') : $message;
 
         return new NotFoundHttpException($message, $previous);
     }
 
     /**
-     * Returns a NotFoundHttpException.
+     * Returns a AccessDeniedException.
      *
-     * This will result in a 404 response code. Usage example:
+     * This will result in a 403 response code. Usage example:
      *
-     *     throw $this->createNotFoundException('Page not found!');
+     *     throw $this->createAccessDeniedException();
      *
-     * @param string    $message  A message
-     * @param \Exception $previous The previous exception
+     * @param string     $message  A message.
+     * @param \Exception $previous The previous exception.
      *
      * @return AccessDeniedException
      */
-    public function createAccessDeniedHttpException($message = null, \Exception $previous = null)
+    public function createAccessDeniedException($message = null, \Exception $previous = null)
     {
-        $message = null === $message ? __('Access Denied') : $message;
+        $message = null === $message ? __('Access denied') : $message;
 
         return new AccessDeniedException($message, $previous);
     }

--- a/src/lib/legacy/Zikula/AbstractBase.php
+++ b/src/lib/legacy/Zikula/AbstractBase.php
@@ -815,6 +815,25 @@ abstract class Zikula_AbstractBase implements Zikula_TranslatableInterface, Cont
     }
 
     /**
+     * Returns a AccessDeniedException.
+     *
+     * This will result in a 403 response code. Usage example:
+     *
+     *     throw $this->createAccessDeniedException();
+     *
+     * @param string     $message  A message.
+     * @param \Exception $previous The previous exception.
+     *
+     * @return AccessDeniedException
+     */
+    public function createAccessDeniedException($message = null, \Exception $previous = null)
+    {
+        $message = null === $message ? __('Access denied') : $message;
+
+        return new AccessDeniedException($message, $previous);
+    }
+
+    /**
      * Convenience to get a service.
      *
      * @param string $id Service Name.

--- a/src/lib/legacy/Zikula/AbstractController.php
+++ b/src/lib/legacy/Zikula/AbstractController.php
@@ -196,36 +196,17 @@ abstract class Zikula_AbstractController extends Zikula_AbstractBase
      *
      * This will result in a 404 response code. Usage example:
      *
-     *     throw $this->createNotFoundException('Page not found!');
+     *     throw $this->createNotFoundException();
      *
-     * @param string    $message  A message
-     * @param \Exception $previous The previous exception
+     * @param string     $message  A message.
+     * @param \Exception $previous The previous exception.
      *
      * @return NotFoundHttpException
      */
     public function createNotFoundException($message = null, \Exception $previous = null)
     {
-        $message = null === $message ? __('Not Found') : $message;
+        $message = null === $message ? __('Page not found') : $message;
 
         return new NotFoundHttpException($message, $previous);
-    }
-
-    /**
-     * Returns a NotFoundHttpException.
-     *
-     * This will result in a 403 response code. Usage example:
-     *
-     *      throw $this->createAccessDeniedHttpException('Access Denied');
-     *
-     * @param string    $message  A message
-     * @param \Exception $previous The previous exception
-     *
-     * @return NotFoundException
-     */
-    public function createAccessDeniedHttpException($message = null, \Exception $previous = null)
-    {
-        $message = null === $message ? __('Access Denied') : $message;
-
-        return new AccessDeniedException($message, $previous);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | --- |
| Fixed tickets | #1507 |
| Refs tickets | --- |
| License | MIT |
| Doc PR | --- |
- renamed `createAccessDeniedHttpException` to `createAccessDeniedException`
- moved `createAccessDeniedException` from Abstract_Controller to Abstract_Base to make it possible to use it in apis, closes #1507.

@shefik For the record, the issue you had in #1507 came up because the `createAccessDeniedException` was not available in `Abstract_Base`

@craigh You will have to rename `createAccessDeniedHttpException` to `createAccessDeniedException` in Dizkus.
