### PR TITLE
move sessionEpireListener to own class.

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/LegacyRouteListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/LegacyRouteListener.php
@@ -223,21 +223,10 @@ class LegacyRouteListener implements EventSubscriberInterface
         }
     }
 
-    public function onKernelRequestSessionExpire(GetResponseEvent $event)
-    {
-        if (\SessionUtil::hasExpired()) {
-            // Session has expired, display warning
-            $response = new Response(\ModUtil::apiFunc('ZikulaUsersModule', 'user', 'expiredsession', 403));
-            //$response = \Zikula_View_Theme::getInstance()->themefooter($response);
-            $this->setResponse($event, $response);
-        }
-    }
-
     public static function getSubscribedEvents()
     {
         return array(
             KernelEvents::REQUEST => array(
-                array('onKernelRequestSessionExpire', 31),
                 array('onKernelRequest', 31),
             )
         );

--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/SessionExpireListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/SessionExpireListener.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright Zikula Foundation 2014 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Util
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+namespace Zikula\Bundle\CoreBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class SessionExpireListener implements EventSubscriberInterface
+{
+    public function onKernelRequestSessionExpire(GetResponseEvent $event)
+    {
+        if (\SessionUtil::hasExpired()) {
+            // Session has expired, display warning
+            $response = new Response(\ModUtil::apiFunc('ZikulaUsersModule', 'user', 'expiredsession', 403));
+            $this->setResponse($event, $response);
+        }
+    }
+
+    private function setResponse(GetResponseEvent $event, Response $response)
+    {
+        $response->legacy = true;
+        $event->setResponse($response);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array(
+                array('onKernelRequestSessionExpire', 31),
+            )
+        );
+    }
+}

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
@@ -6,8 +6,8 @@
 
     <parameters>
         <parameter key="zikula.theme_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeListener</parameter>
-        <parameter key="zikula.themeinit_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeInitListener</parameter>
-        <parameter key="zikula.system_listener.class">Zikula\Bundle\CoreBundle\EventListener\SystemListener</parameter>
+        <!--<parameter key="zikula.themeinit_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeInitListener</parameter>-->
+        <!--<parameter key="zikula.system_listener.class">Zikula\Bundle\CoreBundle\EventListener\SystemListener</parameter>-->
         <parameter key="zikula.template_override_listener.class">Zikula\Bundle\CoreBundle\EventListener\TemplateOverrideYamlListener</parameter>
 
         <parameter key="zikula.doctrine1_connector.class">Zikula\Bundle\CoreBundle\EventListener\Doctrine1ConnectorListener</parameter>
@@ -26,8 +26,8 @@
         <parameter key="markdown.class">Michelf\Markdown</parameter>
         <parameter key="markdown_extra.class">Michelf\MarkdownExtra</parameter>
 
-        <parameter key="zikula_core.class">Zikula\Core\Core</parameter>
-        <parameter key="zikula.core_init_listener.class">Zikula\Bundle\CoreBundle\EventListener\InitListener</parameter>
+        <!--<parameter key="zikula_core.class">Zikula\Core\Core</parameter>-->
+        <!--<parameter key="zikula.core_init_listener.class">Zikula\Bundle\CoreBundle\EventListener\InitListener</parameter>-->
 
         <parameter key="zikula.site_off_listener.class">Zikula\Bundle\CoreBundle\EventListener\SiteOffListener</parameter>
         <parameter key="zikula.session_expire_listener.class">Zikula\Bundle\CoreBundle\EventListener\SessionExpireListener</parameter>
@@ -107,6 +107,10 @@
         </service>
 
         <service id="zikula.site_off_listener" class="%zikula.site_off_listener.class%">
+            <tag name="kernel.event_subscriber" />
+        </service>
+
+        <service id="zikula.session_expire_listener" class="%zikula.session_expire_listener.class%">
             <tag name="kernel.event_subscriber" />
         </service>
 


### PR DESCRIPTION
move sessionEpireListener to own class. refs #1698
also comment out unused parameters in `core.xml`

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | #1698 |
| License | MIT |
| Doc PR | - |
