### PR TITLE
try/catch block here not proper 

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/LegacyRouteListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/LegacyRouteListener.php
@@ -85,14 +85,8 @@ class LegacyRouteListener implements EventSubscriberInterface
             }
 
             // call the requested/homepage module
-            try {
-                ModUtil::getModule($module);
-                $newType = true;
-            } catch (\Exception $e) {
-                $newType = false;
-            }
-
-            if ($newType) {
+            $moduleBundle = ModUtil::getModule($module);
+            if (null !== $moduleBundle) {
                 $return = ModUtil::func($modinfo['name'], $type, $func);
             } else {
                 $return = ModUtil::func($modinfo['name'], $type, $func, $arguments);


### PR DESCRIPTION
as `getModule()` method already wraps the call and outputs object or `null`. so check for `null` instead of catching exception. ping @Guite fixes #2293 

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | #2293
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no

would like some more extensive testing of this to make sure it doesn't affect other things. @Guite you were the original author of what existed. Do you remember what you were trying to fix?