### PR TITLE
add proxy classes to accommodate BC breaks

### DIFF
--- a/src/docs/en/dev/UPGRADE-1.4.0.md
+++ b/src/docs/en/dev/UPGRADE-1.4.0.md
@@ -6,12 +6,8 @@ A very strong effort has been made to keep to the standards of [Semantic Version
 that BC must be maintained within each major version (1.0.0 until 2.0.0). Therefore, all Core-1.3.x modules and themes
 *should* continue to work as expected in Core-1.4.0.
 
-However, because of a necessary upgrade of the Symfony library and despite the development team's best efforts, a few
-BC breaks have still occurred:
-
-  1. [Gedmo (Doctrine Extensions)](#gedmo)
-  2. [Paginate (Doctrine Extensions)](#paginate)
-
+However, because of a necessary upgrade of the Symfony library and despite the development team's best efforts, one
+BC break has still occurred:
 
 <a name="gedmo" />
 Gedmo (Doctrine Extensions)
@@ -48,12 +44,17 @@ to:
     private $slug;
 ```
 
+Deprecations
+============
+Zikula Core 1.4.0 moves a lot of code to Symfony-based classes and methods. In this process, **many** original Zikula
+Core 1.3.x classes and methods have been deprecated and will be removed in Core 2.0.0. These classes are mostly marked
+as `@deprecated` in the code and PHPDoc headers. In addition, several libraries will be removed in Core 2.0.0 and
+therefore, developers should refactor their code for the suitable replacement.
+
 <a name="paginate" />
 Paginate (Doctrine Extensions)
 -----------------------------
 The Doctrine Extension Paginate is deprecated. If you are using it, you should refactor it to `Doctrine\ORM\Tools\Pagination\Paginator`.
-
-*note: is this a true BC-break?*
 
 
 Forward Compatibility Layer

--- a/src/docs/en/dev/UPGRADE-1.4.0.md
+++ b/src/docs/en/dev/UPGRADE-1.4.0.md
@@ -10,10 +10,7 @@ However, because of a necessary upgrade of the Symfony library and despite the d
 BC breaks have still occurred:
 
   1. [Gedmo (Doctrine Extensions)](#gedmo)
-  2. [$this->request->files](#requestfiles)
-  3. [$this->request->filter](#requestfilter)
-  4. [Paginate (Doctrine Extensions)](#paginate)
-  5. [Event removal](#eventremoval)
+  2. [Paginate (Doctrine Extensions)](#paginate)
 
 
 <a name="gedmo" />
@@ -51,50 +48,12 @@ to:
     private $slug;
 ```
 
-<a name="requestfiles" />
-$this->request->files
----------------------
-The format for this method is changed.
-
-`$this->request->files->get()` returns instances of `Symfony\Component\HttpFoundation\File\UploadedFile` now,
-before it returned plain arrays out of `$_FILES`.
-
-*note: there is still some question as to whether the old `->getFiles()` method might be able to maintain BC or
-to find another method of providing for BC in this case. (refs #1002, #1261)
-"one could replace the ParameterBag with a proxy class and magic methods for example.
-The request object is supposed to be created only once in the front controller btw"*
-
-<a name="requestfilter" />
-$this->request->filter
-----------------------
-The format for this method is changed.
-
-```
-$this->request->request/query->filter($key, $default=null, $filter=FILTER_DEFAULT, array $options=array())
-```
-has changed to
-```
-$this->request->request/query->filter(string $key, mixed $default = null, boolean $deep = false, integer $filter = FILTER_DEFAULT, mixed $options = array())
-```
-(note additional $deep parameter)
-
-*note: There may still be some effort to provide a BC layer here. (refs #1261)
-"if someone cares enough it might be possible to handle with a proxy"*
-
 <a name="paginate" />
 Paginate (Doctrine Extensions)
 -----------------------------
 The Doctrine Extension Paginate is deprecated. If you are using it, you should refactor it to `Doctrine\ORM\Tools\Pagination\Paginator`.
 
 *note: is this a true BC-break?*
-
-<a name="eventremoval" />
-Event Removal
--------------
-
-The following events have been removed:
-
-  - `systemerror` - This was never actually implemented in the core and there is no replacement
 
 
 Forward Compatibility Layer

--- a/src/lib/legacy/Zikula/Bag/FileBag.php
+++ b/src/lib/legacy/Zikula/Bag/FileBag.php
@@ -21,7 +21,7 @@ use Zikula_UploadedFile as UploadedFile;
  * @deprecated as of 1.4.0
  * @see \Symfony\Component\HttpFoundation\FileBag
  */
-class Zikula_FileBag extends \Symfony\Component\HttpFoundation\FileBag
+class Zikula_Bag_FileBag extends \Symfony\Component\HttpFoundation\FileBag
 {
     private static $fileKeys = array('error', 'name', 'size', 'tmp_name', 'type');
 

--- a/src/lib/legacy/Zikula/Bag/ParameterBag.php
+++ b/src/lib/legacy/Zikula/Bag/ParameterBag.php
@@ -40,14 +40,14 @@ class Zikula_Bag_ParameterBag extends \Symfony\Component\HttpFoundation\Paramete
             if (is_bool(func_get_arg(2))) {
                 // usage is compatible with normal ParameterBag
                 $deep = func_get_arg(2);
-                $filter = func_get_arg(3) === false ? FILTER_DEFAULT : func_get_arg(3);
-                $options = func_get_arg(4) === false ? array() : func_get_arg(4);
+                $filter = (func_num_args() >= 4) && (func_get_arg(3) !== false) ? func_get_arg(3) : FILTER_DEFAULT;
+                $options = (func_num_args() == 5) && (func_get_arg(4) !== false) ? func_get_arg(4) : array();
             } else {
                 // using old signature - third param exists and is a constant, not a bool
                 LogUtil::log('The method signature for filter() has changed. See \Symfony\Component\HttpFoundation\ParameterBag::filter().', E_USER_DEPRECATED);
                 $deep = false;
-                $filter = func_get_arg(2) === false ? FILTER_DEFAULT : func_get_arg(2);
-                $options = func_get_arg(3) === false ? array() : func_get_arg(3);
+                $filter = (func_num_args() >= 3) && (func_get_arg(2) !== false) ? func_get_arg(2) : FILTER_DEFAULT;
+                $options = (func_num_args() >= 4) && (func_get_arg(3) !== false) ? func_get_arg(3) : array();
             }
         }
 

--- a/src/lib/legacy/Zikula/Bag/ParameterBag.php
+++ b/src/lib/legacy/Zikula/Bag/ParameterBag.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * ParameterBag is a container for key/value pairs.
+ * @deprecated as of Core 1.4.0
+ */
+class Zikula_Bag_ParameterBag extends \Symfony\Component\HttpFoundation\ParameterBag
+{
+    /**
+     * Filter key.
+     * @deprecated as of Core 1.4.0
+     *
+     * @see http://php.net/manual/en/function.filter-var.php
+     *
+     * @return mixed
+     */
+    public function filter()
+    {
+        /**
+         * New args in order:
+         *  key
+         *  default = null
+         *  deep = false (missing in old signature)
+         *  filter = FILTER_DEFAULT
+         *  options = array()
+         */
+        $key = func_get_arg(0);
+        $default = func_get_arg(1) === false ? null : func_get_arg(2);
+        $deep = false;
+        $filter = FILTER_DEFAULT;
+        $options = array();
+
+        if (func_num_args() > 2) {
+            if (is_bool(func_get_arg(2))) {
+                // usage is compatible with normal ParameterBag
+                $deep = func_get_arg(2);
+                $filter = func_get_arg(3) === false ? FILTER_DEFAULT : func_get_arg(3);
+                $options = func_get_arg(4) === false ? array() : func_get_arg(4);
+            } else {
+                // using old signature
+                $deep = false;
+                $filter = func_get_arg(2) === false ? FILTER_DEFAULT : func_get_arg(2);
+                $options = func_get_arg(3) === false ? array() : func_get_arg(3);
+            }
+        }
+
+        return parent::filter($key, $default, $deep, $filter, $options);
+    }
+}

--- a/src/lib/legacy/Zikula/Bag/ParameterBag.php
+++ b/src/lib/legacy/Zikula/Bag/ParameterBag.php
@@ -1,12 +1,16 @@
 <?php
-
-/*
- * This file is part of the Symfony package.
+/**
+ * Copyright 2015 Zikula Foundation.
  *
- * (c) Fabien Potencier <fabien@symfony.com>
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
  *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Zikula
+ * @subpackage Zikula_Exception
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
  */
 
 /**
@@ -20,26 +24,18 @@ class Zikula_Bag_ParameterBag extends \Symfony\Component\HttpFoundation\Paramete
      * @deprecated as of Core 1.4.0
      * @see \Symfony\Component\HttpFoundation\ParameterBag::filter
      *
+     * @param string $key     Key.
+     * @param mixed  $default Default = null.
+     * @param bool   $deep    Default = false.
+     * @param int    $filter  FILTER_* constant.
+     * @param mixed  $options Filter options.
+     *
      * @see http://php.net/manual/en/function.filter-var.php
      *
      * @return mixed
      */
-    public function filter()
+    public function filter($key, $default = null, $deep = false, $filter = FILTER_DEFAULT, $options = array())
     {
-        /**
-         * Args in order:
-         *  key
-         *  default = null
-         *  deep = false (missing in old signature)
-         *  filter = FILTER_DEFAULT
-         *  options = array()
-         */
-        $key = func_get_arg(0);
-        $default = func_get_arg(1) === false ? null : func_get_arg(2);
-        $deep = false;
-        $filter = FILTER_DEFAULT;
-        $options = array();
-
         if (func_num_args() > 2) {
             if (is_bool(func_get_arg(2))) {
                 // usage is compatible with normal ParameterBag

--- a/src/lib/legacy/Zikula/Bag/ParameterBag.php
+++ b/src/lib/legacy/Zikula/Bag/ParameterBag.php
@@ -18,6 +18,7 @@ class Zikula_Bag_ParameterBag extends \Symfony\Component\HttpFoundation\Paramete
     /**
      * Filter key.
      * @deprecated as of Core 1.4.0
+     * @see \Symfony\Component\HttpFoundation\ParameterBag::filter
      *
      * @see http://php.net/manual/en/function.filter-var.php
      *
@@ -26,7 +27,7 @@ class Zikula_Bag_ParameterBag extends \Symfony\Component\HttpFoundation\Paramete
     public function filter()
     {
         /**
-         * New args in order:
+         * Args in order:
          *  key
          *  default = null
          *  deep = false (missing in old signature)
@@ -46,7 +47,8 @@ class Zikula_Bag_ParameterBag extends \Symfony\Component\HttpFoundation\Paramete
                 $filter = func_get_arg(3) === false ? FILTER_DEFAULT : func_get_arg(3);
                 $options = func_get_arg(4) === false ? array() : func_get_arg(4);
             } else {
-                // using old signature
+                // using old signature - third param exists and is a constant, not a bool
+                LogUtil::log('The method signature for filter() has changed. See \Symfony\Component\HttpFoundation\ParameterBag::filter().', E_USER_DEPRECATED);
                 $deep = false;
                 $filter = func_get_arg(2) === false ? FILTER_DEFAULT : func_get_arg(2);
                 $options = func_get_arg(3) === false ? array() : func_get_arg(3);

--- a/src/lib/legacy/Zikula/FileBag.php
+++ b/src/lib/legacy/Zikula/FileBag.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright 2015 Zikula Foundation.
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Zikula
+ * @subpackage Zikula_Exception
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+use Zikula_UploadedFile as UploadedFile;
+
+/**
+ * FileBag is a container for uploaded files.
+ *
+ * @deprecated as of 1.4.0
+ * @see \Symfony\Component\HttpFoundation\FileBag
+ */
+class Zikula_FileBag extends \Symfony\Component\HttpFoundation\FileBag
+{
+    private static $fileKeys = array('error', 'name', 'size', 'tmp_name', 'type');
+
+    /**
+     * Converts uploaded files to UploadedFile instances.
+     *
+     * @deprecated as of 1.4.0
+     *
+     * @param array|UploadedFile $file A (multi-dimensional) array of uploaded file information
+     *
+     * @return array A (multi-dimensional) array of UploadedFile instances
+     */
+    protected function convertFileInformation($file)
+    {
+        if ($file instanceof \Symfony\Component\HttpFoundation\File\UploadedFile) {
+            return $file;
+        }
+
+        $file = $this->fixPhpFilesArray($file);
+        if (is_array($file)) {
+            $keys = array_keys($file);
+            sort($keys);
+
+            if ($keys == self::$fileKeys) {
+                if (UPLOAD_ERR_NO_FILE == $file['error']) {
+                    $file = null;
+                } else {
+                    $file = new UploadedFile($file['tmp_name'], $file['name'], $file['type'], $file['size'], $file['error']);
+                }
+            } else {
+                $file = array_map(array($this, 'convertFileInformation'), $file);
+            }
+        }
+
+        return $file;
+    }
+
+}

--- a/src/lib/legacy/Zikula/Request/Http.php
+++ b/src/lib/legacy/Zikula/Request/Http.php
@@ -22,6 +22,27 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 class Zikula_Request_Http extends Zikula_Request_AbstractRequest
 {
+    public $files;
+
+    /**
+     * Constructor.
+     *
+     * @param array  $query      The GET parameters
+     * @param array  $request    The POST parameters
+     * @param array  $attributes The request attributes (parameters parsed from the PATH_INFO, ...)
+     * @param array  $cookies    The COOKIE parameters
+     * @param array  $files      The FILES parameters
+     * @param array  $server     The SERVER parameters
+     * @param string $content    The raw body data
+     *
+     * @api
+     */
+    public function __construct(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null)
+    {
+        parent::initialize($query, $request, $attributes, $cookies, $files, $server, $content);
+        $this->files = new Zikula_FileBag($files);
+    }
+
      /**
      * Return the request method.
      *
@@ -37,7 +58,7 @@ class Zikula_Request_Http extends Zikula_Request_AbstractRequest
      *
      * @deprecated use $request->query instead
      *
-     * @return Zikula_Request_Collection
+     * @return \Symfony\Component\HttpFoundation\ParameterBag
      */
     public function getGet()
     {
@@ -51,7 +72,7 @@ class Zikula_Request_Http extends Zikula_Request_AbstractRequest
      *
      * @deprecated use $request->request instead
      *
-     * @return Zikula_Request_Collection
+     * @return \Symfony\Component\HttpFoundation\ParameterBag
      */
     public function getPost()
     {
@@ -63,11 +84,11 @@ class Zikula_Request_Http extends Zikula_Request_AbstractRequest
     /**
      * Getter for COOKIE.
      *
-     * @return Zikula_Request_Collection
+     * @return \Symfony\Component\HttpFoundation\ParameterBag
      */
     public function getCookie()
     {
-        return $this->cookie;
+        return $this->cookies;
     }
 
     /**
@@ -75,7 +96,7 @@ class Zikula_Request_Http extends Zikula_Request_AbstractRequest
      *
      * @deprecated use $request->server instead
      *
-     * @return Zikula_Request_Collection
+     * @return \Symfony\Component\HttpFoundation\ServerBag
      */
     public function getServer()
     {
@@ -91,17 +112,19 @@ class Zikula_Request_Http extends Zikula_Request_AbstractRequest
      */
     public function getEnv()
     {
-        return $this->env;
+        // this is not defined!
+        //return $this->env;
+        return null;
     }
 
     /**
      * Getter for args.
      *
-     * @return Zikula_Request_Collection
+     * @return \Symfony\Component\HttpFoundation\ParameterBag
      */
     public function getArgs()
     {
-        return $this->args;
+        return $this->attributes->all();
     }
 
     /**
@@ -109,7 +132,7 @@ class Zikula_Request_Http extends Zikula_Request_AbstractRequest
      *
      * @deprecated use $request->files instead
      *
-     * @return Zikula_Request_Collection
+     * @return \Symfony\Component\HttpFoundation\FileBag
      */
     public function getFiles()
     {

--- a/src/lib/legacy/Zikula/Request/Http.php
+++ b/src/lib/legacy/Zikula/Request/Http.php
@@ -40,7 +40,9 @@ class Zikula_Request_Http extends Zikula_Request_AbstractRequest
     public function __construct(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null)
     {
         parent::initialize($query, $request, $attributes, $cookies, $files, $server, $content);
-        $this->files = new Zikula_FileBag($files);
+        $this->query = new Zikula_Bag_ParameterBag($query);
+        $this->request = new Zikula_Bag_ParameterBag($request);
+        $this->files = new Zikula_Bag_FileBag($files);
     }
 
      /**

--- a/src/lib/legacy/Zikula/UploadedFile.php
+++ b/src/lib/legacy/Zikula/UploadedFile.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2015 Zikula Foundation.
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Zikula
+ * @subpackage Zikula_Exception
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+/**
+ * A file uploaded through a form.
+ *
+ * @deprecated as of 1.4.0
+ * @see \Symfony\Component\HttpFoundation\File\UploadedFile
+ */
+class Zikula_UploadedFile extends \Symfony\Component\HttpFoundation\File\UploadedFile
+{
+    /**
+     * @deprecated as of 1.4.0
+     * @param $property
+     * @return int|null|string
+     */
+    public function __get($property)
+    {
+        LogUtil::log('Array access to file properties is deprecated. Please use SPL methods.', E_USER_DEPRECATED);
+
+        switch ($property) {
+            case 'name':
+                $value = $this->getClientOriginalName();
+                break;
+            case 'type':
+                $value = $this->getClientMimeType();
+                break;
+            case 'size':
+                $value = $this->getClientSize();
+                break;
+            case 'tmp_name':
+                $value = $this->getRealPath();
+                break;
+            case 'error':
+                $value = $this->getError();
+                break;
+            default:
+                $value = null;
+        }
+
+        return $value;
+    }
+}

--- a/src/lib/legacy/Zikula/UploadedFile.php
+++ b/src/lib/legacy/Zikula/UploadedFile.php
@@ -19,18 +19,35 @@
  * @deprecated as of 1.4.0
  * @see \Symfony\Component\HttpFoundation\File\UploadedFile
  */
-class Zikula_UploadedFile extends \Symfony\Component\HttpFoundation\File\UploadedFile
+class Zikula_UploadedFile extends \Symfony\Component\HttpFoundation\File\UploadedFile implements \ArrayAccess
 {
     /**
-     * @deprecated as of 1.4.0
-     * @param $property
-     * @return int|null|string
+     * @deprecated at 1.4.0
+     * Whether a offset exists
+     * @param mixed $offset
+     * An offset to check for.
+     *
+     * @return boolean true on success or false on failure.
      */
-    public function __get($property)
+    public function offsetExists($offset)
     {
-        LogUtil::log('Array access to file properties is deprecated. Please use SPL methods.', E_USER_DEPRECATED);
+        $value = $this->offsetGet($offset);
 
-        switch ($property) {
+        return isset($value);
+    }
+
+    /**
+     * @deprecated at 1.4.0
+     * Offset to retrieve
+     * @param mixed $offset
+     * The offset to retrieve.
+     * @return mixed Can return all value types.
+     */
+    public function offsetGet($offset)
+    {
+        LogUtil::log('Array Access to file properties is deprecated. Please use SPL methods.', E_USER_DEPRECATED);
+
+        switch ($offset) {
             case 'name':
                 $value = $this->getClientOriginalName();
                 break;
@@ -51,5 +68,31 @@ class Zikula_UploadedFile extends \Symfony\Component\HttpFoundation\File\Uploade
         }
 
         return $value;
+    }
+
+    /**
+     * @deprecated at 1.4.0
+     * Offset to set
+     * @param mixed $offset
+     * The offset to assign the value to.
+     * @param mixed $value
+     * The value to set.
+     * @throws \Exception
+     */
+    public function offsetSet($offset, $value)
+    {
+        throw new \Exception("It is not possible to set values via Array Access. Please use SPL methods.");
+    }
+
+    /**
+     * @deprecated at 1.4.0
+     * Offset to unset
+     * @param mixed $offset
+     * The offset to unset.
+     * @throws \Exception
+     */
+    public function offsetUnset($offset)
+    {
+        throw new \Exception("It is not possible to unset values via Array Access. Please use SPL methods.");
     }
 }


### PR DESCRIPTION
refs #1856 and refs #1002 
fixes BC-breaks

 - add proxy class for UploadableFile & FileBag to fix issue where file parameters were not accessible by ArrayAccess
 - add proxy class for ParameterBag to fix filter method signature so it is both forward and backward compatible.

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | #1856, #1002
| License           | MIT
| Doc PR            | -
| Changelog updated | no

todo
 - [x] approval @cmfcmf 
 - [x] approval @Guite
 - [x] update docs
