### PR TITLE
[1.3.x] Users account.php updated to avoid E_WARNING

### DIFF
--- a/src/system/Users/lib/Users/Api/Account.php
+++ b/src/system/Users/lib/Users/Api/Account.php
@@ -53,13 +53,15 @@ class Users_Api_Account extends Zikula_AbstractApi
         }
 
         // check if the users block exists
-        $blocks = ModUtil::apiFunc('Blocks', 'user', 'getAll');
+        $blocks = ModUtil::apiFunc('Blocks', 'user', 'getall');
         $usersModuleID = ModUtil::getIdFromName($this->name);
         $found = false;
-        foreach ($blocks as $block) {
-            if (($block['mid'] == $usersModuleID) && ($block['bkey'] == 'user')) {
-                $found = true;
-                break;
+        if (is_array($blocks)) {
+            foreach ($blocks as $block) {
+                if (($block['mid'] == $usersModuleID) && ($block['bkey'] == 'user')) {
+                    $found = true;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |

Going to the Users panel (http://localhost:8888/zk138/Users) in the current Zikula 1.3.x gives the following E_WARNING on PHP 5.4.10. 

WARN (4): E_WARNING: Invalid argument supplied for foreach() in /Volumes/DATA_ES/MAMP_htdocs/zk138/system/Users/lib/Users/Api/Account.php line 59

I've adapted that line to make sure an extra check is done on the existence of an array variable. That removes the E_WARNING. Also the method call to Blocks api getAll was with a capital, where the method in Blocks is not.
