### PR TITLE
Multilingual site title, description and meta tags

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -116,3 +116,4 @@ Features:
   - Includes CLI-based installer and upgrader
   - Auto-creates `custom_parameters.yml` and `personal_config.php`
 - Include Zikula/Wizard - a library to assist in multi-stage user interaction (used in installer)
+- Added multilingual support for site name, site description and site meta tags (#2316).

--- a/src/lib/i18n/ZLanguage.php
+++ b/src/lib/i18n/ZLanguage.php
@@ -160,6 +160,7 @@ class ZLanguage
         $this->detectLanguage();
         $this->validate();
         $this->fixLanguageToSession();
+        ModUtil::setupMultilingual();
         $this->setLocale($this->languageCode);
         $request->setLocale($this->languageCode);
         $request->setDefaultLocale($this->languageCode);

--- a/src/lib/util/ModUtil.php
+++ b/src/lib/util/ModUtil.php
@@ -145,7 +145,6 @@ class ModUtil
     public static function setupMultilingual()
     {
         $lang = ZLanguage::getLanguageCode();
-        LogUtil::registerStatus('ModUtil: '.$lang);
         $items = array('sitename', 'slogan', 'metakeywords', 'defaultpagetitle', 'defaultmetadescription');
         foreach ($items as $item) {
             self::$modvars['ZConfig'][$item] = isset(self::$modvars['ZConfig'][$item . '_' . $lang]) ? self::$modvars['ZConfig'][$item . '_' . $lang] : '';

--- a/src/lib/util/ModUtil.php
+++ b/src/lib/util/ModUtil.php
@@ -138,6 +138,23 @@ class ModUtil
     }
 
     /**
+     * Init variables multilingual dependent.
+     *
+     * @return boolean True
+     */
+    public static function setupMultilingual()
+    {
+        $lang = ZLanguage::getLanguageCode();
+        LogUtil::registerStatus('ModUtil: '.$lang);
+        $items = array('sitename', 'slogan', 'metakeywords', 'defaultpagetitle', 'defaultmetadescription');
+        foreach ($items as $item) {
+            self::$modvars['ZConfig'][$item] = isset(self::$modvars['ZConfig'][$item . '_' . $lang]) ? self::$modvars['ZConfig'][$item . '_' . $lang] : '';
+        }
+
+        return true;
+    }
+
+    /**
      * Checks to see if a module variable is set.
      *
      * @param string $modname The name of the module.

--- a/src/system/Zikula/Module/SettingsModule/Controller/AdminController.php
+++ b/src/system/Zikula/Module/SettingsModule/Controller/AdminController.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\RouterInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use ZLanguage;
 
 /**
  * @Route("/admin")
@@ -83,6 +84,7 @@ class AdminController extends \Zikula_AbstractController
         $zlibExtensionEnabled = extension_loaded('zlib');
 
         $this->view->assign('pagetitle', $pagetitle)
+                   ->assign('languages', ZLanguage::getInstalledLanguageNames())
                    ->assign('zlibEnabled', $zlibExtensionEnabled);
 
         return new Response($this->view->fetch('Admin/modifyconfig.tpl'));

--- a/src/system/Zikula/Module/SettingsModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/SettingsModule/Resources/views/Admin/modifyconfig.tpl
@@ -9,18 +9,42 @@
         <input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
         <fieldset>
             <legend>{gt text='Main info'}</legend>
-            <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_sitename">{gt text='Site name'}</label>
-                <div class="col-lg-9">
-                    <input id="settings_sitename" type="text" class="form-control" name="settings[sitename]" value="{$modvars.ZConfig.sitename|safetext}" size="50" maxlength="100" />
+            {if $modvars.ZConfig.multilingual}
+                {foreach from=$languages key='code' item='language'}
+                <fieldset>
+                    <legend>{$language}</legend>
+                    {assign var='varname' value='sitename_'|cat:$code}
+                    <div class="form-group">
+                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Site name'}</label>
+                        <div class="col-lg-9">
+                            <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="100" />
+                        </div>
+                    </div>
+                    {assign var='varname' value='slogan_'|cat:$code}
+                    <div class="form-group">
+                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Description line'}</label>
+                        <div class="col-lg-9">
+                            <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="100" />
+                        </div>
+                    </div>
+                </fieldset>
+                {/foreach}
+            {else}
+                {assign var='varname' value='sitename_'|cat:$lang}
+                <div class="form-group">
+                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Site name'}</label>
+                    <div class="col-lg-9">
+                        <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="100" />
+                    </div>
                 </div>
-            </div>
-            <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_slogan">{gt text='Description line'}</label>
-                <div class="col-lg-9">
-                    <input id="settings_slogan" type="text" class="form-control" name="settings[slogan]" value="{$modvars.ZConfig.slogan|safetext}" size="50" maxlength="100" />
+                {assign var='varname' value='slogan_'|cat:$lang}
+                <div class="form-group">
+                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Description line'}</label>
+                    <div class="col-lg-9">
+                        <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="100" />
+                    </div>
                 </div>
-            </div>
+            {/if}
             <div class="form-group">
                 <label class="col-lg-3 control-label" for="settings_pagetitle">{gt text='Page title structure'}</label>
                 <div class="col-lg-9">
@@ -56,26 +80,56 @@
         </fieldset>
         <fieldset>
             <legend>{gt text='Meta tag settings'}</legend>
-            <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_defaultpagetitle">{gt text='Default page title'}</label>
-                <div class="col-lg-9">
-                    <input id="settings_defaultpagetitle" type="text" class="form-control" name="settings[defaultpagetitle]" value="{$modvars.ZConfig.defaultpagetitle|safetext}" size="50" maxlength="255" />
-                </div>
-            </div>
-            <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_defaultmetadescription">{gt text='Default meta description'}</label>
-                <div class="col-lg-9">
-                    <input id="settings_defaultmetadescription" type="text" class="form-control" name="settings[defaultmetadescription]" value="{$modvars.ZConfig.defaultmetadescription|safetext}" size="50" maxlength="255" />
-                </div>
-            </div>
-            <div id="settings_keywords_container">
+            {if $modvars.ZConfig.multilingual}
+                {foreach from=$languages key='code' item='language'}
+                <fieldset>
+                    <legend>{$language}</legend>
+                    {assign var='varname' value='defaultpagetitle_'|cat:$code}
+                    <div class="form-group">
+                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default page title'}</label>
+                        <div class="col-lg-9">
+                            <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="255" />
+                        </div>
+                    </div>
+                    {assign var='varname' value='defaultmetadescription_'|cat:$code}
+                    <div class="form-group">
+                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta description'}</label>
+                        <div class="col-lg-9">
+                            <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="255" />
+                        </div>
+                    </div>
+                    {assign var='varname' value='metakeywords_'|cat:$code}
+                    <div class="form-group">
+                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta keywords'}</label>
+                        <div class="col-lg-9">
+                            <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="255" />
+                        </div>
+                    </div>
+                </fieldset>
+                {/foreach}
+            {else}
+                {assign var='varname' value='defaultpagetitle_'|cat:$lang}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_metakeywords">{gt text='Default meta keywords'}</label>
+                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default page title'}</label>
                     <div class="col-lg-9">
-                        <textarea class="form-control" id="settings_metakeywords" name="settings[metakeywords]" cols="60" rows="5">{$modvars.ZConfig.metakeywords|safetext}</textarea>
+                        <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="255" />
                     </div>
                 </div>
-            </div>
+                {assign var='varname' value='defaultmetadescription_'|cat:$lang}
+                <div class="form-group">
+                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta description'}</label>
+                    <div class="col-lg-9">
+                        <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="255" />
+                    </div>
+                </div>
+                {assign var='varname' value='metakeywords_'|cat:$lang}
+                <div class="form-group">
+                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta keywords'}</label>
+                    <div class="col-lg-9">
+                        <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="255" />
+                    </div>
+                </div>
+            {/if}
         </fieldset>
         <fieldset>
             <legend>{gt text='Start page settings'}</legend>

--- a/src/system/Zikula/Module/SettingsModule/SettingsModuleInstaller.php
+++ b/src/system/Zikula/Module/SettingsModule/SettingsModuleInstaller.php
@@ -43,11 +43,6 @@ class SettingsModuleInstaller extends \Zikula_AbstractInstaller
         // there doesn't need to be a check to see if the variable is set in
         // the rest of the code as it always will be.
         System::setVar('debug', '0');
-        System::setVar('sitename', $this->__('Site name'));
-        System::setVar('slogan', $this->__('Site description'));
-        System::setVar('metakeywords', $this->__('zikula, portal, portal web, open source, web site, website, weblog, blog, content management, content management system, web content management, web content management system, enterprise web content management, cms, application framework'));
-        System::setVar('defaultpagetitle', $this->__('Site name'));
-        System::setVar('defaultmetadescription', $this->__('Site description'));
         System::setVar('startdate', date('m/Y', time()));
         System::setVar('adminmail', 'example@example.com');
         System::setVar('Default_Theme', 'ZikulaAndreas08Theme');
@@ -74,6 +69,14 @@ class SettingsModuleInstaller extends \Zikula_AbstractInstaller
         System::setVar('shorturls', false);
         System::setVar('shorturlstype', '0');
         System::setVar('shorturlsseparator', '-');
+        // Multilingual support
+        foreach (ZLanguage::getInstalledLanguages() as $lang) {
+            System::setVar('sitename_' . $lang, $this->__('Site name'));
+            System::setVar('slogan_' . $lang, $this->__('Site description'));
+            System::setVar('metakeywords_' . $lang, $this->__('zikula, portal, open source, web site, website, weblog, blog, content management system, cms, application framework'));
+            System::setVar('defaultpagetitle_' . $lang, $this->__('Site name'));
+            System::setVar('defaultmetadescription_' . $lang, $this->__('Site description'));
+        }
 
         if (function_exists('apache_get_modules') && in_array('mod_rewrite', apache_get_modules())) {
             // Only strip entry point if "mod_rewrite" is available.
@@ -144,7 +147,7 @@ class SettingsModuleInstaller extends \Zikula_AbstractInstaller
         switch ($oldversion) {
             case '2.9.7':
                 EventUtil::registerPersistentModuleHandler($this->name, 'installer.module.deactivated', array('Zikula\Module\SettingsModule\Listener\ModuleListener', 'moduleDeactivated'));
-            // future upgrade routines
+
             case '2.9.8':
                 $permasearch = System::getVar('permasearch');
                 if (empty($permasearch)) {
@@ -158,7 +161,23 @@ class SettingsModuleInstaller extends \Zikula_AbstractInstaller
                 if (empty($locale)) {
                     System::setVar('locale',  ZLanguage::getLocale());
                 }
+
             case '2.9.9':
+                // Multilingual support
+                foreach (ZLanguage::getInstalledLanguages() as $lang) {
+                    System::setVar('sitename_' . $lang, $sitename = System::getVar('sitename'));
+                    System::setVar('slogan_' . $lang, $sitename = System::getVar('slogan'));
+                    System::setVar('metakeywords_' . $lang, $sitename = System::getVar('metakeywords'));
+                    System::setVar('defaultpagetitle_' . $lang, $sitename = System::getVar('defaultpagetitle'));
+                    System::setVar('defaultmetadescription_' . $lang, $sitename = System::getVar('defaultmetadescription'));
+                }
+                System::delVar('sitename');
+                System::delVar('slogan');
+                System::delVar('metakeywords');
+                System::delVar('defaultpagetitle');
+                System::delVar('defaultmetadescription');
+
+            case '3.0.0':
                 // current version
         }
 

--- a/src/system/Zikula/Module/SettingsModule/SettingsModuleInstaller.php
+++ b/src/system/Zikula/Module/SettingsModule/SettingsModuleInstaller.php
@@ -177,7 +177,7 @@ class SettingsModuleInstaller extends \Zikula_AbstractInstaller
                 System::delVar('defaultpagetitle');
                 System::delVar('defaultmetadescription');
 
-            case '3.0.0':
+            case '2.9.10':
                 // current version
         }
 

--- a/src/system/Zikula/Module/SettingsModule/SettingsModuleVersion.php
+++ b/src/system/Zikula/Module/SettingsModule/SettingsModuleVersion.php
@@ -30,7 +30,7 @@ class SettingsModuleVersion extends \Zikula_AbstractVersion
         $meta['description'] = $this->__('General site configuration interface.');
         //! module name that appears in URL
         $meta['url'] = $this->__('settings');
-        $meta['version'] = '2.9.9';
+        $meta['version'] = '3.0.0';
         $meta['core_min'] = '1.4.0';
         $meta['securityschema'] = array('ZikulaSettingsModule::' => '::');
 

--- a/src/system/Zikula/Module/SettingsModule/SettingsModuleVersion.php
+++ b/src/system/Zikula/Module/SettingsModule/SettingsModuleVersion.php
@@ -30,7 +30,7 @@ class SettingsModuleVersion extends \Zikula_AbstractVersion
         $meta['description'] = $this->__('General site configuration interface.');
         //! module name that appears in URL
         $meta['url'] = $this->__('settings');
-        $meta['version'] = '3.0.0';
+        $meta['version'] = '2.9.10';
         $meta['core_min'] = '1.4.0';
         $meta['securityschema'] = array('ZikulaSettingsModule::' => '::');
 


### PR DESCRIPTION
With this PR I'm trying to fix a long awaiting multilingual issue.

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | #777, #519
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | yes

Some pictures from the interface for entering multilingual items. This is of course subject to change, if sombody like to make better interface.

![image](https://cloud.githubusercontent.com/assets/628801/6513630/edbfbf3c-c384-11e4-9477-ac2728521f1d.png)

![image](https://cloud.githubusercontent.com/assets/628801/6513671/4be42d0a-c385-11e4-9de1-4e9c41a81f59.png)

Please check changed files, to discuss if this is the best way to implement.