### PR TITLE
fix scanning for psr-0/psr-4 type modules for admin capabilities.

### DIFF
--- a/src/system/Zikula/Module/ExtensionsModule/Api/AdminApi.php
+++ b/src/system/Zikula/Module/ExtensionsModule/Api/AdminApi.php
@@ -550,7 +550,6 @@ class AdminApi extends \Zikula_AbstractApi
 
                     // loads the gettext domain for 3rd party modules
                     if (is_dir("modules/$dir/locale"))  {
-                        // psr-4 evaluates to true here
                         ZLanguage::bindModuleDomain($dir);
                     }
 


### PR DESCRIPTION
fixes #1679 Also correct some general module scan issues and make sure translation domain is loaded with correct key.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1679 |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |
