### PR TITLE
Add vendor libraries in javascript folder - proof of concept.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "src/javascript"
+}

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,10 @@
+{
+    "name": "zikula",
+    "authors": [
+        "Zikula"
+    ],
+    "private": true,
+    "dependencies": {
+        "select2": "latest"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "zikula/jquery-bundle": "dev-master",
         "zikula/jquery-ui-bundle": "dev-master",
         "zikula/bootstrap-bundle": "dev-master",
-        "zikula/fontawesome-bundle": "dev-master"
+        "zikula/fontawesome-bundle": "dev-master",
+        "beelab/bowerphp": "dev-master@dev"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
This PR shows how to install bower components to the javascript folder. I just picked some random ones, without any version specification, as this is only a proof of concept.

You need to run:

```
composer update
php bin/bowerphp install
```

This downloads select2 into the javascript folder.
