### PR TITLE
remove `spool` parameter from swiftmailer config. fixes #1993

### DIFF
--- a/src/app/config/dynamic/default.yml
+++ b/src/app/config/dynamic/default.yml
@@ -14,6 +14,5 @@ swiftmailer:
     port: 25
     encryption: null
     auth_mode: null
-    spool: { type: memory }
     delivery_address: null
     disable_delivery: false

--- a/src/system/Zikula/Module/MailerModule/Form/Handler/ModifyConfigHandler.php
+++ b/src/system/Zikula/Module/MailerModule/Form/Handler/ModifyConfigHandler.php
@@ -132,7 +132,7 @@ class ModifyConfigHandler extends \Zikula_Form_AbstractHandler
                     'encryption' => $this->getFormValue('encryption', null),
                     'auth_mode' => $this->getFormValue('auth_mode', null),
                     // the items below can be configured by modifying the app/config/dynamic/generated.yml file
-                    'spool' => !empty($currentConfig['spool']) ? $currentConfig['spool'] : array('type' => 'memory'),
+//                    'spool' => !empty($currentConfig['spool']) ? $currentConfig['spool'] : array('type' => 'memory'),
                     'delivery_address' => !empty($currentConfig['delivery_address']) ? $currentConfig['delivery_address'] : null,
                     'disable_delivery' => !empty($currentConfig['disable_delivery']) ? $currentConfig['disable_delivery'] : false,
                 );

--- a/src/system/Zikula/Module/MailerModule/MailerModuleInstaller.php
+++ b/src/system/Zikula/Module/MailerModule/MailerModuleInstaller.php
@@ -85,6 +85,12 @@ class MailerModuleInstaller extends \Zikula_AbstractInstaller
                 $configDumper->setConfiguration('swiftmailer', $config);
 
             case '1.4.0':
+                $configDumper = $this->getContainer()->get('zikula.dynamic_config_dumper');
+                $config = $configDumper->getConfiguration('swiftmailer');
+                // remove spool parameter
+                unset($config['spool']);
+                $configDumper->setConfiguration('swiftmailer', $config);
+            case '1.4.1':
             // future upgrade routines
         }
 

--- a/src/system/Zikula/Module/MailerModule/MailerModuleVersion.php
+++ b/src/system/Zikula/Module/MailerModule/MailerModuleVersion.php
@@ -30,7 +30,7 @@ class MailerModuleVersion extends \Zikula_AbstractVersion
         $meta['description']    = $this->__('Mailer module, provides mail API and mail setting administration.');
         //! module name that appears in URL
         $meta['url']            = $this->__('mailer');
-        $meta['version']        = '1.4.0';
+        $meta['version']        = '1.4.1';
         $meta['core_min']       = '1.4.0';
 
         $meta['securityschema'] = array('ZikulaMailerModule::' => '::');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1993 |
| Refs tickets | - |
| License | MIT |
| Doc PR | - |
