### PR TITLE
[Imagine plugin] spelling corrected of Javascript methods

### DIFF
--- a/src/plugins/Imagine/javascript/configuration.js
+++ b/src/plugins/Imagine/javascript/configuration.js
@@ -68,7 +68,7 @@ Zikula.Imagine.getPresetCopy = function(source) {
 };
 
 Zikula.Imagine.insertPresetCopy = function(preset) {
-    $$('.presets fieldset:last')[0].insert({
+    $$('fieldset:last')[0].insert({
         after: preset
     });
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

method names were spelled as Perset instead of Preset
