### PR TITLE
View plugin {moduleheader}

### DIFF
--- a/src/docs/CHANGELOG
+++ b/src/docs/CHANGELOG
@@ -10,6 +10,7 @@ CHANGELOG - ZIKULA 1.3.10
 - Updated Imagine lib to 0.6.2 and plugin is enhanced with width/height autoscale and jpg/png quality (#2174, #1644)
 - New view plugin {langchange} for switching language, also function with shorturls enabled (#2356)
 - Multilingual site name, site description and site meta tags (#2358)
+- Added view plugin {moduleheader} to unify module headers and make styling at one place - moduleheader.tpl (#2371).
 
 CHANGELOG - ZIKULA 1.3.9
 ------------------------

--- a/src/lib/viewplugins/function.moduleheader.php
+++ b/src/lib/viewplugins/function.moduleheader.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Zikula Application Framework
+ *
+ * Copyright Zikula Foundation 2011 - Zikula Application Framework
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package      Zikula_System_Modules
+ * @subpackage   Zikula_Admin
+ */
+
+
+/**
+ * Smarty function build module header in user content page.
+ *
+ * {moduleheader}
+ *
+ * Available parameters:
+ *  modname    Module name to display header for (optional, defaults to current module)
+ *  type       Type for module links (defaults to 'user')
+ *  title      Title to display in header (optional, defaults to module name)
+ *  titlelink  Link to attach to title (optional, defaults to none)
+ *  setpagetitle If set to true, {pagesetvar} is used to set page title
+ *  insertstatusmsg If set to true, {insert name='getstatusmsg'} is put in front of template
+ *  menufirst  If set to true, menu is first, then title
+ *  putimage   If set to true, module image is also displayed next to title
+ *
+ * @param array       $params All attributes passed to this function from the template.
+ * @param Zikula_View $view   Reference to the Zikula_View object.
+ *
+ * @return string A formatted string containing navigation for the module admin panel.
+ */
+function smarty_function_moduleheader($params, $view)
+{
+    if (!isset($params['modname']) || !ModUtil::available($params['modname'])) {
+        $params['modname'] = ModUtil::getName();
+    }
+    if (empty($params['modname'])) {
+        return false;
+    }
+    $type = isset($params['type']) ? $params['type'] : 'user';
+    $assign = isset($params['assign']) ? $params['assign'] : null;
+    $menufirst = isset($params['menufirst']) ? $params['menufirst'] : false;
+    $putimage = isset($params['putimage']) ? $params['putimage'] : false;
+    $setpagetitle = isset($params['setpagetitle']) ? $params['setpagetitle'] : false;
+    $insertstatusmsg = isset($params['insertstatusmsg']) ? $params['insertstatusmsg'] : false;
+    $cutlenght = isset($params['cutlenght']) ? $params['cutlenght'] : 20;
+    if ($putimage) {
+        $image = isset($params['image']) ? $params['image'] : ModUtil::getModuleImagePath($params['modname']);
+    } else {
+        $image = '';
+    }
+    if (!isset($params['title'])) {
+        $modinfo = ModUtil::getInfoFromName($params['modname']);
+        if (isset($modinfo['displayname'])) {
+            $params['title'] = $modinfo['displayname'];
+        } else {
+            $params['title'] = ModUtil::getName();
+        }
+    }
+    $titlelink = isset($params['titlelink']) ? $params['titlelink'] : false;
+
+    $renderer = Zikula_View::getInstance('Theme');
+    $renderer->setCaching(Zikula_View::CACHE_DISABLED);
+
+    $renderer->assign('themename', UserUtil::getTheme());
+    $renderer->assign('modname', $params['modname']);
+    $renderer->assign('type', $params['type']);
+    $renderer->assign('title', $params['title']);
+    $renderer->assign('titlelink', $titlelink);
+    $renderer->assign('truncated', mb_strlen($params['title']) > $cutlenght);
+    $renderer->assign('titletruncated', mb_substr($params['title'], 0, $cutlenght) . '...');
+    $renderer->assign('setpagetitle', $setpagetitle);
+    $renderer->assign('insertstatusmsg', $insertstatusmsg);
+    $renderer->assign('menufirst', $menufirst);
+    $renderer->assign('image', $image);
+
+    if ($assign) {
+        $view->assign($assign, $renderer->fetch('moduleheader.tpl'));
+    } else {
+        return $renderer->fetch('moduleheader.tpl');
+    }
+}

--- a/src/system/Admin/templates/admin_admin_header.tpl
+++ b/src/system/Admin/templates/admin_admin_header.tpl
@@ -1,8 +1,5 @@
 {admincategorymenu}
 <div class="z-admin-content z-clearfix">
-    <div class="z-admin-content-modtitle">
-	{modgetinfo modname=$toplevelmodule info='displayname' assign='displayName'}
-	<img src="{modgetimage|safetext}" alt="{$displayName|safetext}" />
-	<h2>{$displayName}</h2>
-    </div>
-    {modulelinks modname=$toplevelmodule type='admin'}
+    {modgetinfo modname=$toplevelmodule info='displayname' assign='displayName'}
+    {modgetimage assign='image'}
+    {moduleheader modname=$toplevelmodule type='admin' title=$displayName putimage=true image=$image}

--- a/src/system/Search/templates/search_user_menu.tpl
+++ b/src/system/Search/templates/search_user_menu.tpl
@@ -1,5 +1,2 @@
-{insert name="getstatusmsg"}
 {gt text="Site search" assign=title domain='zikula'}
-<h2>{$title|safetext}</h2>
-{pagesetvar name=title value=$templatetitle}
-{modulelinks modname='Search' type='user'}
+{moduleheader modname='Search' type='user' title=$title setpagetitle=true insertstatusmsg=true}

--- a/src/system/Theme/templates/moduleheader.tpl
+++ b/src/system/Theme/templates/moduleheader.tpl
@@ -1,0 +1,19 @@
+{if $setpagetitle && $title}
+    {pagesetvar name='title' value=$title}
+{/if}
+{if $insertstatusmsg}
+    {insert name='getstatusmsg'}
+{/if}
+
+{if $themename|strtolower|strpos:"printer" !== false}
+    {if isset($image) && $image}<img src="{$image|safetext}" alt="{$title|safetext}" />{/if}
+    {if $title}<h2>{$title|safetext}</h2>{/if}
+
+{else}
+    {if $menufirst}{modulelinks modname=$modname type=$type}{/if}
+    <div class="{if $type == 'user'}z-modtitle{else}z-admin-content-modtitle{/if}">
+        {if $image}<img src="{$image|safetext}" alt="{$title|safetext}" class="z-floatleft" />{/if}
+        {if $title}<h2>{$title|safetext}</h2>{/if}
+    </div>
+    {if !$menufirst}{modulelinks modname=$modname type=$type}{/if}
+{/if}

--- a/src/system/Users/templates/users_user_login.tpl
+++ b/src/system/Users/templates/users_user_login.tpl
@@ -6,7 +6,6 @@
 {/if}
 {/foreach}
 {gt text='User log-in' assign='templatetitle'}
-{modulelinks modname='Users' type='user'}
 {include file='users_user_menu.tpl'}
 {if (count($authentication_method_display_order) > 1)}
 <div>

--- a/src/system/Users/templates/users_user_lostpassword.tpl
+++ b/src/system/Users/templates/users_user_lostpassword.tpl
@@ -1,5 +1,4 @@
 {gt text='Lost password recovery' assign='templatetitle'}
-{modulelinks modname='Users' type='user'}
 {include file='users_user_menu.tpl'}
 
 <p class="z-informationmsg">{gt text="Please enter EITHER your user name OR your e-mail address below and click the 'Submit' button. You will be e-mailed a confirmation code. Check your e-mail, and follow the given instructions."}</p>

--- a/src/system/Users/templates/users_user_lostpasswordcode.tpl
+++ b/src/system/Users/templates/users_user_lostpasswordcode.tpl
@@ -1,5 +1,4 @@
 {gt text='Enter confirmation code' assign='templatetitle'}
-{modulelinks modname='Users' type='user'}
 {include file='users_user_menu.tpl'}
 
 <p class="z-informationmsg">{gt text="Please enter and EITHER your user name OR your e-mail address, and also enter the confirmation code you received. Once you enter this information and click the 'Submit' button you will receive a new password via e-mail."}</p>

--- a/src/system/Users/templates/users_user_lostpwduname.tpl
+++ b/src/system/Users/templates/users_user_lostpwduname.tpl
@@ -1,5 +1,4 @@
 {gt text='Account information and password recovery' assign='templatetitle'}
-{modulelinks modname='Users' type='user'}
 {include file='users_user_menu.tpl'}
 
 <p>{gt text="Please select one of the following:"}</p>

--- a/src/system/Users/templates/users_user_lostuname.tpl
+++ b/src/system/Users/templates/users_user_lostuname.tpl
@@ -1,5 +1,4 @@
 {gt text='Account information recovery' assign='templatetitle'}
-{modulelinks modname='Users' type='user'}
 {include file='users_user_menu.tpl'}
 
 <p class="z-informationmsg">{gt text="Please enter your e-mail address below and click the 'Submit' button. You will be sent an e-mail with your account information."}</p>

--- a/src/system/Users/templates/users_user_menu.tpl
+++ b/src/system/Users/templates/users_user_menu.tpl
@@ -1,8 +1,4 @@
 {if $templatetitle|default:'' eq ''}
     {gt text='My account' assign='templatetitle'}
 {/if}
-{pagesetvar name='title' value=$templatetitle}
-
-<h2>{$templatetitle}</h2>
-
-{insert name='getstatusmsg'}
+{moduleheader modname='Users' type='user' title=$templatetitle setpagetitle=true insertstatusmsg=true}

--- a/src/system/Users/templates/users_user_passwordreminder.tpl
+++ b/src/system/Users/templates/users_user_passwordreminder.tpl
@@ -1,5 +1,4 @@
 {gt text='Lost password recovery' assign='templatetitle'}
-{modulelinks modname='Users' type='user'}
 {include file='users_user_menu.tpl'}
 
 {if !empty($passreminder)}

--- a/src/system/Users/templates/users_user_verifyregistration.tpl
+++ b/src/system/Users/templates/users_user_verifyregistration.tpl
@@ -17,7 +17,6 @@
     {/if}
 {/strip}
             
-{modulelinks modname='Users' type='user'}
 {include file='users_user_menu.tpl'}
 
 {if !empty($errormessages)}


### PR DESCRIPTION
This is last step in making easier to style module headers at one place - now with overriding ```moduleheader.tpl``` in system module Themes.

This is my last new feature proposal  to 1.3 branch.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| 1.4 PR        | - #2372
| Refs tickets  | -
| License       | LGPLv3+
| Doc PR        | - no