### PR TITLE
mbstring.internal_encoding - This feature has been deprecated as of PHP 5.6.0.

### DIFF
--- a/src/jcss.php
+++ b/src/jcss.php
@@ -13,7 +13,19 @@
  */
 
 include 'lib/bootstrap.php';
-ini_set('mbstring.internal_encoding', 'UTF-8');
+
+/**
+ * mbstring.internal_encoding
+ *
+ * This feature has been deprecated as of PHP 5.6.0. Relying on this feature is highly discouraged.
+ * PHP 5.6 and later users should leave this empty and set default_charset instead.
+ *
+ * @link http://php.net/manual/en/mbstring.configuration.php#ini.mbstring.internal-encoding
+ */
+if (version_compare(\PHP_VERSION, '5.6.0', '<')) {
+    ini_set('mbstring.internal_encoding', 'UTF-8'); 
+}
+
 ini_set('default_charset', 'UTF-8');
 global $ZConfig;
 $f = (isset($_GET['f']) ? filter_var($_GET['f'], FILTER_SANITIZE_STRING) : false);

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Util/ControllerUtil.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Util/ControllerUtil.php
@@ -48,7 +48,7 @@ class ControllerUtil
         if (!function_exists('mb_get_info')) {
             $warnings[] = __('mbstring is not installed in PHP.  Zikula cannot install or upgrade without this extension.');
         }
-        if (ini_set('mbstring.internal_encoding', 'UTF-8') === false) {
+        if ((version_compare(\PHP_VERSION, '5.6.0', '<')) && (ini_set('mbstring.internal_encoding', 'UTF-8') === false)) {
             // mbstring.internal_encoding is deprecated in php 5.6.0
             $currentSetting = ini_get('mbstring.internal_encoding');
             $warnings[] = __f('Could not use %1$s to set the %2$s to the value of %3$s. The install or upgrade process may fail at your current setting of %4$s.', array('ini_set', 'mbstring.internal_encoding', 'UTF-8', $currentSetting));

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Util/UpgradeFunctions.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Util/UpgradeFunctions.php
@@ -16,7 +16,18 @@ use Doctrine\DBAL\Connection;
 use Zikula\Core\CoreEvents;
 use Zikula\Core\Event\ModuleStateEvent;
 
-ini_set('mbstring.internal_encoding', 'UTF-8');
+/**
+ * mbstring.internal_encoding
+ *
+ * This feature has been deprecated as of PHP 5.6.0. Relying on this feature is highly discouraged.
+ * PHP 5.6 and later users should leave this empty and set default_charset instead.
+ *
+ * @link http://php.net/manual/en/mbstring.configuration.php#ini.mbstring.internal-encoding
+ */
+if (version_compare(\PHP_VERSION, '5.6.0', '<')) {
+    ini_set('mbstring.internal_encoding', 'UTF-8'); 
+}
+
 ini_set('default_charset', 'UTF-8');
 mb_regex_encoding('UTF-8');
 $warnings = array();

--- a/src/lib/i18n/ZMO.php
+++ b/src/lib/i18n/ZMO.php
@@ -165,7 +165,7 @@ class ZMO
         $this->total = $this->readint();
         $this->originals = $this->readint();
         $this->translations = $this->readint();
-        $this->encoding = ini_get('mbstring.internal_encoding');
+        $this->encoding = (version_compare(\PHP_VERSION, '5.6.0', '<')) ? ini_get('mbstring.internal_encoding') : ini_get('default_charset');
     }
 
     /**

--- a/src/lib/legacy/Zikula/Core.php
+++ b/src/lib/legacy/Zikula/Core.php
@@ -27,7 +27,19 @@ define('ACCESS_EDIT', 500);
 define('ACCESS_ADD', 600);
 define('ACCESS_DELETE', 700);
 define('ACCESS_ADMIN', 800);
-ini_set('mbstring.internal_encoding', 'UTF-8');
+
+/**
+ * mbstring.internal_encoding
+ *
+ * This feature has been deprecated as of PHP 5.6.0. Relying on this feature is highly discouraged.
+ * PHP 5.6 and later users should leave this empty and set default_charset instead.
+ *
+ * @link http://php.net/manual/en/mbstring.configuration.php#ini.mbstring.internal-encoding
+ */
+if (version_compare(\PHP_VERSION, '5.6.0', '<')) {
+    ini_set('mbstring.internal_encoding', 'UTF-8'); 
+}
+
 ini_set('default_charset', 'UTF-8');
 mb_regex_encoding('UTF-8');
 

--- a/src/mo2json.php
+++ b/src/mo2json.php
@@ -12,7 +12,18 @@
  * information regarding copyright and licensing.
  */
 
-ini_set('mbstring.internal_encoding', 'UTF-8');
+/**
+ * mbstring.internal_encoding
+ *
+ * This feature has been deprecated as of PHP 5.6.0. Relying on this feature is highly discouraged.
+ * PHP 5.6 and later users should leave this empty and set default_charset instead.
+ *
+ * @link http://php.net/manual/en/mbstring.configuration.php#ini.mbstring.internal-encoding
+ */
+if (version_compare(\PHP_VERSION, '5.6.0', '<')) {
+    ini_set('mbstring.internal_encoding', 'UTF-8'); 
+}
+
 ini_set('default_charset', 'UTF-8');
 mb_regex_encoding('UTF-8');
 


### PR DESCRIPTION
mbstring.internal_encoding

This feature has been deprecated as of PHP 5.6.0. Relying on this feature is highly discouraged. PHP 5.6 and later users should leave this empty and set default_charset instead. Refs. https://github.com/zikula/core/issues/2197.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | yes
| Tests pass?       | yes
| Fixed tickets     | https://github.com/zikula/core/issues/2197
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no