### PR TITLE
[POC] Install Legal module via composer WHEN BUILDING Zikula

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -89,6 +89,9 @@
         <mkdir dir="${builddir}/tmp"/>
         <mkdir dir="${builddir}/jsdoc"/>
         <exec command="curl -s https://getcomposer.org/installer | php;mv composer.phar ${workspace}/source"/>
+        <!-- Add any modules to install below -->
+        <exec command="${workspace}/source/composer.phar require --no-update zikula/legal-module:dev-master"/>
+        <!-- Install dependencies -->
         <exec command="${workspace}/source/composer.phar install --prefer-dist --no-scripts"/>
     </target>
 
@@ -98,10 +101,6 @@
         <!-- ATTN export urls require manual edit -->
 
         <exec command="cp -a ${workspace}/source/src ${packagepath}"/>
-
-        <exec command="svn export https://github.com/zikula-modules/Legal/branches/master
- ${builddir}/tmp/Legal"/>
-        <exec command="mv ${builddir}/tmp/Legal ${packagepath}/modules"/>
 
         <exec command="svn export https://github.com/zikula-modules/Profile/branches/master
  ${builddir}/tmp/Profile"/>

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
         "bootstrap-plus/bootstrap-jqueryui": "dev-master",
         "bassjobsen/bootstrap-3-typeahead": "dev-master",
         "vakata/jstree": "dev-master",
-        "afarkas/html5shiv": "*"
+        "afarkas/html5shiv": "*",
+        "composer/installers": "~1.0"
     },
     "scripts": {
         "post-install-cmd": [
@@ -88,6 +89,15 @@
     },
     "extra": {
         "symfony-app-dir": "src/app",
-        "symfony-web-dir": "src/web"
-    }
+        "symfony-web-dir": "src/web",
+        "installer-paths": {
+            "src/modules/{$vendor}/{$name}": ["type:zikula-module"]
+        }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/zikula-modules/Legal"
+        }
+    ]
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | --- |
| Fixed tickets | --- |
| Refs tickets | --- |
| License | MIT |
| Doc PR | --- |

This is a proof of concept which shows how to install Zikula modules via composer **when building Zikula**. With this PR, the newest version of the Legal module always is installed when Zikula is built. 
The `repositories` section at the bottom is needed, because the Legal module is not yet available at Packagist.
