### PR TITLE
[1.4.x] Updated JCSSUtil to always load prototype first

### DIFF
--- a/src/lib/util/JCSSUtil.php
+++ b/src/lib/util/JCSSUtil.php
@@ -363,6 +363,11 @@ class JCSSUtil
     public static function scriptsMap()
     {
         $scripts = array(
+            'prototype'          => array(
+                'path'    => 'javascript/ajax/proto_scriptaculous.combined.min.js',
+                'require' => array('zikula'),
+                'aliases' => array('prototype', 'scriptaculous'),
+            ),
             'jquery'             => array(
                 'path'    => 'web/jquery/jquery.min.js',
                 'require' => array('noconflict', 'jquery-migrate'),
@@ -376,11 +381,6 @@ class JCSSUtil
             ),
             'jquery-migrate'     => array(
                 'path' => 'web/jquery/jquery-migrate.min.js',
-            ),
-            'prototype'          => array(
-                'path'    => 'javascript/ajax/proto_scriptaculous.combined.min.js',
-                'require' => array('zikula'),
-                'aliases' => array('prototype', 'scriptaculous'),
             ),
             'livepipe'           => array(
                 'path'    => 'javascript/livepipe/livepipe.combined.min.js',


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | -
| Fixed tickets     | #2170
| Refs tickets      | #2223
| License           | MIT
| Doc PR            | -
| Changelog updated | yes

In noconflict mode of jquery this is the way it is documented to first load other script, the jquery+noconflict.
So that's why I write bug fix