### PR TITLE
Update Installer.php

### DIFF
--- a/src/system/Blocks/lib/Blocks/Installer.php
+++ b/src/system/Blocks/lib/Blocks/Installer.php
@@ -35,6 +35,9 @@ class Blocks_Installer extends Zikula_AbstractInstaller
             return false;
         }
 
+        // register ui_hooks for HTML block editing
+        HookUtil::registerSubscriberBundles($this->version->getHookSubscriberBundles());
+                
         // Set a default value for a module variable
         $this->setVar('collapseable', 0);
 


### PR DESCRIPTION
HTML block hook is not registered during a fresh install of Zikula 1.3.9.
Philippe
