### PR TITLE
View plugin moduleheader

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -119,3 +119,4 @@ Features:
 - Include Zikula/Wizard - a library to assist in multi-stage user interaction (used in installer)
 - Added multilingual support for site name, site description and site meta tags (#2316).
 - Added view plugin {langchange} for switching language, function with shorturls enabled (#2364)
+- Added view plugin {moduleheader} to unify module headers and make styling at one place - moduleheader.tpl (#2372).

--- a/src/lib/legacy/viewplugins/function.moduleheader.php
+++ b/src/lib/legacy/viewplugins/function.moduleheader.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Zikula Application Framework
+ *
+ * Copyright Zikula Foundation 2011 - Zikula Application Framework
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package      Zikula_System_Modules
+ * @subpackage   Zikula_Admin
+ */
+
+
+/**
+ * Smarty function build module header in user content page.
+ *
+ * {moduleheader}
+ *
+ * Available parameters:
+ *  modname    Module name to display header for (optional, defaults to current module)
+ *  type       Type for module links (defaults to 'user')
+ *  title      Title to display in header (optional, defaults to module name)
+ *  titlelink  Link to attach to title (optional, defaults to none)
+ *  setpagetitle If set to true, {pagesetvar} is used to set page title
+ *  insertstatusmsg If set to true, {insert name='getstatusmsg'} is put in front of template
+ *  menufirst  If set to true, menu is first, then title
+ *  putimage   If set to true, module image is also displayed next to title
+ *
+ * @param array       $params All attributes passed to this function from the template.
+ * @param Zikula_View $view   Reference to the Zikula_View object.
+ *
+ * @return string A formatted string containing navigation for the module admin panel.
+ */
+function smarty_function_moduleheader($params, $view)
+{
+    if (!isset($params['modname']) || !ModUtil::available($params['modname'])) {
+        $params['modname'] = ModUtil::getName();
+    }
+    if (empty($params['modname'])) {
+        return false;
+    }
+    $type = isset($params['type']) ? $params['type'] : 'user';
+    $assign = isset($params['assign']) ? $params['assign'] : null;
+    $menufirst = isset($params['menufirst']) ? $params['menufirst'] : false;
+    $putimage = isset($params['putimage']) ? $params['putimage'] : false;
+    $setpagetitle = isset($params['setpagetitle']) ? $params['setpagetitle'] : false;
+    $insertstatusmsg = isset($params['insertstatusmsg']) ? $params['insertstatusmsg'] : false;
+    $cutlenght = isset($params['cutlenght']) ? $params['cutlenght'] : 20;
+    if ($putimage) {
+        $image = isset($params['image']) ? $params['image'] : ModUtil::getModuleImagePath($params['modname']);
+    } else {
+        $image = '';
+    }
+    if (!isset($params['title'])) {
+        $modinfo = ModUtil::getInfoFromName($params['modname']);
+        if (isset($modinfo['displayname'])) {
+            $params['title'] = $modinfo['displayname'];
+        } else {
+            $params['title'] = ModUtil::getName();
+        }
+    }
+    $titlelink = isset($params['titlelink']) ? $params['titlelink'] : false;
+
+    $renderer = Zikula_View::getInstance('Theme');
+    $renderer->setCaching(Zikula_View::CACHE_DISABLED);
+
+    $renderer->assign('themename', UserUtil::getTheme());
+    $renderer->assign('modname', $params['modname']);
+    $renderer->assign('type', $params['type']);
+    $renderer->assign('title', $params['title']);
+    $renderer->assign('titlelink', $titlelink);
+    $renderer->assign('truncated', mb_strlen($params['title']) > $cutlenght);
+    $renderer->assign('titletruncated', mb_substr($params['title'], 0, $cutlenght) . '...');
+    $renderer->assign('setpagetitle', $setpagetitle);
+    $renderer->assign('insertstatusmsg', $insertstatusmsg);
+    $renderer->assign('menufirst', $menufirst);
+    $renderer->assign('image', $image);
+
+    if ($assign) {
+        $view->assign($assign, $renderer->fetch('moduleheader.tpl'));
+    } else {
+        return $renderer->fetch('moduleheader.tpl');
+    }
+}

--- a/src/system/Zikula/Module/AdminModule/Resources/views/Admin/header.tpl
+++ b/src/system/Zikula/Module/AdminModule/Resources/views/Admin/header.tpl
@@ -1,8 +1,5 @@
 {admincategorymenu}
 <div class="z-admin-content clearfix">
-    <div class="z-admin-content-modtitle">
-        {modgetinfo modname=$toplevelmodule info='displayname' assign='displayName'}
-        <img src="{modgetimage|safetext}" alt="{$displayName|safetext}" />  
-        <h2>{$displayName}</h2>
-    </div>
-    {modulelinks modname=$toplevelmodule type='admin'}
+    {modgetinfo modname=$toplevelmodule info='displayname' assign='displayName'}
+    {modgetimage assign='image'}
+    {moduleheader modname=$toplevelmodule type='admin' title=$displayName putimage=true image=$image}

--- a/src/system/Zikula/Module/SearchModule/Resources/views/User/menu.tpl
+++ b/src/system/Zikula/Module/SearchModule/Resources/views/User/menu.tpl
@@ -1,5 +1,2 @@
-{insert name='getstatusmsg'}
-{gt text='Site search' assign='title' domain='zikula'}
-<h2>{$title|safetext}</h2>
-{pagesetvar name='title' value=$title}
-{modulelinks modname='ZikulaSearchModule' type='user'}
+{gt text="Site search" assign=title domain='zikula'}
+{moduleheader modname='Search' type='user' title=$title setpagetitle=true insertstatusmsg=true}

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/moduleheader.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/moduleheader.tpl
@@ -1,0 +1,19 @@
+{if $setpagetitle && $title}
+    {pagesetvar name='title' value=$title}
+{/if}
+{if $insertstatusmsg}
+    {insert name='getstatusmsg'}
+{/if}
+
+{if $themename|strtolower|strpos:"printer" !== false}
+    {if isset($image) && $image}<img src="{$image|safetext}" alt="{$title|safetext}" />{/if}
+    {if $title}<h2>{$title|safetext}</h2>{/if}
+
+{else}
+    {if $menufirst}{modulelinks modname=$modname type=$type}{/if}
+    <div class="{if $type == 'user'}z-modtitle{else}z-admin-content-modtitle{/if}">
+        {if $image}<img src="{$image|safetext}" alt="{$title|safetext}" class="z-floatleft" />{/if}
+        {if $title}<h2>{$title|safetext}</h2>{/if}
+    </div>
+    {if !$menufirst}{modulelinks modname=$modname type=$type}{/if}
+{/if}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/menu.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/menu.tpl
@@ -1,9 +1,4 @@
 {if $templatetitle|default:'' eq ''}
     {gt text='My account' assign='templatetitle'}
 {/if}
-
-{pagesetvar name='title' value=$templatetitle}
-
-<h2>{$templatetitle}</h2>
-{modulelinks modname='ZikulaUsersModule' type='user'}
-{insert name='getstatusmsg'}
+{moduleheader modname='Users' type='user' title=$templatetitle setpagetitle=true insertstatusmsg=true}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/passwordreminder.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/passwordreminder.tpl
@@ -1,5 +1,4 @@
 {gt text='Lost password recovery' assign='templatetitle'}
-{modulelinks modname='ZikulaUsersModule' type='user'}
 {include file='User/menu.tpl'}
 
 {if !empty($passreminder)}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/verifyregistration.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/verifyregistration.tpl
@@ -18,7 +18,6 @@
     {/if}
 {/strip}
             
-{modulelinks modname='ZikulaUsersModule' type='user'}
 {include file='User/menu.tpl'}
 
 {if !empty($errormessages)}


### PR DESCRIPTION
This is last step in making easier to style module headers at one place - now with overriding moduleheader.tpl in system module Themes.

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no