### PR TITLE
added additional permissions schema, fixes #709

### DIFF
--- a/src/system/Zikula/Module/CategoriesModule/CategoriesModuleVersion.php
+++ b/src/system/Zikula/Module/CategoriesModule/CategoriesModuleVersion.php
@@ -32,7 +32,8 @@ class CategoriesModuleVersion extends \Zikula_AbstractVersion
         $meta['url']            = $this->__('categories');
         $meta['version']        = '1.2.2';
         $meta['core_min'] = '1.3.7';
-        $meta['securityschema'] = array('ZikulaCategoriesModule::Category' => 'Category ID:Category Path:Category IPath');
+        $meta['securityschema'] = array('ZikulaCategoriesModule::' => '::',
+                                        'ZikulaCategoriesModule::Category' => 'Category ID:Category Path:Category IPath');
 
         return $meta;
     }


### PR DESCRIPTION
This PR adds to the module version file a permission schema used in the module that otherwise is undocumented.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #709 |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |
