### PR TITLE
In an attempt to reduce redundancy, removing placeholders

### DIFF
--- a/src/system/Zikula/Module/UsersModule/Resources/views/Authentication/LoginFormFields/Default/Default.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Authentication/LoginFormFields/Default/Default.tpl
@@ -39,7 +39,7 @@
             {elseif $authentication_method eq 'uname' || $authentication_method eq 'unameoremail'}
                 <i class="fa fa-fw fa-user input-group-addon"></i>
             {/if}
-            <input id="users_login_login_id" class="form-control"  type="text" name="authentication_info[login_id]" maxlength="64" value="{if isset($authentication_info.login_id)}{$authentication_info.login_id}{/if}" placeholder="{if $authentication_method eq 'email'}{gt text='Email address'}{elseif $authentication_method eq 'uname'}{gt text='User name'}{elseif $authentication_method eq 'unameoremail'}{gt text='User name or e-mail address'}{/if}" required="required" />
+            <input id="users_login_login_id" class="form-control"  type="text" name="authentication_info[login_id]" maxlength="64" value="{if isset($authentication_info.login_id)}{$authentication_info.login_id}{/if}" required="required" />
         </div>
     </div>
 </div>
@@ -49,7 +49,7 @@
     <div class="col-lg-9">
         <div class="input-group">
             <i class="fa fa-fw fa-asterisk input-group-addon"></i>
-            <input id="users_login_pass" class="form-control" type="password" name="authentication_info[pass]" size="25" maxlength="60" placeholder="{if isset($change_password) && $change_password}{gt text='Current password'}{else}{gt text='Password'}{/if}" required="required" />
+            <input id="users_login_pass" class="form-control" type="password" name="authentication_info[pass]" size="25" maxlength="60" required="required" />
             <i id="capsLok" class="fa fa-fw fa-arrow-circle-up input-group-addon hide"> {gt text='Caps Lock is on!'}</i>
         </div>
     </div>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Authentication/LoginFormFields/loginblock/Default.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Authentication/LoginFormFields/loginblock/Default.tpl
@@ -8,10 +8,10 @@
             {gt text='User name or e-mail address'}
         {/if}
     </label>
-    <input id="users_loginblock_login_id" class="form-control input-sm" type="text" name="authentication_info[login_id]" maxlength="64" value="" placeholder="{if $authentication_method eq 'email'}{gt text='Email address'}{elseif $authentication_method eq 'uname'}{gt text='User name'}{elseif $authentication_method eq 'unameoremail'}{gt text='User name or e-mail address'}{/if}" />
+    <input id="users_loginblock_login_id" class="form-control input-sm" type="text" name="authentication_info[login_id]" maxlength="64" value="" />
 </div>
 
 <div class="form-group">
     <label class="control-label sr-only" for="users_loginblock_pass">{gt text='Password'}</label>
-    <input id="users_loginblock_pass" class="form-control input-sm" type="password" name="authentication_info[pass]" size="25" maxlength="60" placeholder="{gt text='Password'}" />
+    <input id="users_loginblock_pass" class="form-control input-sm" type="password" name="authentication_info[pass]" size="25" maxlength="60" />
 </div>


### PR DESCRIPTION
In an attempt to reduce redundancy, removing placeholders which are not providing extra information of importance to the end user. The same content that was displayed in the placeholders are already displayed as the labels for the corresponding form fields.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no