### PR TITLE
Fixed exporter function in Users module

### DIFF
--- a/src/system/Users/templates/users_admin_export.tpl
+++ b/src/system/Users/templates/users_admin_export.tpl
@@ -6,6 +6,7 @@
 
 <form class="z-form" action="{modurl modname='Users' type='admin' func='exporter'}" method="post" enctype="multipart/form-data">
     <div>
+	<input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
         <input type="hidden" name="confirmed" value="1" />
         <fieldset>
             <legend>Export Options</legend>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | - |

Some details:
- Error is in module-Users, func-exporter when submit the form. The problem is in the template: it must post the _csrftoken_.

I have two questions:
- I don't know if I must add this little issues to _changelog_ .
- Exporter function report a csv with groups names (like 'Users|Editors|Group A'). Import function needs groups _gid_ (like '1|3|7'). Maybe it's better that exporter report _gid_s. It's not a bug... I can send a PR, but I'll wait your opinions. 
