### PR TITLE
[1.4 Users] Updated Api_registration for sendpass

### DIFF
--- a/src/system/Zikula/Module/UsersModule/Api/RegistrationApi.php
+++ b/src/system/Zikula/Module/UsersModule/Api/RegistrationApi.php
@@ -424,7 +424,7 @@ class RegistrationApi extends \Zikula_AbstractApi
         $adminNotification = isset($args['adminnotification']) ? $args['adminnotification'] : true;
 
         // Handle password
-        $sendPassword = $isAdminOrSubAdmin && isset($args['sendpass']) ? $args['sendpass'] : false;
+        $sendPassword = isset($args['sendpass']) ? $args['sendpass'] : false;
 
         if ($sendPassword) {
             // Function called by admin adding user/reg, administrator created the password; no approval needed, so must need verification.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

When another module wants to use the Users_registration Api and the registerNewUser method you cannot use the sendpass functionality. When a webshop (e.g. zwebstore) with automatic account creation based on user data with a generated password wants to send the generated password to the new account then this update is needed. Otherwise you cannot send the password. 

Automatic account creation saves 1 extra step in customer approach in webshops. And 1 extra step can be one too many in these fast times.
