### PR TITLE
Fix for TextInput form plugin

### DIFF
--- a/src/lib/Zikula/Form/Plugin/TextInput.php
+++ b/src/lib/Zikula/Form/Plugin/TextInput.php
@@ -421,9 +421,9 @@ class Zikula_Form_Plugin_TextInput extends Zikula_Form_AbstractStyledPlugin
 
         if ($this->mandatory && $this->isEmpty()) {
             $this->setError(__('Error! An entry in this field is mandatory.'));
-        } elseif (strlen($this->text) > $this->maxLength && $this->maxLength > 0) {
+        } elseif (mb_strlen($this->text) > $this->maxLength && $this->maxLength > 0) {
             $this->setError(sprintf(__f('Error! Input text must be no longer than %s characters.', $this->maxLength)));
-        } elseif (strlen($this->text) < $this->minLength && $this->minLength >= 0) {
+        } elseif (mb_strlen($this->text) < $this->minLength && $this->minLength >= 0) {
             $this->setError(sprintf(__f('Error! Input text must be longer than %s characters.', $this->minLength)));
         } elseif ($this->regexValidationPattern != null && $this->text != '' && !preg_match($this->regexValidationPattern, $this->text)) {
             $this->setError($view->translateForDisplay($this->regexValidationMessage));


### PR DESCRIPTION
Form handled in this way restrict improper length of the strings.

Bug is already fixed in Zikula 1.4.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| 1.4 PR        | - it is already fixed there
| Refs tickets  | -
| License       | LGPLv3+
| Doc PR        | -