### PR TITLE
[1.3 branch] Updated .htaccess in modules for fonts, jpeg

### DIFF
--- a/src/modules/.htaccess
+++ b/src/modules/.htaccess
@@ -3,7 +3,7 @@
 #                  stored under the modules/ directory
 # ----------------------------------------------------------------------
 deny from all
-<FilesMatch "\.(css|js|jpg|gif|png|swf)$">
+<FilesMatch "\.(css|eot|gif|jpeg|jpg|js|pdf|png|svg|swf|ttf|woff)$">
 order allow,deny
 allow from all
 </filesmatch>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

Updated the htaccess in modules to support local fonts, like glyphicons and other font libs. 
Also jpeg was still missing here. 
This is now in line with the htaccess in 1.4 branch
