### PR TITLE
[1.3.x] Updated DBUtil for OrderBy and table prefix

### DIFF
--- a/src/lib/util/DBUtil.php
+++ b/src/lib/util/DBUtil.php
@@ -1399,6 +1399,8 @@ class DBUtil
                             $hasMath = (bool)(strcmp($fullColumnName, str_replace($search, $replace, $fullColumnName)));
                             if ($hasMath) {
                                 $fullColumnName = "'$left'";
+                            } elseif (!$hasTablePrefix) {
+                                $fullColumnName = "tbl.$fullColumnName";
                             }
                         } else {
                             if (!$hasTablePrefix) {


### PR DESCRIPTION
ZWebstore uses this function and ordering of products is not working without this small update. It's an extra check for table prefix in the column checking. Not checked in 1.4.x. yet.

I have checked with other modules using DBUtil as well (e.g. Content), and there no problems arise due to this small change.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |
