### PR TITLE
Correctly set request context before matching routes

### DIFF
--- a/src/lib/util/System.php
+++ b/src/lib/util/System.php
@@ -664,6 +664,9 @@ class System
         }
 
         // Try to match a route first.
+        // Make sure we have the correct request context.
+        $requestContext = ServiceUtil::get('router.request_context');
+        $requestContext->fromRequest($request);
         /** @var \Symfony\Component\Routing\Matcher\RequestMatcherInterface $router */
         $router = ServiceUtil::get('router');
         try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | --- |
| Fixed tickets | --- |
| Refs tickets | --- |
| License | MIT |
| Doc PR | --- |

(cannot be done via EventListener on KERNEL_REQUEST, as the method is called in Core::init() and therefore before Symfony)
