### PR TITLE
[1.3.x] updated core.css - added some z-w widths

### DIFF
--- a/src/style/core.css
+++ b/src/style/core.css
@@ -764,11 +764,13 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
 * Widths styles
 ******************************************************************************/
 
+.z-w100 { width: 100%; }
 .z-w90 { width: 90%; }
 .z-w85 { width: 85%; }
 .z-w80 { width: 80%; }
 .z-w75 { width: 75%; }
 .z-w70 { width: 70%; }
+.z-w68 { width: 68%; }
 .z-w66 { width: 66%; }
 .z-w60 { width: 60%; }
 .z-w50 { width: 50%; }
@@ -777,6 +779,7 @@ button.z-imagebutton, /* Buttons in inline 'ajax' forms */
 .z-w40 { width: 40%; }
 .z-w35 { width: 35%; }
 .z-w33 { width: 33%; }
+.z-w32 { width: 32%; }
 .z-w30 { width: 30%; }
 .z-w25 { width: 25%; }
 .z-w22 { width: 22%; }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes minor |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

Added some extra widths in the core.css. 100% was missing as z-w100 specification to keep it consistent and 68/32 as golden rule was missing. That is being used quite a bit in Content as width division.
