### PR TITLE
Added array_column replacement for PHP < 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
+        "rhumsaa/array_column": "~1.1",
         "beberlei/DoctrineExtensions": "dev-master",
         "doctrine/doctrine-bundle": "~1.2",
         "doctrine/orm": ">=2.2.3,<2.5-dev",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | --- |
| Fixed tickets | --- |
| Refs tickets | --- |
| License | MIT |
| Doc PR | --- |

This adds support for `array_column` to PHP <5.5. Read more about the `array_column` function in the PHP manual: http://php.net/manual/en/function.array-column.php.

I personally find it extremely useful and would like to see it in the core.
