### PR TITLE
move Listener to container on load for theme overrides and set priority.

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/ConfigTemplateOverrideYamlListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/ConfigTemplateOverrideYamlListener.php
@@ -20,12 +20,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 /**
  * Event handler to override templates.
  */
-class TemplateOverrideYamlListener implements EventSubscriberInterface
+class ConfigTemplateOverrideYamlListener implements EventSubscriberInterface
 {
     /**
      * Associative array.
      *
-     * Maps template path to overriden path.
+     * Maps template path to overridden path.
      *
      * @var array
      */
@@ -55,6 +55,8 @@ class TemplateOverrideYamlListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return array('zikula_view.template_override' => array('handler', 5));
+        // weight as 4 sets theme overrides taking precedent over config overrides
+        // @see \Zikula\Bundle\CoreBundle\EventListener\ThemeTemplateOverrideYamlListener
+        return array('zikula_view.template_override' => array('handler', 4));
     }
 }

--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/ThemeTemplateOverrideYamlListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/ThemeTemplateOverrideYamlListener.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright 2010 Zikula Foundation
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+namespace Zikula\Bundle\CoreBundle\EventListener;
+
+use Zikula\Core\Event\GenericEvent;
+use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event handler to override templates.
+ */
+class ThemeTemplateOverrideYamlListener implements EventSubscriberInterface
+{
+    /**
+     * Associative array.
+     *
+     * Maps template path to overriden path.
+     *
+     * @var array
+     */
+    private $overrideMap = array();
+
+    public function __construct()
+    {
+        $themeName = \UserUtil::getTheme();
+        $theme = \ThemeUtil::getTheme($themeName);
+        if (null !== $theme && is_readable($path = $theme->getConfigPath() . '/overrides.yml')) {
+            // bundle type theme
+            $this->overrideMap = Yaml::parse($path);
+        } else if (is_readable("themes/$themeName/templates/overrides.yml")) {
+            // pre-1.4.0 style theme
+            $this->_overrideMap = Yaml::parse("themes/$themeName/templates/overrides.yml");
+        }
+    }
+
+    /**
+     * Listens for 'zikula_view.template_override' events.
+     *
+     * @param GenericEvent $event Event handler.
+     *
+     * @return void
+     */
+    public function handler(GenericEvent $event)
+    {
+        if (array_key_exists($event->data, $this->overrideMap)) {
+            $event->data = $this->overrideMap[$event->data];
+            $event->stopPropagation();
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        // weight as 5 sets theme overrides taking precedent over config overrides
+        // @see \Zikula\Bundle\CoreBundle\EventListener\ConfigTemplateOverrideYamlListener
+        return array('zikula_view.template_override' => array('handler', 5));
+    }
+}

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
@@ -8,7 +8,8 @@
         <parameter key="zikula.theme_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeListener</parameter>
         <!--<parameter key="zikula.themeinit_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeInitListener</parameter>-->
         <!--<parameter key="zikula.system_listener.class">Zikula\Bundle\CoreBundle\EventListener\SystemListener</parameter>-->
-        <parameter key="zikula.template_override_listener.class">Zikula\Bundle\CoreBundle\EventListener\TemplateOverrideYamlListener</parameter>
+        <parameter key="zikula.config_template_override_listener.class">Zikula\Bundle\CoreBundle\EventListener\ConfigTemplateOverrideYamlListener</parameter>
+        <parameter key="zikula.theme_template_override_listener.class">Zikula\Bundle\CoreBundle\EventListener\ThemeTemplateOverrideYamlListener</parameter>
 
         <parameter key="zikula.doctrine1_connector.class">Zikula\Bundle\CoreBundle\EventListener\Doctrine1ConnectorListener</parameter>
         <parameter key="zikula.doctrine_connector.class">Zikula\Bundle\CoreBundle\EventListener\DoctrineListener</parameter>
@@ -97,7 +98,11 @@
             <!--<argument type="service" id="service_container" />-->
         <!--</service>-->
 
-        <service id="zikula.template_override_listener" class="%zikula.template_override_listener.class%">
+        <service id="zikula.config_template_override_listener" class="%zikula.config_template_override_listener.class%">
+            <tag name="kernel.event_subscriber" />
+        </service>
+
+        <service id="zikula.theme_template_override_listener" class="%zikula.theme_template_override_listener.class%">
             <tag name="kernel.event_subscriber" />
         </service>
 

--- a/src/lib/legacy/Zikula/View/Theme.php
+++ b/src/lib/legacy/Zikula/View/Theme.php
@@ -181,14 +181,6 @@ class Zikula_View_Theme extends Zikula_View
 
         EventUtil::attachCustomHandlers("themes/$themeName/EventHandlers");
         EventUtil::attachCustomHandlers("themes/$themeName/lib/$themeName/EventHandlers");
-        $themeBundle = ThemeUtil::getTheme($themeName);
-        if (null !== $themeBundle && is_readable($yaml = $themeBundle->getPath().'/Resources/config/overrides.yml')) {
-            $this->getDispatcher()->addListener('zikula_view.template_override', array($this, '_templateOverride'), 0);
-            $this->_overrideMap = Yaml::parse($yaml);
-        } else if (is_readable("themes/$themeName/templates/overrides.yml")) {
-            $this->getDispatcher()->addListener('zikula_view.template_override', array($this, '_templateOverride'), 0);
-            $this->_overrideMap = Yaml::parse("themes/$themeName/templates/overrides.yml");
-        }
 
         $event = new \Zikula\Core\Event\GenericEvent($this);
         $this->eventManager->dispatch('theme.preinit', $event);


### PR DESCRIPTION
This is required because Zikula_View_Theme is not initialized until after the Zikula_View renders the module templates. fixes #1783 

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1783 |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |
