### PR TITLE
Fix initial values to multilingual setting variables

### DIFF
--- a/src/lib/util/ModUtil.php
+++ b/src/lib/util/ModUtil.php
@@ -127,7 +127,7 @@ class ModUtil
          }
 
          // Init multilingual variables here, just to have values, even with default site language (page language is set later)
-         self::function setupMultilingual()
+         self::setupMultilingual()
 
          // Pre-load the module variables array with empty arrays for known modules that
          // do not define any module variables to prevent unnecessary SQL queries to

--- a/src/lib/util/ModUtil.php
+++ b/src/lib/util/ModUtil.php
@@ -126,6 +126,9 @@ class ModUtil
             }
          }
 
+         // Init multilingual variables here, just to have values, even with default site language (page language is set later)
+         self::function setupMultilingual()
+
          // Pre-load the module variables array with empty arrays for known modules that
          // do not define any module variables to prevent unnecessary SQL queries to
          // the module_vars table.

--- a/src/system/Zikula/Module/SettingsModule/SettingsModuleInstaller.php
+++ b/src/system/Zikula/Module/SettingsModule/SettingsModuleInstaller.php
@@ -164,18 +164,15 @@ class SettingsModuleInstaller extends \Zikula_AbstractInstaller
 
             case '2.9.9':
                 // Multilingual support
-                foreach (ZLanguage::getInstalledLanguages() as $lang) {
-                    System::setVar('sitename_' . $lang, System::getVar('sitename'));
-                    System::setVar('slogan_' . $lang, System::getVar('slogan'));
-                    System::setVar('metakeywords_' . $lang, System::getVar('metakeywords'));
-                    System::setVar('defaultpagetitle_' . $lang, System::getVar('defaultpagetitle'));
-                    System::setVar('defaultmetadescription_' . $lang, System::getVar('defaultmetadescription'));
+                foreach (array('sitename', 'slogan', 'metakeywords', 'defaultpagetitle', 'defaultmetadescription') as $variable) {
+                    foreach (ZLanguage::getInstalledLanguages() as $langcode) {
+                        $variable_ml = $variable . '_' . $langcode;
+                        if (!isset(System::getVar($variable_ml)) || empty(System::getVar($variable_ml))) {
+                            System::setVar($variable_ml, System::getVar($variable));
+                        }
+                    }
+                    System::delVar($variable);
                 }
-                System::delVar('sitename');
-                System::delVar('slogan');
-                System::delVar('metakeywords');
-                System::delVar('defaultpagetitle');
-                System::delVar('defaultmetadescription');
 
             case '2.9.10':
                 // current version


### PR DESCRIPTION
This make sure variables have initial values when site loads.
Also more robust check in upgrade process.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | - #2330
| Refs tickets      | - #2316
| License           | MIT
| Doc PR            | -
| Changelog updated | no