### PR TITLE
Updated View.php for expose_template and IE<10

### DIFF
--- a/src/lib/legacy/Zikula/View.php
+++ b/src/lib/legacy/Zikula/View.php
@@ -764,7 +764,9 @@ class Zikula_View extends Smarty implements Zikula_TranslatableInterface
 
         if ($this->expose_template == true) {
             $template = DataUtil::formatForDisplay($template);
-            $output = "\n<!-- Start " . $this->template_dir . "/$template -->\n" . $output . "\n<!-- End " . $this->template_dir . "/$template -->\n";
+            //$output = "\n<!-- Start " . $this->template_dir . "/$template -->\n" . $output . "\n<!-- End " . $this->template_dir . "/$template -->\n";
+            // Changed comment into conditional statement for IE<10
+            $output = "\n<!--[if !IE]> Start " . $this->template_dir . "/$template <![endif]-->\n" . $output . "\n<!-- End " . $this->template_dir . "/$template -->\n";
         }
 
         $event = new \Zikula\Core\Event\GenericEvent($this, array('template' => $template), $output);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | #666, #1599 |
| License | MIT |
| Doc PR | - |

The change done in #1599 also applied to the 1.3 branch in the Legacy. This to make sure the when templates are exposed in comments, the comments above DOCTYPE do not mess up IE<10.
