### PR TITLE
[Core] fix symfony-service-definiton-validator version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "friendsofsymfony/jsrouting-bundle": "~1.5",
         "gedmo/doctrine-extensions": "dev-master",
         "imagine/Imagine": "dev-master",
-        "matthiasnoback/symfony-service-definition-validator": "dev-master",
+        "matthiasnoback/symfony-service-definition-validator": "~1.2,>=1.2.1",
         "michelf/php-markdown": "1.4.*@dev",
         "phpids/phpids": "dev-master",
         "sensio/distribution-bundle": "dev-master",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #2143 |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |

Update the `matthiasnoback/symfony-service-definition-validator`
dependency to a version that supports the new factory syntax introduced
in Symfony 2.6.
