### PR TITLE
The module name should not be passed as a hard-coded value

### DIFF
--- a/src/system/Zikula/Module/ExtensionsModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/ExtensionsModule/Controller/AdminController.php
@@ -732,7 +732,7 @@ class AdminController extends \Zikula_AbstractController
             }
 
             // Clear the Zikula_View cached/compiled files and Themes cached/compiled/cssjs combination files
-            $theme = Zikula_View_Theme::getInstance('ZikulaThemeModule');
+            $theme = Zikula_View_Theme::getInstance();
             $theme->clear_compiled();
             $theme->clear_all_cache();
             $theme->clear_cssjscombinecache();


### PR DESCRIPTION
The module name should not be passed as a hard-coded value, since it is not a valid theme name. Refs. https://github.com/zikula/core/issues/1816

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |
