### PR TITLE
User theme name in moduleheader

### DIFF
--- a/src/lib/legacy/viewplugins/function.moduleheader.php
+++ b/src/lib/legacy/viewplugins/function.moduleheader.php
@@ -62,7 +62,7 @@ function smarty_function_moduleheader($params, $view)
     $renderer = Zikula_View::getInstance('Theme');
     $renderer->setCaching(Zikula_View::CACHE_DISABLED);
 
-    $renderer->assign('themename', UserUtil::getTheme());
+    $renderer->assign('userthemename', UserUtil::getTheme());
     $renderer->assign('modname', $params['modname']);
     $renderer->assign('type', $params['type']);
     $renderer->assign('title', $params['title']);

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/moduleheader.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/moduleheader.tpl
@@ -5,7 +5,7 @@
     {insert name='getstatusmsg'}
 {/if}
 
-{if $themename|strtolower|strpos:"printer" !== false}
+{if $userthemename|strtolower|strpos:"printer" !== false}
     {if isset($image) && $image}<img src="{$image|safetext}" alt="{$title|safetext}" />{/if}
     {if $title}<h2>{$title|safetext}</h2>{/if}
 


### PR DESCRIPTION
Change the name of variable, because goes in conflict when editing theme in admin panel, so use more specific name.
Please merge this, it is related to #2372.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | - #2372
| License           | MIT
| Doc PR            | -
| Changelog updated | no