### PR TITLE
Fix form tag textarea  for metakeywords in settings

### DIFF
--- a/src/system/Zikula/Module/SettingsModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/SettingsModule/Resources/views/Admin/modifyconfig.tpl
@@ -102,7 +102,7 @@
                     <div class="form-group">
                         <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta keywords'}</label>
                         <div class="col-lg-9">
-                            <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="255" />
+                            <textarea class="form-control" id="settings_{$varname}" name="settings[{$varname}]" cols="60" rows="3">{$modvars.ZConfig.$varname|safetext}</textarea>
                         </div>
                     </div>
                 </fieldset>
@@ -126,7 +126,7 @@
                 <div class="form-group">
                     <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta keywords'}</label>
                     <div class="col-lg-9">
-                        <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|safetext}" size="50" maxlength="255" />
+                        <textarea class="form-control" id="settings_{$varname}" name="settings[{$varname}]" cols="60" rows="3">{$modvars.ZConfig.$varname|safetext}</textarea>
                     </div>
                 </div>
             {/if}


### PR DESCRIPTION
This fix is to PR #2316.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | - #2316
| License           | MIT
| Doc PR            | -
| Changelog updated | no