### PR TITLE
add listener to strip front controller from routes. refs #1978

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/StripFrontControllerListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/StripFrontControllerListener.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Copyright Zikula Foundation 2014 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+namespace Zikula\Bundle\CoreBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Strip the Front Controller (index.php) from the URI
+ */
+class StripFrontControllerListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array(
+                array('onKernelRequest', 1023),
+            )
+        );
+    }
+
+    /**
+     * Strip the Front Controller (index.php) from the URI
+     *
+     * @param GetResponseEvent $event An GetResponseEvent instance
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $requestUri = $event->getRequest()->getRequestUri();
+        $frontController = \System::getVar('entrypoint', 'index.php');
+        $stripEntryPoint = (bool) \System::getVar('shorturlsstripentrypoint', false);
+        $containsFrontController = (strpos($requestUri, "$frontController/") !== false);
+
+        if ($containsFrontController && $stripEntryPoint) {
+            $url = str_ireplace("$frontController/", "", $requestUri);
+            $response = new RedirectResponse($url, 301);
+            $event->setResponse($response);
+            $event->stopPropagation();
+        }
+    }
+}

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
@@ -34,6 +34,7 @@
         <parameter key="zikula.legacy_route_listener.class">Zikula\Bundle\CoreBundle\EventListener\LegacyRouteListener</parameter>
         <parameter key="router_listener.class">Zikula\Bundle\CoreBundle\EventListener\RouterListener</parameter>
         <parameter key="zikula.exception_listener.class">Zikula\Bundle\CoreBundle\EventListener\ExceptionListener</parameter>
+        <parameter key="zikula.strip_front_controller_listener.class">Zikula\Bundle\CoreBundle\EventListener\StripFrontControllerListener</parameter>
     </parameters>
 
     <services>
@@ -136,5 +137,10 @@
             <argument type="service" id="logger" on-invalid="ignore" />
             <argument type="service" id="router" />
         </service>
+
+        <service id="zikula.strip_front_controller_listener" class="%zikula.strip_front_controller_listener.class%">
+            <tag name="kernel.event_subscriber" />
+        </service>
+
     </services>
 </container>


### PR DESCRIPTION
I don't know if this is the best way to solve this.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | #1978 |
| License | MIT |
| Doc PR | - |

I considered a custom route that would redirect to a route without the FC. It didn't work as I expected so I abandoned that approach.

I am still having some issues with the News module and the setting to 'strip entry point' set to false - but only locally - it seems to work fine when I test at zikula.org. So it must be something local that is the problem.
