### PR TITLE
do not load library if php < 5.4.0

### DIFF
--- a/src/app/ZikulaKernel.php
+++ b/src/app/ZikulaKernel.php
@@ -25,8 +25,13 @@ class ZikulaKernel extends Kernel
             new JMS\I18nRoutingBundle\JMSI18nRoutingBundle(),
             new JMS\TranslationBundle\JMSTranslationBundle(),
             new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
-            new Matthias\SymfonyConsoleForm\Bundle\SymfonyConsoleFormBundle(),
         );
+        // only add SymfonyConsoleFormBundle if PHP >= 5.4.0 @todo remove this check for 2.0.0 and include
+        $x = explode('.', str_replace('-', '.', phpversion()));
+        $phpVersion = "$x[0].$x[1].$x[2]";
+        if (version_compare($phpVersion, '5.4.0', ">=")) {
+           $bundles[] = new Matthias\SymfonyConsoleForm\Bundle\SymfonyConsoleFormBundle();
+        }
 
         $this->registerCoreModules($bundles);
 


### PR DESCRIPTION
merging this would (by definition) fail build 448 and close #2264

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | #2270
| Refs tickets      | #2264
| License           | MIT
| Doc PR            | -
| Changelog updated | n/a

fixes #2270