### PR TITLE
[1.3] Allow to hook Scribite in Send e-mail to  users form

### DIFF
--- a/src/system/Users/templates/users_admin_mailusers.tpl
+++ b/src/system/Users/templates/users_admin_mailusers.tpl
@@ -91,6 +91,8 @@
                 </div>
             </fieldset>
 
+            {notifydisplayhooks eventname='users.ui_hooks.user.form_edit' id=null}
+
             <div class="z-formbuttons z-buttons">
                 {button type='submit' src='mail_generic.png' set='icons/extrasmall' __alt="Send e-mail to selected recipients" __title="Send e-mail to selected recipients" __text="Send e-mail to selected recipients"}
                 <a href="{modurl modname='Users' type='admin' func='main'}" title="{gt text='Cancel'}">{img modname='core' src='button_cancel.png' set='icons/extrasmall'  __alt='Cancel' __title='Cancel'} {gt text='Cancel'}</a>


### PR DESCRIPTION
This allows site administrator to hook Scribite visual editor provider to the form for sending mail to users.
It is useful to prepare HTML formatted mails.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| 1.4 PR        | - already done in 1.4 branch
| Refs tickets  | -
| License       | LGPLv3+
| Doc PR        | -