### PR TITLE
Corect permissions to see admin top menu

### DIFF
--- a/src/themes/Zikula/Theme/Andreas08Theme/Resources/views/admin.tpl
+++ b/src/themes/Zikula/Theme/Andreas08Theme/Resources/views/admin.tpl
@@ -3,13 +3,34 @@
 <div id="theme_navigation_bar">
     <ul class="clearfix">
         <li><a href="{homepage}">{gt text='Home'}</a></li>
+        {checkpermission component='ZikulaSettingsModule::' instance='::' level='ACCESS_ADMIN' assign='okAccess'}
+        {if $okAccess}
         <li><a href="{modurl modname='ZikulaSettingsModule' type='admin' func='index'}">{gt text="Settings"}</a></li>
+        {/if}
+        {checkpermission component='ZikulaExtensionsModule::' instance='::' level='ACCESS_ADMIN' assign='okAccess'}
+        {if $okAccess}
         <li><a href="{modurl modname='ZikulaExtensionsModule' type='admin' func='index'}">{gt text="Extensions"}</a></li>
+        {/if}
+        {checkpermission component='ZikulaBlocksModule::' instance='::' level='ACCESS_EDIT' assign='okAccess'}
+        {if $okAccess}
         <li><a href="{modurl modname='ZikulaBlocksModule' type='admin' func='index'}">{gt text="Blocks"}</a></li>
+        {/if}
+        {checkpermission component='ZikulaUsersModule::' instance='::' level='ACCESS_MODERATE' assign='okAccess'}
+        {if $okAccess}
         <li><a href="{modurl modname='ZikulaUsersModule' type='admin' func='index'}">{gt text="Users"}</a></li>
+        {/if}
+        {checkpermission component='ZikulaGroupsModule::' instance='::' level='ACCESS_EDIT' assign='okAccess'}
+        {if $okAccess}
         <li><a href="{modurl modname='ZikulaGroupsModule' type='admin' func='index'}">{gt text="Groups"}</a></li>
+        {/if}
+        {checkpermission component='ZikulaPermissionsModule::' instance='::' level='ACCESS_ADMIN' assign='okAccess'}
+        {if $okAccess}
         <li><a href="{modurl modname='ZikulaPermissionsModule' type='admin' func='index'}">{gt text="Permission rules"}</a></li>
+        {/if}
+        {checkpermission component='ZikulaThemeModule::' instance='::' level='ACCESS_EDIT' assign='okAccess'}
+        {if $okAccess}
         <li><a href="{modurl modname='ZikulaThemeModule' type='admin' func='index'}">{gt text="Themes"}</a></li>
+        {/if}
     </ul>
 </div>
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | - 
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | [yes/no]

This PR is addressed to cases when we are giving partial admin access to a group, here Sitemanager.

Consider we give folowing rights to Sitemanager's:
![image](https://cloud.githubusercontent.com/assets/628801/6399948/7053fb20-bdfe-11e4-9368-0e71a8544afa.png)

A member of this group will see admin panel like this:
![image](https://cloud.githubusercontent.com/assets/628801/6400000/cad68d24-bdfe-11e4-8f77-8bd092a1db15.png)

Unwanted menu items are marked with red color.

After this PR the user will see:
![image](https://cloud.githubusercontent.com/assets/628801/6400022/f2411640-bdfe-11e4-981d-2bf42212a8e7.png)

This is theme-dependent, here applied to Andreas theme, which is default after installation.