### PR TITLE
Fixed exporter function in Users module in 1.4... like #1630 in 1.3

### DIFF
--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/export.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/export.tpl
@@ -6,6 +6,7 @@
 
 <form class="form-horizontal" role="form" action="{modurl modname='ZikulaUsersModule' type='admin' func='exporter'}" method="post" enctype="multipart/form-data">
     <div>
+	<input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
         <input type="hidden" name="confirmed" value="1" />
         <fieldset>
             <legend>Export Options</legend>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| License | MIT |
| Doc PR | - |

Some details:
- Detected Error is in module-Users, func-exporter when submit the form. The problem is in the template: it must post the _csrftoken_.
- #1630 PR try to arrange this issue on 1.3 branch
- This PR applies the same change (no tested) on 1.4 branch
