### PR TITLE
Ensure ajax type is set for legacy calls

### DIFF
--- a/src/ajax.php
+++ b/src/ajax.php
@@ -15,5 +15,5 @@
 /**
  * @deprecated remove in 2.0
  */
+$_GET['type'] = 'ajax';
 include 'index.php';
-


### PR DESCRIPTION
This sets type=ajax for all legacy requests using ajax.php as entrypoint.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| Refs tickets | #1586 |
| License | MIT |
| Doc PR | - |
