### PR TITLE
Setting InnoDB as the default engine

### DIFF
--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/DbCredsType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/DbCredsType.php
@@ -38,7 +38,7 @@ class DbCredsType extends AbstractType
                 'choices' => array(
                     'innodb' => __('InnoDB'),
                     'myisam' => __('MyISAM')),
-                'data' => 'myisam'))
+                'data' => 'innodb'))
             ->add('database_host', 'text', array(
                 'label' => __('Host'),
                 'label_attr' => array('class' => 'col-lg-5'),


### PR DESCRIPTION
InnoDB as the Default MySQL Storage Engine

http://dev.mysql.com/doc/refman/5.5/en/innodb-default-se.html

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no