### PR TITLE
Mailer module - set proper content type

### DIFF
--- a/src/system/Zikula/Module/MailerModule/Api/UserApi.php
+++ b/src/system/Zikula/Module/MailerModule/Api/UserApi.php
@@ -168,7 +168,7 @@ class UserApi extends \Zikula_AbstractApi
             $bodyFormat = 'text/plain';
         }
         $message->setBody($args['body']);
-        $message->setFormat($bodyFormat);
+        $message->setContentType($bodyFormat);
         if (!empty($args['altbody'])) {
             $message->addPart($args['altbody'], 'text/plain');
         }


### PR DESCRIPTION
This PR fixes wrong method used to set Content type for HTML emails.
All mail sent, for example in user registration process, was plane, even they are with HTML content. Now this is fixed.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |
