### PR TITLE
remove all exception handling from legacyRouteListener. 

### DIFF
--- a/src/app/Resources/TwigBundle/views/Exception/error.html.twig
+++ b/src/app/Resources/TwigBundle/views/Exception/error.html.twig
@@ -4,4 +4,5 @@
         <div>
             Something is broken. Please let us know what you were doing when this error occurred.
             We will fix it as soon as possible. Sorry for any inconvenience caused.
-        </div>
+        </div><br />
+        <div class="alert alert-warning">{{ exception.message }}</div>

--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/ExceptionListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/ExceptionListener.php
@@ -72,6 +72,9 @@ class ExceptionListener implements EventSubscriberInterface
             }
             // list and handle additional exceptions here
         } while (null !== $exception = $exception->getPrevious());
+
+        // force all exception to render in BC theme (remove in 2.0.0)
+        $event->getRequest()->attributes->set('_legacy', true);
     }
 
     /**


### PR DESCRIPTION
Forces all Exceptions to be handled by the same Listener (\Zikula\Bundle\CoreBundle\EventListener\ExceptionListener) refs #1789

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | #1789 |
| License | MIT |
| Doc PR | - |
