### PR TITLE
Set the System Identifier as a unique string.

### DIFF
--- a/src/install/lib.php
+++ b/src/install/lib.php
@@ -266,7 +266,7 @@ function install(Zikula_Core $core, Request $request)
                     UserUtil::loginUsing($authenticationMethod, $authenticationInfo);
 
                     // Set the System Identifier as a unique string.
-                    System::setVar('system_identifier', uniqid());
+                    System::setVar('system_identifier', str_replace('.', '', uniqid(rand(1000000000, 9999999999), true)));
                     
                     // add admin email as site email
                     System::setVar('adminmail', $email);

--- a/src/upgrade.php
+++ b/src/upgrade.php
@@ -242,7 +242,7 @@ function _upg_upgrademodules($username, $password)
 
     // Set the System Identifier as a unique string.
     if (!System::getVar('system_identifier')) {
-        System::setVar('system_identifier', uniqid());
+        System::setVar('system_identifier', str_replace('.', '', uniqid(rand(1000000000, 9999999999), true)));
     }
 
     // force load the modules admin API


### PR DESCRIPTION
Use Case: At installation, it is useful to set a unique identifier (as a system var) that can be used to identify the system. This system var can be then to be used as string mapped to third-party services.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |
