### PR TITLE
move SiteOffListener to own Class.

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/LegacyRouteListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/LegacyRouteListener.php
@@ -223,30 +223,6 @@ class LegacyRouteListener implements EventSubscriberInterface
         }
     }
 
-    public function onKernelRequestSiteOff(GetResponseEvent $event)
-    {
-        $request = $event->getRequest();
-        // Get variables
-        $module = $request->attributes->get('_module');
-        $type = $request->attributes->get('_type');
-        $func = $request->attributes->get('_func');
-
-        // Check for site closed
-        if (\System::getVar('siteoff')
-            && !\SecurityUtil::checkPermission('ZikulaSettingsModule::', 'SiteOff::', ACCESS_ADMIN)
-            && !($module == 'Users' && $type == 'user' && $func == 'siteOffLogin')
-            || (\Zikula_Core::VERSION_NUM != \System::getVar('Version_Num'))
-        ) {
-            if (\SecurityUtil::checkPermission('ZikulaUsersModule::', '::', ACCESS_OVERVIEW) && \UserUtil::isLoggedIn()
-            ) {
-                \UserUtil::logout();
-            }
-            header('HTTP/1.1 503 Service Unavailable');
-            require_once \System::getSystemErrorTemplate('siteoff.tpl');
-            exit;
-        }
-    }
-
     public function onKernelRequestSessionExpire(GetResponseEvent $event)
     {
         if (\SessionUtil::hasExpired()) {
@@ -261,7 +237,6 @@ class LegacyRouteListener implements EventSubscriberInterface
     {
         return array(
             KernelEvents::REQUEST => array(
-                array('onKernelRequestSiteOff', 31),
                 array('onKernelRequestSessionExpire', 31),
                 array('onKernelRequest', 31),
             )

--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/SiteOffListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/SiteOffListener.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright Zikula Foundation 2014 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Util
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+namespace Zikula\Bundle\CoreBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SiteOffListener implements EventSubscriberInterface
+{
+
+    public function onKernelRequestSiteOff(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        // Get variables
+        $module = $request->attributes->get('_module');
+        $type = $request->attributes->get('_type');
+        $func = $request->attributes->get('_func');
+        $siteOff = (bool)\System::getVar('siteoff');
+        $hasAdminPerms = \SecurityUtil::checkPermission('ZikulaSettingsModule::', 'SiteOff::', ACCESS_ADMIN);
+        $urlParams = ($module == 'users' && $type == 'user' && $func == 'siteofflogin'); // params are lowercase
+        $versionCheck = (\Zikula_Core::VERSION_NUM != \System::getVar('Version_Num'));
+
+        // Check for site closed
+        if (($siteOff && !$hasAdminPerms && !$urlParams) || $versionCheck) {
+            $hasOnlyOverviewAccess = \SecurityUtil::checkPermission('ZikulaUsersModule::', '::', ACCESS_OVERVIEW);
+            if ($hasOnlyOverviewAccess && \UserUtil::isLoggedIn()) {
+                \UserUtil::logout();
+            }
+            header('HTTP/1.1 503 Service Unavailable');
+            require_once \System::getSystemErrorTemplate('siteoff.tpl');
+            exit;
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array(
+                array('onKernelRequestSiteOff', 31),
+            )
+        );
+    }
+
+}

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
@@ -106,6 +106,10 @@
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
+        <service id="zikula.site_off_listener" class="%zikula.site_off_listener.class%">
+            <tag name="kernel.event_subscriber" />
+        </service>
+
         <service id="zikula.theme_listener" class="%zikula.theme_listener.class%">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />


### PR DESCRIPTION
 refs #1698 This also corrects a non-working admin login when site was closed. Also makes the code a little easier to read in the Listener in order to debug.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | #1698 |
| License | MIT |
| Doc PR | - |
