### PR TITLE
Allow to hook Scribite to mailer test e-mail settings form

### DIFF
--- a/src/system/Zikula/Module/MailerModule/MailerModuleInstaller.php
+++ b/src/system/Zikula/Module/MailerModule/MailerModuleInstaller.php
@@ -50,6 +50,7 @@ class MailerModuleInstaller extends \Zikula_AbstractInstaller
             case '1.3.1':
                 $this->setVar('smtpsecuremethod', 'ssl');
             case '1.3.2':
+            case '1.3.3':
                 // clear old modvars
                 // use manual method because getVars() is not available during system upgrade
                 $modVarEntities = $this->entityManager->getRepository('Zikula\Core\Doctrine\Entity\ExtensionVarEntity')->findBy(array('modname' => $this->name));
@@ -95,6 +96,7 @@ class MailerModuleInstaller extends \Zikula_AbstractInstaller
                 unset($config['spool']);
                 $configDumper->setConfiguration('swiftmailer', $config);
             case '1.4.1':
+                HookUtil::unregisterSubscriberBundles($this->version->getHookSubscriberBundles());
                 HookUtil::registerSubscriberBundles($this->version->getHookSubscriberBundles());
             case '1.4.2':
             // future upgrade routines

--- a/src/system/Zikula/Module/MailerModule/MailerModuleInstaller.php
+++ b/src/system/Zikula/Module/MailerModule/MailerModuleInstaller.php
@@ -50,7 +50,6 @@ class MailerModuleInstaller extends \Zikula_AbstractInstaller
             case '1.3.1':
                 $this->setVar('smtpsecuremethod', 'ssl');
             case '1.3.2':
-            case '1.3.3':
                 // clear old modvars
                 // use manual method because getVars() is not available during system upgrade
                 $modVarEntities = $this->entityManager->getRepository('Zikula\Core\Doctrine\Entity\ExtensionVarEntity')->findBy(array('modname' => $this->name));
@@ -96,7 +95,6 @@ class MailerModuleInstaller extends \Zikula_AbstractInstaller
                 unset($config['spool']);
                 $configDumper->setConfiguration('swiftmailer', $config);
             case '1.4.1':
-                HookUtil::unregisterSubscriberBundles($this->version->getHookSubscriberBundles());
                 HookUtil::registerSubscriberBundles($this->version->getHookSubscriberBundles());
             case '1.4.2':
             // future upgrade routines

--- a/src/system/Zikula/Module/MailerModule/MailerModuleInstaller.php
+++ b/src/system/Zikula/Module/MailerModule/MailerModuleInstaller.php
@@ -14,6 +14,7 @@
 namespace Zikula\Module\MailerModule;
 
 use ZLanguage;
+use HookUtil;
 
 /**
  * Installation and upgrade routines for the mailer module
@@ -28,6 +29,8 @@ class MailerModuleInstaller extends \Zikula_AbstractInstaller
     public function install()
     {
         $this->setVars($this->getDefaults());
+
+        HookUtil::registerSubscriberBundles($this->version->getHookSubscriberBundles());
 
         // Initialisation successful
         return true;
@@ -92,6 +95,8 @@ class MailerModuleInstaller extends \Zikula_AbstractInstaller
                 unset($config['spool']);
                 $configDumper->setConfiguration('swiftmailer', $config);
             case '1.4.1':
+                HookUtil::registerSubscriberBundles($this->version->getHookSubscriberBundles());
+            case '1.4.2':
             // future upgrade routines
         }
 
@@ -108,6 +113,9 @@ class MailerModuleInstaller extends \Zikula_AbstractInstaller
     {
         // Delete any module variables
         $this->delVars();
+
+        // Remove hooks
+        HookUtil::unregisterSubscriberBundles($this->version->getHookSubscriberBundles());
 
         // Deletion successful
         return true;

--- a/src/system/Zikula/Module/MailerModule/MailerModuleVersion.php
+++ b/src/system/Zikula/Module/MailerModule/MailerModuleVersion.php
@@ -13,6 +13,9 @@
 
 namespace Zikula\Module\MailerModule;
 
+use HookUtil;
+use Zikula\Component\HookDispatcher\SubscriberBundle;
+
 /**
  * Version information for the mailer module
  */
@@ -30,11 +33,22 @@ class MailerModuleVersion extends \Zikula_AbstractVersion
         $meta['description']    = $this->__('Mailer module, provides mail API and mail setting administration.');
         //! module name that appears in URL
         $meta['url']            = $this->__('mailer');
-        $meta['version']        = '1.4.1';
+        $meta['version']        = '1.4.2';
         $meta['core_min']       = '1.4.0';
-
+        $meta['capabilities']   = array(HookUtil::SUBSCRIBER_CAPABLE => array('enabled' => true));
         $meta['securityschema'] = array('ZikulaMailerModule::' => '::');
 
         return $meta;
+    }
+
+    /**
+     * Set up hook subscriber bundle
+     */
+    protected function setupHookBundles()
+    {
+        // This enables Scribite 5 connection to HTML e-mail test
+        $bundle = new SubscriberBundle($this->name, 'subscriber.mailer.ui_hooks.htmlmail', 'ui_hooks', $this->__('HTML mail hook'));
+        $bundle->addEvent('form_edit', 'mailer.ui_hooks.htmlmail.form_edit');
+        $this->registerHookSubscriberBundle($bundle);
     }
 }

--- a/src/system/Zikula/Module/MailerModule/Resources/views/Admin/testconfig.tpl
+++ b/src/system/Zikula/Module/MailerModule/Resources/views/Admin/testconfig.tpl
@@ -74,6 +74,8 @@
         </div>
     </fieldset>
 
+    {notifydisplayhooks eventname='mailer.ui_hooks.htmlmail.form_edit' id=null}
+
     <div class="form-group">
         <div class="col-lg-offset-3 col-lg-9">
             {formbutton class='btn btn-success' commandName='save' __text='Send test email now'}


### PR DESCRIPTION
This allows site administrator to hook Scribite visual editor provider to the form for test mailer settings. It is useful to prepare HTML formatted mails.

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | [no]