### PR TITLE
[RFC] highlight missing parameter classes

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
@@ -6,8 +6,8 @@
 
     <parameters>
         <parameter key="zikula.theme_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeListener</parameter>
-        <parameter key="zikula.themeinit_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeInitListener</parameter>
-        <parameter key="zikula.system_listener.class">Zikula\Bundle\CoreBundle\EventListener\SystemListener</parameter>
+        <!-- class does not exist! --> <parameter key="zikula.themeinit_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeInitListener</parameter>
+        <!-- class does not exist! --><parameter key="zikula.system_listener.class">Zikula\Bundle\CoreBundle\EventListener\SystemListener</parameter>
         <parameter key="zikula.template_override_listener.class">Zikula\Bundle\CoreBundle\EventListener\TemplateOverrideYamlListener</parameter>
 
         <parameter key="zikula.doctrine1_connector.class">Zikula\Bundle\CoreBundle\EventListener\Doctrine1ConnectorListener</parameter>
@@ -26,11 +26,11 @@
         <parameter key="markdown.class">Michelf\Markdown</parameter>
         <parameter key="markdown_extra.class">Michelf\MarkdownExtra</parameter>
 
-        <parameter key="zikula_core.class">Zikula\Core\Core</parameter>
-        <parameter key="zikula.core_init_listener.class">Zikula\Bundle\CoreBundle\EventListener\InitListener</parameter>
+        <!-- class does not exist! --><parameter key="zikula_core.class">Zikula\Core\Core</parameter>
+        <!-- class does not exist! --><parameter key="zikula.core_init_listener.class">Zikula\Bundle\CoreBundle\EventListener\InitListener</parameter>
 
-        <parameter key="zikula.site_off_listener.class">Zikula\Bundle\CoreBundle\EventListener\SiteOffListener</parameter>
-        <parameter key="zikula.session_expire_listener.class">Zikula\Bundle\CoreBundle\EventListener\SessionExpireListener</parameter>
+        <!-- class does not exist! --><parameter key="zikula.site_off_listener.class">Zikula\Bundle\CoreBundle\EventListener\SiteOffListener</parameter>
+        <!-- class does not exist! --><parameter key="zikula.session_expire_listener.class">Zikula\Bundle\CoreBundle\EventListener\SessionExpireListener</parameter>
         <parameter key="zikula.legacy_route_listener.class">Zikula\Bundle\CoreBundle\EventListener\LegacyRouteListener</parameter>
         <parameter key="zikula.theme_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeListener</parameter>
         <parameter key="router_listener.class">Zikula\Bundle\CoreBundle\EventListener\RouterListener</parameter>


### PR DESCRIPTION
**This is not intended to ever actually be pulled**, so I am not including the proper header.

This is just to highlight that several classes that are referenced in the `config/core.xml` file are missing. So I was hoping for an explanation from @drak or @cmfcmf (or anyone that knows)

I discovered this when attempting to look into the problem of https://github.com/zikula/core/issues/1680 _('Disable Site' does not work correctly)_
