### PR TITLE
[1.3] Zikula_Form class usage in legacy pnFormRender::execute

### DIFF
--- a/src/lib/legacy/Compat.php
+++ b/src/lib/legacy/Compat.php
@@ -695,7 +695,7 @@ class pnFormRender extends Zikula_Form_View
      *
      * @return mixed False on errors, true on redirects, and otherwise it returns the HTML output for the page.
      */
-    public function execute($template, pnFormHandler $eventHandler)
+    public function execute($template, Zikula_Form_AbstractHandler $eventHandler)
     {
         if (!$eventHandler instanceof pnFormHandler) {
             throw new Zikula_Exception_Fatal('Form handlers must inherit from pnFormHandler.');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

During upgrade from 137 to 138 I get the following message in the Upgrade opening screen.
Strict Standards: Declaration of pnFormRender::execute() should be compatible with Zikula_Form_View::execute($template, Zikula_Form_AbstractHandler $eventHandler) in ..\zk138\lib\legacy\Compat.php on line 543

The old method declaration used pnFormHandler as class reference, which is not accepted by PHP STRICT standards. Changing to the suggested change solves that. It's only for really old stuff still using pnFormRender.
