### PR TITLE
The charset attribute is new in HTML5

### DIFF
--- a/src/themes/SeaBreezeTheme/Resources/views/includes/head.tpl
+++ b/src/themes/SeaBreezeTheme/Resources/views/includes/head.tpl
@@ -1,4 +1,4 @@
-<meta http-equiv="Content-Type" content="text/html; charset={charset}" />
+<meta charset="{charset}" />
 <title>{pagegetvar name='title'}</title>
 <meta name="description" content="{$metatags.description}" />
 <meta name="keywords" content="{$metatags.keywords}" />

--- a/src/themes/Zikula/Theme/Andreas08Theme/Resources/views/includes/header.tpl
+++ b/src/themes/Zikula/Theme/Andreas08Theme/Resources/views/includes/header.tpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{lang}" dir="{langdirection}">
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset={charset}" />
+        <meta charset="{charset}" />
         <title>{pagegetvar name='title'}</title>
         <meta name="description" content="{$metatags.description}" />
         <meta name="keywords" content="{$metatags.keywords}" />

--- a/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/includes/header.tpl
+++ b/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/includes/header.tpl
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="{lang}" dir="{langdirection}">
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset={charset}" />
+        <meta charset="{charset}" />
         <title>{pagegetvar name='title'}</title>
         <meta name="description" content="{$metatags.description}" />
         <meta name="keywords" content="{$metatags.keywords}" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">        
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />        
         {pageaddvar name="stylesheet" value="$stylepath/style.css"}
     </head>
     <body>


### PR DESCRIPTION
The charset attribute is new in HTML5, and replaces the need for: <meta ...http-equiv="Content-Type" content="text/html; charset=UTF-8">.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no