### PR TITLE
Prevent duplicates in module_vars table

### DIFF
--- a/src/lib/util/ModUtil.php
+++ b/src/lib/util/ModUtil.php
@@ -267,8 +267,8 @@ class ModUtil
         }
 
         $em = ServiceUtil::get('doctrine.entitymanager');
-        if (self::hasVar($modname, $name)) {
-            $entities = $em->getRepository('Zikula\Core\Doctrine\Entity\ExtensionVarEntity')->findBy(array('modname' => $modname, 'name' => $name));
+        $entities = $em->getRepository('Zikula\Core\Doctrine\Entity\ExtensionVarEntity')->findBy(array('modname' => $modname, 'name' => $name));
+        if (count($entities) > 0) {
             foreach($entities as $entity) {
                 // possible duplicates exist. update all (refs #2385)
                 $entity->setValue($value);


### PR DESCRIPTION
More robust handling with module and config variables when setting them.
See #2385, #2382.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | - #2385
| Refs tickets      | - #2385, #2382
| License           | MIT
| Doc PR            | -
| Changelog updated | no