### PR TITLE
[1.4] Change language in template with shorturls enabled

### DIFF
--- a/src/lib/legacy/viewplugins/function.langchange.php
+++ b/src/lib/legacy/viewplugins/function.langchange.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright Zikula Foundation 2009 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Zikula_View
+ * @subpackage Template_Plugins
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+/**
+ * Zikula_View function to get current URI/URL to change language, handling in proper way short URLs
+ *
+ * This function obtains the current request URI and returns URI/URL with parameter to change language.
+ * The results of this function are already sanitized to display, so it should not be passed to the safetext modifier.
+ *
+ * Available parameters:
+ *   - assign:   If set, the results are assigned to the corresponding variable instead of printed out
+ *   - lang:     Language code to change to
+ *   - fqurl:    Fully Qualified URL. True to get full URL, otherwise return URI
+ *
+ * Example
+ *   {langchange lang='de'}
+ *
+ * @param array       $params All attributes passed to this function from the template.
+ * @param Zikula_View $view   Reference to the Zikula_View object.
+ *
+ * @return string The changed current URI.
+ */
+function smarty_function_langchange($params, Zikula_View $view)
+{
+    $assign = null;
+    if (isset($params['assign'])) {
+        $assign = $params['assign'];
+        unset($params['assign']);
+    }
+    $lang = null;
+    if (isset($params['lang'])) {
+        $lang = $params['lang'];
+    }
+    $fqurl = false;
+    if (isset($params['fqurl'])) {
+        $fqurl = $params['fqurl'];
+        unset($params['fqurl']);
+    }
+
+    // Handling short URL's similar to Language selector block
+    $shorturls = System::getVar('shorturls', false);
+    if (isset($lang) && $shorturls) {
+        $module = FormUtil::getPassedValue('module', null, 'GET', FILTER_SANITIZE_STRING);
+        $type = FormUtil::getPassedValue('type', null, 'GET', FILTER_SANITIZE_STRING);
+        $func = FormUtil::getPassedValue('func', null, 'GET', FILTER_SANITIZE_STRING);
+        if (isset($module) && isset($type) && isset($func)) {
+            // build URL based on module URL
+            $result = ModUtil::url($module, $type, $func, $_GET, null, null, $fqurl, false, $lang);
+        } else {
+            // to homepage with language set in terms of short url's
+            if ($fqurl) {
+                $result = System::getVar('entrypoint', 'index.php') . "?lang=" . $lang;
+            } else {
+                $result = $lang;
+            }
+        }
+    } else {
+        if ($fqurl) {
+            $result = htmlspecialchars(System::getCurrentUrl($params));
+        } else {
+            $result = htmlspecialchars(System::getCurrentUri($params));
+        }
+    }
+
+    if ($assign) {
+        $view->assign($assign, $result);
+    } else {
+        return $result;
+    }
+}


### PR DESCRIPTION
The problem described here:
#2348: ```[1.3] Problem in changing to default language with shorturls enabled and using {getcurrenturi} in template```
exist in 1.4 branch also.
This PR transfers the ```langchange``` view plugin  in 1.4 branch. The code is compared, tested, works, and it remains same as in 1.3 branch.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | - #2348
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no