### PR TITLE
[1.3] Allow to hook Scribite to mailer test e-mail settings form

### DIFF
--- a/src/system/Mailer/lib/Mailer/Installer.php
+++ b/src/system/Mailer/lib/Mailer/Installer.php
@@ -41,6 +41,9 @@ class Mailer_Installer extends Zikula_AbstractInstaller
         $this->setVar('smtppassword', '');
         $this->setVar('smtpsecuremethod', 'ssl');
 
+        // register ui_hook for HTML e-mail test
+        HookUtil::registerSubscriberBundles($this->version->getHookSubscriberBundles());
+
         // Initialisation successful
         return true;
     }
@@ -61,6 +64,9 @@ class Mailer_Installer extends Zikula_AbstractInstaller
             case '1.3.1':
                 $this->setVar('smtpsecuremethod', 'ssl');
             case '1.3.2':
+                // register ui_hook for HTML e-mail test
+                HookUtil::registerSubscriberBundles($this->version->getHookSubscriberBundles());
+            case '1.3.3':
                 // future upgrade routines
         }
 
@@ -78,6 +84,9 @@ class Mailer_Installer extends Zikula_AbstractInstaller
     {
         // Delete any module variables
         $this->delVars();
+
+        // Remove hooks
+        HookUtil::unregisterSubscriberBundles($this->version->getHookSubscriberBundles());
 
         // Deletion successful
         return true;

--- a/src/system/Mailer/lib/Mailer/Version.php
+++ b/src/system/Mailer/lib/Mailer/Version.php
@@ -21,10 +21,21 @@ class Mailer_Version extends Zikula_AbstractVersion
         $meta['description']    = $this->__('Mailer module, provides mail API and mail setting administration.');
         //! module name that appears in URL
         $meta['url']            = $this->__('mailer');
-        $meta['version']        = '1.3.2';
-
+        $meta['version']        = '1.3.3';
+        $meta['capabilities']   = array(HookUtil::SUBSCRIBER_CAPABLE => array('enabled' => true));
         $meta['securityschema'] = array('Mailer::' => '::');
 
         return $meta;
+    }
+
+    /**
+     * Set up hook subscriber bundle
+     */
+    protected function setupHookBundles()
+    {
+        // This enables Scribite 5 connection to HTML e-mail test
+        $bundle = new Zikula_HookManager_SubscriberBundle($this->name, 'subscriber.mailer.ui_hooks.htmlmail', 'ui_hooks', $this->__('HTML mail hook'));
+        $bundle->addEvent('form_edit', 'mailer.ui_hooks.htmlmail.form_edit');
+        $this->registerHookSubscriberBundle($bundle);
     }
 }

--- a/src/system/Mailer/templates/mailer_admin_testconfig.tpl
+++ b/src/system/Mailer/templates/mailer_admin_testconfig.tpl
@@ -54,6 +54,8 @@
             </div>
         </fieldset>
 
+        {notifydisplayhooks eventname='mailer.ui_hooks.htmlmail.form_edit' id=null}
+
         <div class="z-buttons z-formbuttons">
             {formbutton class='z-bt-ok' commandName='save' __text='Test settings now'}
             {formbutton class='z-bt-cancel' commandName='cancel' __text='Cancel'}


### PR DESCRIPTION
This allows site administrator to hook Scribite visual editor provider to the form for test mailer settings. It is useful to prepare HTML formatted mails.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| 1.4 PR        | - #2256
| Refs tickets  | -
| License       | LGPLv3+
| Doc PR        | -