### PR TITLE
Bootstrap theme overrides

### DIFF
--- a/src/lib/legacy/viewplugins/function.modulelinks.php
+++ b/src/lib/legacy/viewplugins/function.modulelinks.php
@@ -241,7 +241,7 @@ function smarty_function_modulelinks($params, Zikula_View $view)
                 if (!empty($menuitem['icon'])) {
                     $icon = '<span class="fa fa-'.$menuitem['icon'].'"></span> ';
                 }
-                $html .= '<a href="'.DataUtil::formatForDisplay($menuitem['url']).'"'.$attr.'>'.$icon.$menuitem['text'].'</a>';
+                $html .= '<a href="'.DataUtil::formatForDisplay($menuitem['url']).'"'.$attr.' style="display: inline-block;">'.$icon.$menuitem['text'].'</a>';
                 if (isset($menuitem['links'])) {
                     $html .= '<a href="#" class="dropdown-toggle" data-toggle="dropdown" style="text-decoration: none;">&nbsp;<b class="caret"></b></a>';
                 }

--- a/src/themes/Zikula/Theme/BootstrapTheme/Resources/config/overrides.yml
+++ b/src/themes/Zikula/Theme/BootstrapTheme/Resources/config/overrides.yml
@@ -1,0 +1,5 @@
+## YAML Override template
+## original/file.tpl: override/file.tpl
+---
+system/Zikula/Module/UsersModule/Resources/views/User/main.tpl: themes/Zikula/Theme/BootstrapTheme/Resources/views/modules/ZikulaUsersModule/User/main.tpl
+system/Zikula/Module/ThemeModule/Resources/views/moduleheader.tpl: themes/Zikula/Theme/BootstrapTheme/Resources/views/modules/ZikulaThemeModule/moduleheader.tpl

--- a/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/includes/header.tpl
+++ b/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/includes/header.tpl
@@ -21,6 +21,39 @@
           <a class="navbar-brand" href="{homepage}">{$modvars.ZConfig.sitename}</a>
         </div>
         <div class="navbar-collapse collapse">
+        {if $pagetype eq 'admin'}
+          <ul class="nav navbar-nav">
+            <li><a href="{homepage}">{gt text='Home'}</a></li>
+            {checkpermission component='ZikulaSettingsModule::' instance='::' level='ACCESS_ADMIN' assign='okAccess'}
+            {if $okAccess}
+            <li><a href="{modurl modname='ZikulaSettingsModule' type='admin' func='index'}">{gt text="Settings"}</a></li>
+            {/if}
+            {checkpermission component='ZikulaExtensionsModule::' instance='::' level='ACCESS_ADMIN' assign='okAccess'}
+            {if $okAccess}
+            <li><a href="{modurl modname='ZikulaExtensionsModule' type='admin' func='index'}">{gt text="Extensions"}</a></li>
+            {/if}
+            {checkpermission component='ZikulaBlocksModule::' instance='::' level='ACCESS_EDIT' assign='okAccess'}
+            {if $okAccess}
+            <li><a href="{modurl modname='ZikulaBlocksModule' type='admin' func='index'}">{gt text="Blocks"}</a></li>
+            {/if}
+            {checkpermission component='ZikulaUsersModule::' instance='::' level='ACCESS_MODERATE' assign='okAccess'}
+            {if $okAccess}
+            <li><a href="{modurl modname='ZikulaUsersModule' type='admin' func='index'}">{gt text="Users"}</a></li>
+            {/if}
+            {checkpermission component='ZikulaGroupsModule::' instance='::' level='ACCESS_EDIT' assign='okAccess'}
+            {if $okAccess}
+            <li><a href="{modurl modname='ZikulaGroupsModule' type='admin' func='index'}">{gt text="Groups"}</a></li>
+            {/if}
+            {checkpermission component='ZikulaPermissionsModule::' instance='::' level='ACCESS_ADMIN' assign='okAccess'}
+            {if $okAccess}
+            <li><a href="{modurl modname='ZikulaPermissionsModule' type='admin' func='index'}">{gt text="Permission rules"}</a></li>
+            {/if}
+            {checkpermission component='ZikulaThemeModule::' instance='::' level='ACCESS_EDIT' assign='okAccess'}
+            {if $okAccess}
+            <li><a href="{modurl modname='ZikulaThemeModule' type='admin' func='index'}">{gt text="Themes"}</a></li>
+            {/if}
+          </ul>
+        {else}
           <ul class="nav navbar-nav">
             <li class="active"><a href="{homepage}" title="{gt text="Go to the site's home page"}">{gt text='Home'}</a></li>
             <li><a href="{modurl modname='ZikulaUsersModule' type='user' func='main'}" title="{gt text='Go to your account panel'}">{gt text="My Account"}</a></li>
@@ -47,6 +80,7 @@
             </div>
             <button type="submit" class="btn btn-success">Sign in</button>
           </form>
+        {/if}
         </div><!--/.navbar-collapse -->
       </div>
     </div>

--- a/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/modules/ZikulaThemeModule/moduleheader.tpl
+++ b/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/modules/ZikulaThemeModule/moduleheader.tpl
@@ -1,0 +1,43 @@
+{if $setpagetitle && $title}
+    {pagesetvar name='title' value=$title}
+{/if}
+{if $insertstatusmsg}
+    {insert name='getstatusmsg'}
+{/if}
+
+{if $themename|strtolower|strpos:"printer" !== false}
+    {if isset($image) && $image}<img src="{$image|safetext}" alt="{$title|safetext}" />{/if}
+    {if $title}<h2>{$title|safetext}</h2>{/if}
+
+{elseif $type != 'admin'}
+    <div class="navbar navbar-inverse navbar-noborder">
+        <div class="navbar-inner navbar-bgimages">
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button data-target="#userheader-div" data-toggle="collapse" type="button" class="navbar-toggle">
+                        <span class="sr-only">{gt text='Navigation'}</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    {if isset($image) && $image}
+                        <a class="navbar-brand" href="{if $titlelink}{$titlelink}{else}#{/if}" title="{$title}"><img class="img-responsive" alt="" src="{$image}" /></a>
+                    {/if}
+                    <a href="{if $titlelink}{$titlelink}{else}#{/if}" class="navbar-brand" title="{$title}">{if $truncated}{$titletruncated}{else}{$title}{/if}</a>
+                </div>
+                <div class="collapse navbar-collapse" id="userheader-div">
+                    {if $truncated}<h4>{$title}</h4>{/if}
+                    {modulelinks modname=$modname type=$type menuclass='nav navbar-nav'}
+                </div>
+            </div>
+        </div>
+    </div>
+
+{else}
+    {if $menufirst}{modulelinks modname=$modname type=$type}{/if}
+    <div class="{if $type == 'user'}z-modtitle{else}z-admin-content-modtitle{/if}">
+        {if $image}<img src="{$image|safetext}" alt="{$title|safetext}" class="z-floatleft" />{/if}
+        {if $title}<h2>{$title|safetext}</h2>{/if}
+    </div>
+    {if !$menufirst}{modulelinks modname=$modname type=$type}{/if}
+{/if}

--- a/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/modules/ZikulaUsersModule/User/main.tpl
+++ b/src/themes/Zikula/Theme/BootstrapTheme/Resources/views/modules/ZikulaUsersModule/User/main.tpl
@@ -1,0 +1,26 @@
+{gt text='My account' assign='templatetitle'}
+{include file='User/menu.tpl'}
+
+<ul class="list-group">
+{foreach item='accountLink' from=$accountLinks}
+    <li class="list-group-item">
+        <a href="{$accountLink.url|safetext}">
+            <div class="media">
+                <div class="media-left">
+                {if $modvars.ZikulaUsersModule.accountdisplaygraphics eq 1}
+                    {if isset($accountLink.set) && !empty($accountLink.set)}
+                        {assign var="iconset" value=$accountLink.set}
+                    {else}
+                        {assign var="iconset" value=null}
+                    {/if}
+                    {img src=$accountLink.icon modname=$accountLink.module set=$iconset class="media-object"}
+                {/if}
+                </div>
+                <div class="media-body">
+                    <h4><strong>{$accountLink.title|safetext}</strong></h4>
+                </div>
+            </div>
+        </a>
+    </li>
+{/foreach}
+</ul>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | - #2372
| License           | MIT
| Doc PR            | -
| Changelog updated | no

Main purpose of this PR is to make example use of overriding introduced with  #2372 (```moduleheader``` plugin and template), but also is proposal for some theme overrides, to make Bootstrap theme in 1.4 more mobile-devices friendly.

I'm not sure what is purpose of Bootstrap theme, included in the package, but if it is to be used on mobile devices, @craigh, @Guite, you can consider merging this, or just discuss what to do.

I'll make some inline notes in commit. here bellow are two screenshots from my mobile phone, to illustrate the matter.

![screenshot_2015-03-28-17-08-53](https://cloud.githubusercontent.com/assets/628801/6881659/ecf67dee-d571-11e4-8bd1-0eb456aa9d72.png)


![screenshot_2015-03-28-17-10-04](https://cloud.githubusercontent.com/assets/628801/6881660/ee7dd130-d571-11e4-89d7-cbdce9e10b86.png)
