### PR TITLE
Added already installed check (taken from StartCommand), closes #2241

### DIFF
--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/FinishCommand.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/FinishCommand.php
@@ -40,6 +40,12 @@ class FinishCommand extends AbstractCoreInstallerCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->bootstrap(false);
+
+        if ($this->getContainer()->getParameter('installed') == true) {
+            $output->writeln("<error>" . __('Zikula already appears to be installed.') . "</error>");
+            return;
+        }
+
         $output->writeln("*** INSTALLING ***");
         // install!
         $ajaxInstallerStage = new AjaxInstallerStage();


### PR DESCRIPTION
This PR copies a check for ZK already being installed from the installer start cli function to finish function.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2241
| Refs tickets  |
| License       | MIT
| Doc PR        |