### PR TITLE
back-ported fix for deprecated /e modifier to preg_replace refs #889

### DIFF
--- a/src/docs/CHANGELOG
+++ b/src/docs/CHANGELOG
@@ -2,6 +2,7 @@ CHANGELOG - ZIKULA 1.3.7
 ------------------------
 
 - Fixed unsanitized inputs (Secunia Advisory SA56274)
+- Fixed deprecated /e modifier to preg_replace (PHP 5.5) #889
 
 
 CHANGELOG - ZIKULA 1.3.6

--- a/src/lib/util/DataUtil.php
+++ b/src/lib/util/DataUtil.php
@@ -202,23 +202,21 @@ class DataUtil
      */
     public static function formatForDisplay($var)
     {
-        // This search and replace finds the text 'x@y' and replaces
-        // it with HTML entities, this provides protection against
-        // email harvesters
-        static $search = array('/(.)@(.)/se');
-
-        static $replace = array('"&#" .
-                                sprintf("%03d", ord("\\1")) .
-                                ";&#064;&#" .
-                                sprintf("%03d", ord("\\2")) . ";";');
-
         if (is_array($var)) {
             foreach ($var as $k => $v) {
                 $var[$k] = self::formatForDisplay($v);
             }
         } else {
-            $var = htmlspecialchars((string)$var);
-            $var = preg_replace($search, $replace, $var);
+            $var = htmlspecialchars((string) $var);
+            // This search and replace finds the text 'x@y' and replaces
+            // it with HTML entities, this provides protection against
+            // email harvesters
+            $var = preg_replace_callback(
+                '/(.)@(.)/s',
+                function($m) {
+                    return "&#".sprintf("%03d", ord($m[1])).";&#064;&#" .sprintf("%03d", ord($m[2])) . ";";
+                },
+                $var);
         }
 
         return $var;


### PR DESCRIPTION
This PR contains a back-ported fix for better compatability with PHP 5.5.

 | Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| Refs tickets  | #889
| License       | MIT
| Doc PR        | 
