### PR TITLE
Fixed references to removed mobile theme in theme footers. refs #1708

### DIFF
--- a/src/themes/Zikula/Theme/Andreas08Theme/Resources/views/includes/footer.tpl
+++ b/src/themes/Zikula/Theme/Andreas08Theme/Resources/views/includes/footer.tpl
@@ -1,5 +1,5 @@
                 <div id="theme_footer">
-                    <p>{gt text="Powered by"} <a href="http://zikula.org">Zikula</a>{if $modvars.ZikulaThemeModule.enable_mobile_theme} | <a href="{modurl modname='ZikulaThemeModule' type='User' func='enableMobileTheme'}">{gt text="Mobile version"}</a>{/if}</p>
+                    <p>{gt text="Powered by"} <a href="http://zikula.org">Zikula</a></p>
                     {nocache}{pagerendertime}{/nocache}
                 </div>
             </div>

--- a/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/includes/footer.tpl
+++ b/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/includes/footer.tpl
@@ -1,7 +1,7 @@
        <div class="container">
             <hr />
             <footer>
-                <p>{gt text="Powered by"} <a href="http://zikula.org">Zikula</a>{if $modvars.ZikulaThemeModule.enable_mobile_theme} | <a href="{modurl modname='ZikulaThemeModule' type='User' func='enableMobileTheme'}">{gt text="Mobile version"}</a>{/if}</p>
+                <p>{gt text="Powered by"} <a href="http://zikula.org">Zikula</a></p>
                 {nocache}{pagerendertime}{/nocache}
             </footer>
         </div> <!-- /container -->


### PR DESCRIPTION
This PR removes references to the mobile theme in two theme footers.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| Refs tickets | #1708 |
| License | MIT |
| Doc PR |  |
