### PR TITLE
[1.3.x Blocks] Updated Blocks module for HtmlBlock editor hooking

### DIFF
--- a/src/system/Blocks/lib/Blocks/Installer.php
+++ b/src/system/Blocks/lib/Blocks/Installer.php
@@ -84,6 +84,9 @@ class Blocks_Installer extends Zikula_AbstractInstaller
                 $query->getResult();
 
             case '3.8.1':
+                // register ui_hooks for HTML block editing
+                HookUtil::registerSubscriberBundles($this->version->getHookSubscriberBundles());
+            case '3.8.2':
                 // future upgrade routines
         }
 

--- a/src/system/Blocks/lib/Blocks/Version.php
+++ b/src/system/Blocks/lib/Blocks/Version.php
@@ -20,14 +20,36 @@ class Blocks_Version extends Zikula_AbstractVersion
         $meta['displayname']    = $this->__('Blocks');
         $meta['description']    = $this->__('Block administration module.');
         $meta['url']            = $this->__('blocks');
-        $meta['version']        = '3.8.1';
+        $meta['version']        = '3.8.2';
+        $meta['capabilities']   = array(HookUtil::SUBSCRIBER_CAPABLE => array('enabled' => true));
         $meta['securityschema'] = array(
             'Blocks::' => 'Block key:Block title:Block ID',
             'Blocks::position' => 'Position name::Position ID',
             'Menutree:menutreeblock:' => 'Block ID:Link Name:Link ID',
             'ExtendedMenublock::' => 'Block ID:Link ID:');
+        // Module depedencies
+        $meta['dependencies'] = array(
+            array('modname'    => 'Scribite',
+                'minversion' => '5.0.0',
+                'maxversion' => '',
+                'status'     => ModUtil::DEPENDENCY_RECOMMENDED),
+        );
 
         return $meta;
     }
 
+    /**
+     * Set up hook subscriber bundle
+     *
+     * This area is only activated when editing an Html Block.
+     * There are no other hook functions currently implemented since linking
+     * back (via url) to a block is impossible.
+     */
+    protected function setupHookBundles()
+    {
+        // Register ui hooks for html contenttype. This enables Scribite 5 connection
+        $bundle = new Zikula_HookManager_SubscriberBundle($this->name, 'subscriber.blocks.ui_hooks.htmlblock.content', 'ui_hooks', $this->__('HTML Block content hook'));
+        $bundle->addEvent('form_edit', 'blocks.ui_hooks.htmlblock.content.form_edit');
+        $this->registerHookSubscriberBundle($bundle);
+    }
 }

--- a/src/system/Blocks/templates/blocks_admin_modify.tpl
+++ b/src/system/Blocks/templates/blocks_admin_modify.tpl
@@ -129,6 +129,9 @@
                 <textarea id="blocks_content" name="content" cols="50" rows="10">{$content|safetext}</textarea>
             </div>
         </fieldset>
+        {if $bkey eq "Html"}{* notify hooks here strictly for html block *}
+        {notifydisplayhooks eventname='blocks.ui_hooks.htmlblock.content.form_edit' id=$bid}
+        {/if}
         {/if}
 
         {if $blockoutput neq ''}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | #1726 |
| Refs tickets | https://github.com/zikula/core/pull/1741 |
| License | MIT |
| Doc PR | - |

Updated the Blocks System module for the 1.3.x branch with a new version and Hook enabling which makes usage of Scribite 5 possible. Hooks for the HTML block could have been there already, but in previous version of Scribite this worked also by manually activating Scribite.
