### PR TITLE
[release-1.3] Refers to #666 fix for IE<10 login problems

### DIFF
--- a/src/lib/Zikula/View.php
+++ b/src/lib/Zikula/View.php
@@ -730,7 +730,9 @@ class Zikula_View extends Smarty implements Zikula_TranslatableInterface
 
         if ($this->expose_template == true) {
             $template = DataUtil::formatForDisplay($template);
-            $output = "\n<!-- Start " . $this->template_dir . "/$template -->\n" . $output . "\n<!-- End " . $this->template_dir . "/$template -->\n";
+            //$output = "\n<!-- Start " . $this->template_dir . "/$template -->\n" . $output . "\n<!-- End " . $this->template_dir . "/$template -->\n";
+            // Changed comment into conditional statement for IE<10
+            $output = "\n<!--[if !IE]> Start " . $this->template_dir . "/$template <![endif]-->\n" . $output . "\n<!-- End " . $this->template_dir . "/$template -->\n";
         }
 
         $event = new Zikula_Event('view.postfetch', $this, array('template' => $template), $output);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | #666 |
| License | MIT |
| Doc PR | - |

This fixes the problem that hte login window in IE<10 is broken when you switch on generating template comments into the output.

The issue is described clearly in the #666 ticket.
