### PR TITLE
create a simpler method of handling the BC ModUrl issue

### DIFF
--- a/src/lib/Zikula/Core/ModUrl.php
+++ b/src/lib/Zikula/Core/ModUrl.php
@@ -16,7 +16,6 @@
 namespace Zikula\Core;
 
 use Symfony\Component\Routing\RouterInterface;
-use ZLanguage;
 
 /**
  * Url class.


### PR DESCRIPTION
A simpler method of dealing with this issue. I think this is all the changes that would need to be made. All BC would continue to work and new modules could simply use the Route based side of ModUrl

``` php
        $aUrl = new ModUrl();
        $aUrl->setRoute('zikuladizkusmodule_user_viewforum', array('forum' => 2));
        $bUrl = new ModUrl($this->name, 'user', 'viewforum', null, array('forum' => 2));
        $a = $aUrl->getUrl();
        $b = $bUrl->getUrl();
        var_dump($a, $b);
```

outputs:

> string(28) "/core.git/src/forums/forum/2" string(28) "/core.git/src/forums/forum/2"

ping @cmfcmf @Guite @drak 

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | #1945, #1940, #1937, #1947 |
| License | MIT |
| Doc PR | - |
