### PR TITLE
Fix checkPermission problem

### DIFF
--- a/src/lib/util/SecurityUtil.php
+++ b/src/lib/util/SecurityUtil.php
@@ -352,10 +352,10 @@ class SecurityUtil
             return $groupperms;
         }
 
-        static $usergroups = array();
+        $usergroups = array();
         if (!$usergroups) {
             $usergroups[] = -1;
-            if (!UserUtil::isLoggedIn()) {
+            if ($vars['Active User'] == 'unregistered') {
                 $usergroups[] = 0; // Unregistered GID
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| 1.4 PR | I think a 1.4PR is necessary but I cannot test it at the moment. |
| Refs tickets | - |
| License | LGPLv3+ |
| Doc PR | - |

This little patch fixes the call SecurityUtil::checkPermission($component, $instance, $level, $user != 0) for the case the user is NOT logged in. It used always the rules for unregistered users.
