### PR TITLE
Properly use default parameter for cookies.

### DIFF
--- a/src/lib/legacy/util/CookieUtil.php
+++ b/src/lib/legacy/util/CookieUtil.php
@@ -59,7 +59,13 @@ class CookieUtil
      */
     public static function getCookie($name, $signed=true, $default='')
     {
-        $cookie = FormUtil::getPassedValue($name, $default, 'COOKIE');
+        $request = \ServiceUtil::get('request');
+
+        if (!$request->cookies->has($name)) {
+            return $default;
+        }
+
+        $cookie = $request->cookies->get($name);
         if (System::getVar('signcookies') && (!$signed == false)) {
             return SecurityUtil::checkSignedData($cookie);
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | --- |
| Fixed tickets | --- |
| Refs tickets | --- |
| License | MIT |
| Doc PR | --- |

I know `ServiceUtil::get()` is _evil_, but as `CookieUtil` is placed in a `legacy` folder I came up with that solution.

Without this patch, `CookieUtil` fails if a default value is specified and the cookie does not exist.

/cc @craigh
