### PR TITLE
Setting InnoDB as the default storage engine for MySQL.

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -24,9 +24,9 @@ $ZConfig['DBInfo']['databases']['default']['user'] = 'root';
 $ZConfig['DBInfo']['databases']['default']['password'] = '';
 $ZConfig['DBInfo']['databases']['default']['dbname'] = 'test';
 $ZConfig['DBInfo']['databases']['default']['dbdriver'] = 'mysql';
-$ZConfig['DBInfo']['databases']['default']['dbtabletype'] = 'myisam';
+$ZConfig['DBInfo']['databases']['default']['dbtabletype'] = 'innodb';
 $ZConfig['DBInfo']['databases']['default']['charset'] = 'utf8';
-$ZConfig['DBInfo']['databases']['default']['collate'] = 'utf8_general_ci';
+$ZConfig['DBInfo']['databases']['default']['collate'] = 'utf8_unicode_ci';
 // additional DB can be configured here as above external2, external3 etc...
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

http://dev.mysql.com/doc/refman/5.5/en/innodb-default-se.html

"In previous versions of MySQL, MyISAM was the default storage engine. In our experience, most users never changed the default settings. With MySQL 5.5, InnoDB becomes the default storage engine. Again, we expect most users will not change the default settings. But, because of InnoDB, the default settings deliver the benefits users expect from their RDBMS: ACID Transactions, Referential Integrity, and Crash Recovery."
