### PR TITLE
All forms were using incorrect Bootstrap classes

### DIFF
--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/CreateAdminType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/CreateAdminType.php
@@ -30,7 +30,7 @@ class CreateAdminType extends AbstractType
         $builder
             ->add('username', 'text', array(
                 'label' => __('Admin User Name'),
-                'label_attr' => array('class' => 'col-md-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'data' => __('admin'),
                 'constraints' => array(
                     new NotBlank(),
@@ -44,7 +44,7 @@ class CreateAdminType extends AbstractType
                 'type' => 'password',
                 'invalid_message' => 'The password fields must match.',
                 'options' => array(
-                    'label_attr' => array('class' => 'col-md-5'),
+                    'label_attr' => array('class' => 'col-sm-3'),
                     'constraints' => array(
                         new NotBlank(),
                         new Length(array('min' => 7, 'max' => 40))
@@ -56,7 +56,7 @@ class CreateAdminType extends AbstractType
                 ))
             ->add('email', 'email', array(
                 'label' => __('Admin Email Address'),
-                'label_attr' => array('class' => 'col-md-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'constraints' => array(
                     new NotBlank(),
                     new Email(),

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/DbCredsType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/DbCredsType.php
@@ -29,37 +29,37 @@ class DbCredsType extends AbstractType
         $builder
             ->add('database_driver', 'choice', array(
                 'label' => __('Database type'),
-                'label_attr' => array('class' => 'col-lg-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'choices' => $this->getDbTypes(),
                 'data' => 'mysql'))
             ->add('dbtabletype', 'choice', array(
                 'label' => __('Storage Engine'),
-                'label_attr' => array('class' => 'col-lg-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'choices' => array(
                     'innodb' => __('InnoDB'),
                     'myisam' => __('MyISAM')),
                 'data' => 'innodb'))
             ->add('database_host', 'text', array(
                 'label' => __('Host'),
-                'label_attr' => array('class' => 'col-lg-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'data' => __('localhost'),
                 'constraints' => array(
                     new NotBlank(),
                 )))
             ->add('database_user', 'text', array(
                 'label' => __('Database Username'),
-                'label_attr' => array('class' => 'col-lg-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'constraints' => array(
                     new NotBlank(),
                 )))
             ->add('database_password', 'password', array(
                 'label' => __('Database Password'),
-                'label_attr' => array('class' => 'col-lg-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'required' => false
             ))
             ->add('database_name', 'text', array(
                 'label' => __('Database Name'),
-                'label_attr' => array('class' => 'col-lg-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'constraints' => array(
                     new NotBlank(),
                     new Length(array('max' => 64)),

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/LocaleType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/LocaleType.php
@@ -25,7 +25,7 @@ class LocaleType extends AbstractType
         $builder
             ->add('locale', 'choice', array(
                 'label' => __('Select your default language'),
-                'label_attr' => array('class' => 'col-lg-3'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'choices' => \ZLanguage::getInstalledLanguageNames(),
                 'data' => \ZLanguage::getLanguageCode()
             ));

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/LoginType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/LoginType.php
@@ -27,14 +27,14 @@ class LoginType extends AbstractType
         $builder
             ->add('username', 'text', array(
                 'label' => __('User Name'),
-                'label_attr' => array('class' => 'col-md-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'data' => __('admin'),
                 'constraints' => array(
                     new NotBlank(),
                 )))
             ->add('password', 'password', array(
                 'label' => __('Password'),
-                'label_attr' => array('class' => 'col-md-5'),
+                'label_attr' => array('class' => 'col-sm-3'),
                 'constraints' => array(
                     new NotBlank(),
                 )));

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/views/Install/dbcreds.html.twig
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/views/Install/dbcreds.html.twig
@@ -13,42 +13,42 @@
 
         <div class="form-group">
             {{ form_label(form.database_driver) }}
-            <div class="col-lg-7 col-sm-10">
+            <div class="col-sm-9">
                 {{ form_errors(form.database_driver) }}
                 {{ form_widget(form.database_driver) }}
             </div>
         </div>
         <div class="form-group">
             {{ form_label(form.dbtabletype) }}
-            <div class="col-lg-7 col-sm-10">
+            <div class="col-sm-9">
                 {{ form_errors(form.dbtabletype) }}
                 {{ form_widget(form.dbtabletype) }}
             </div>
         </div>
         <div class="form-group">
             {{ form_label(form.database_host) }}
-            <div class="col-lg-7 col-sm-10">
+            <div class="col-sm-9">
                 {{ form_errors(form.database_host) }}
                 {{ form_widget(form.database_host) }}
             </div>
         </div>
         <div class="form-group">
             {{ form_label(form.database_user) }}
-            <div class="col-lg-7 col-sm-10">
+            <div class="col-sm-9">
                 {{ form_errors(form.database_user) }}
                 {{ form_widget(form.database_user) }}
             </div>
         </div>
         <div class="form-group">
             {{ form_label(form.database_password) }}
-            <div class="col-lg-7 col-sm-10">
+            <div class="col-sm-9">
                 {{ form_errors(form.database_password) }}
                 {{ form_widget(form.database_password) }}
             </div>
         </div>
         <div class="form-group">
             {{ form_label(form.database_name) }}
-            <div class="col-lg-7 col-sm-10">
+            <div class="col-sm-9">
                 {{ form_errors(form.database_name) }}
                 {{ form_widget(form.database_name) }}
                 <em class="text-danger">
@@ -57,7 +57,7 @@
             </div>
         </div>
         <div class="form-group">
-            <div class="col-lg-offset-5 col-lg-7">
+            <div class="col-sm-offset-3 col-sm-9">
                 <input type="submit" value="{{ __('Next') }}" class="btn btn-success" />
             </div>
         </div>

--- a/src/system/Zikula/Module/AdminModule/Resources/views/Admin/delete.tpl
+++ b/src/system/Zikula/Module/AdminModule/Resources/views/Admin/delete.tpl
@@ -14,7 +14,7 @@
         <input type="hidden" name="cid" value="{$category.cid|safetext}" />
         
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Delete'}">{gt text='Delete'}</button>
                 <a class="btn btn-danger" href="{route name='zikulaadminmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/AdminModule/Resources/views/Admin/modify.tpl
+++ b/src/system/Zikula/Module/AdminModule/Resources/views/Admin/modify.tpl
@@ -12,21 +12,21 @@
         <input type="hidden" name="category[cid]" value="{$category.cid|safetext}" />
 
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="admin_name">{gt text='Name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="admin_name">{gt text='Name'}</label>
+            <div class="col-sm-9">
                 <input id="admin_name" name="category[name]" type="text" class="form-control" size="30" maxlength="50" required value="{$category.name|safetext}" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="admin_description">{gt text='Description'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="admin_description">{gt text='Description'}</label>
+            <div class="col-sm-9">
                 <textarea class="form-control" id="admin_description" name="category[description]" cols="50" rows="10">{$category.description|safetext}</textarea>
             </div>
         </div>
     </fieldset>
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
             <a class="btn btn-danger" href="{route name='zikulaadminmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             <a class="btn btn-info" href="{route name='zikulaadminmodule_admin_help'}#modify" title="{gt text='Help'}">{gt text='Help'}</a>

--- a/src/system/Zikula/Module/AdminModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/AdminModule/Resources/views/Admin/modifyconfig.tpl
@@ -10,8 +10,8 @@
         <fieldset>
             <legend>{gt text='General settings'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admin_ignoreinstallercheck">{gt text='Ignore check for installer'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admin_ignoreinstallercheck">{gt text='Ignore check for installer'}</label>
+                <div class="col-sm-9">
                     <input id="admin_ignoreinstallercheck" name="modvars[ignoreinstallercheck]" type="checkbox" value="1"{if $modvars.ZikulaAdminModule.ignoreinstallercheck eq 1} checked="checked"{/if} />
                     <div class="alert alert-warning" data-switch="modvars[ignoreinstallercheck]" data-switch-value="1">
                         {gt text='Warning! Only enable the above option if this site is isolated from the Internet, otherwise security could be endangered if you omit to remove the Installer script from the site root and are not prompted to do so.'}
@@ -22,14 +22,14 @@
         <fieldset>
             <legend>{gt text='Display settings'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admin_graphic">{gt text='Display icons'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admin_graphic">{gt text='Display icons'}</label>
+                <div class="col-sm-9">
                     <input id="admin_graphic" name="modvars[admingraphic]" type="checkbox" value="1"{if $modvars.ZikulaAdminModule.admingraphic eq 1} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admin_displaynametype">{gt text='Form of display for module names'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admin_displaynametype">{gt text='Form of display for module names'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="admin_displaynametype" name="modvars[displaynametype]">
                         <option value="1"{if $modvars.ZikulaAdminModule.displaynametype eq 1} selected="selected"{/if}>{gt text='Display name'}</option>
                         <option value="2"{if $modvars.ZikulaAdminModule.displaynametype eq 2} selected="selected"{/if}>{gt text='Internal name'}</option>
@@ -38,20 +38,20 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admin_itemsperpage">{gt text='Modules per page in module categories list'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admin_itemsperpage">{gt text='Modules per page in module categories list'}</label>
+                <div class="col-sm-9">
                     <input id="admin_itemsperpage" name="modvars[itemsperpage]" type="text" class="form-control" size="3" maxlength="3" value="{$modvars.ZikulaAdminModule.itemsperpage|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admin_modulesperrow">{gt text='Modules per row in admin panel'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admin_modulesperrow">{gt text='Modules per row in admin panel'}</label>
+                <div class="col-sm-9">
                     <input id="admin_modulesperrow" name="modvars[modulesperrow]" type="text" class="form-control" size="3" maxlength="3" value="{$modvars.ZikulaAdminModule.modulesperrow|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admintheme">{gt text='Theme to use'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admintheme">{gt text='Theme to use'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="admintheme" name="modvars[admintheme]">
                         <option value="">{gt text="Use site's theme"}</option>
                         {html_select_themes state='ThemeUtil::STATE_ACTIVE'|const filter='ThemeUtil::FILTER_ADMIN'|const selected=$modvars.ZikulaAdminModule.admintheme}
@@ -59,8 +59,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admin_startcategory">{gt text='Category initially selected'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admin_startcategory">{gt text='Category initially selected'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="admin_startcategory" name="modvars[startcategory]">
                     {section name='category' loop=$categories}
                         <option value="{$categories[category].cid|safetext}"{if $modvars.ZikulaAdminModule.startcategory eq $categories[category].cid} selected="selected"{/if}>{$categories[category].name|safetext}</option>
@@ -72,8 +72,8 @@
         <fieldset>
             <legend>{gt text='Modules categorisation'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admin_defaultcategory">{gt text='Default category for newly-added modules'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admin_defaultcategory">{gt text='Default category for newly-added modules'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="admin_defaultcategory" name="modvars[defaultcategory]">
                     {section name='category' loop=$categories}
                         <option value="{$categories[category].cid|safetext}"{if $modvars.ZikulaAdminModule.defaultcategory eq $categories[category].cid} selected="selected"{/if}>{$categories[category].name|safetext}</option>
@@ -83,8 +83,8 @@
             </div>
             {section name='modulecategory' loop=$modulecategories}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admin_{$modulecategories[modulecategory].name}">{$modulecategories[modulecategory].displayname}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admin_{$modulecategories[modulecategory].name}">{$modulecategories[modulecategory].displayname}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="admin_{$modulecategories[modulecategory].name}" name="adminmods[{$modulecategories[modulecategory].name|safetext}]">
                     {section name='category' loop=$categories}
                         <option value="{$categories[category].cid|safetext}"{if $modulecategories[modulecategory].category eq $categories[category].cid} selected="selected"{/if}>{$categories[category].name|safetext}</option>
@@ -96,7 +96,7 @@
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulaadminmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
                 <a class="btn btn-info" href="{route name='zikulaadminmodule_admin_help'}#modifyconfig" title="{gt text='Help'}">{gt text='Help'}</a>

--- a/src/system/Zikula/Module/AdminModule/Resources/views/Admin/newcat.tpl
+++ b/src/system/Zikula/Module/AdminModule/Resources/views/Admin/newcat.tpl
@@ -9,21 +9,21 @@
         <legend>{gt text='New module category'}</legend>
         <input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="admin_name">{gt text='Name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="admin_name">{gt text='Name'}</label>
+            <div class="col-sm-9">
                 <input id="admin_name" name="category[name]" type="text" class="form-control" size="30" maxlength="50" required />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="admin_description">{gt text='Description'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="admin_description">{gt text='Description'}</label>
+            <div class="col-sm-9">
                 <textarea class="form-control" id="admin_description" name="category[description]" cols="50" rows="10"></textarea>
             </div>
         </div>
     </fieldset>
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
             <a class="btn btn-danger" href="{route name='zikulaadminmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             <a class="btn btn-info" href="{route name='zikulaadminmodule_admin_help'}#new" title="{gt text='Help'}">{gt text='Help'}</a>

--- a/src/system/Zikula/Module/AdminModule/Resources/views/Block/adminnav.tpl
+++ b/src/system/Zikula/Module/AdminModule/Resources/views/Block/adminnav.tpl
@@ -4,7 +4,7 @@
         {if $admincategories[admincategories].url ne ''}
             {assign var='adminmodules' value=$admincategories[admincategories].modules}
             <li><a href="{$admincategories[admincategories].url|safetext}">{$admincategories[admincategories].title|safetext}</a></li>
-            <li style="list-style: none">
+            <li style="list-style: none;">
                 <ul>
                     {section name='adminmodules' loop=$adminmodules}
                         <li><a href="{$adminmodules[adminmodules].menutexturl|safetext}">{$adminmodules[adminmodules].menutexttitle|safetext}</a></li>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/delete.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/delete.tpl
@@ -15,7 +15,7 @@
         <input type="hidden" name="bid" value="{$block.bid|safetext}" />
         
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Delete'}">{gt text='Delete'}</button>
                 <a class="btn btn-danger" href="{route name='zikulablocksmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/deleteposition.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/deleteposition.tpl
@@ -15,7 +15,7 @@
         <input type="hidden" name="pid" value="{$position.pid|safetext}" />
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 {button class='btn btn-success' __alt='Delete' __title='Delete' __text='Delete'}
                 <a class="btn btn-danger" href="{route name='zikulablocksmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/modify.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/modify.tpl
@@ -18,20 +18,20 @@
         <fieldset>
             <legend>{$modtitle|safetext}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_title">{gt text='Title'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_title">{gt text='Title'}</label>
+                <div class="col-sm-9">
                     <input id="blocks_title" name="title" class="form-control" type="text" size="40" maxlength="255" value="{$title|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_description">{gt text='Description'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_description">{gt text='Description'}</label>
+                <div class="col-sm-9">
                     <input id="blocks_description" name="description" class="form-control" type="text" size="40" maxlength="255" value="{$description|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_language">{gt text='Language'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_language">{gt text='Language'}</label>
+                <div class="col-sm-9">
                     {html_select_locales id='blocks_language' class='form-control' name='language' selected=$language installed=true all=true}
                 </div>
             </div>
@@ -39,8 +39,8 @@
         <fieldset>
             <legend>{gt text='Block placement filtering'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_position">{gt text='Position(s)'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_position">{gt text='Position(s)'}</label>
+                <div class="col-sm-9">
                     <span>
                         {assign var='selectsize' value=$block_positions|@count}{if $selectsize gt 20}{assign var='selectsize' value=20}{/if}{if $selectsize lt 4}{assign var='selectsize' value=4}{/if}
                         <select id="blocks_position" class="form-control" name="positions[]" multiple="multiple" size="{$selectsize}">
@@ -114,8 +114,8 @@
         <fieldset>
             <legend>{gt text='Collapsibility'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_collapsable">{gt text='Collapsible'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_collapsable">{gt text='Collapsible'}</label>
+                <div class="col-sm-9">
                     <div id="blocks_collapsable">
                         <label for="blocks_collapsable_yes">{gt text='Yes'}</label><input id="blocks_collapsable_yes" name="collapsable" type="radio" value="1"{if $collapsable eq 1} checked="checked"{/if} />
                         <label for="blocks_collapsable_no">{gt text='No'}</label><input id="blocks_collapsable_no" name="collapsable" type="radio" value="0"{if $collapsable ne 1} checked="checked"{/if} />
@@ -123,8 +123,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_defaultstate">{gt text='Default state'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_defaultstate">{gt text='Default state'}</label>
+                <div class="col-sm-9">
                     <div id="blocks_defaultstate">
                         <label for="blocks_defaultstate_expanded">{gt text='Expanded'}</label><input id="blocks_defaultstate_expanded" name="defaultstate" type="radio" value="1"{if $defaultstate eq 1} checked="checked"{/if} />
                         <label for="blocks_defaultstate_collapsed">{gt text='Collapsed'}</label><input id="blocks_defaultstate_collapsed" name="defaultstate" type="radio" value="0"{if $defaultstate ne 1} checked="checked"{/if} />
@@ -138,8 +138,8 @@
             <fieldset>
                 <legend>{gt text='Customisation'}</legend>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="blocks_content">{gt text='Content'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="blocks_content">{gt text='Content'}</label>
+                    <div class="col-sm-9">
                         <textarea id="blocks_content" class="form-control" name="content" cols="50" rows="10">{$content|safetext}</textarea>
                     </div>
                 </div>
@@ -164,8 +164,8 @@
 
         <fieldset>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_refresh">{gt text='Block refresh interval'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_refresh">{gt text='Block refresh interval'}</label>
+                <div class="col-sm-9">
                     <select id="blocks_refresh" class="form-control" name="refresh">
                         {html_options options=$blockrefreshtimes selected=$refresh}
                     </select>
@@ -180,7 +180,7 @@
         {/if}
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{$cancelurl|safetext}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/modifyconfig.tpl
@@ -10,15 +10,15 @@
         <fieldset>
             <legend>{gt text='General settings'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_collapseable">{gt text='Enable menu collapse icons'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_collapseable">{gt text='Enable menu collapse icons'}</label>
+                <div class="col-sm-9">
                     <input id="blocks_collapseable" name="collapseable" type="checkbox" value="1"{if $collapseable eq 1} checked="checked"{/if} />
                 </div>
             </div>
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulablocksmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/modifyposition.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/modifyposition.tpl
@@ -15,20 +15,20 @@
         <input type="hidden" id="position" name="position[pid]" value="{$pid|safetext}" />
         
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="blocks_positionname">{gt text='Name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="blocks_positionname">{gt text='Name'}</label>
+            <div class="col-sm-9">
                 <input type="text" id="blocks_positionname" class="form-control" name="position[name]" value="{$name|safetext}" size="50" maxlength="255" />
                 <em class="sub help-block">{gt text='Characters allowed: a-z, A-Z, 0-9, dash (-) and underscore (_).'}</em>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="blocks_positiondescription">{gt text='Description'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="blocks_positiondescription">{gt text='Description'}</label>
+            <div class="col-sm-9">
                 <textarea name="position[description]" id="blocks_positiondescription" class="form-control" rows="5" cols="30">{$description|safehtml}</textarea>
             </div>
         </div>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulablocksmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/newblock.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/newblock.tpl
@@ -10,20 +10,20 @@
         <fieldset>
             <legend>{gt text='New block'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_title">{gt text='Title'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_title">{gt text='Title'}</label>
+                <div class="col-sm-9">
                     <input id="blocks_title" name="block[title]" value="{$block.title|default:''}" type="text" class="form-control" size="40" maxlength="255" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_description">{gt text='Description'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_description">{gt text='Description'}</label>
+                <div class="col-sm-9">
                     <input id="blocks_description" name="block[description]" value="{$block.description|default:''}" type="text" class="form-control" size="40" maxlength="255" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_blockid">{gt text='Block'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_blockid">{gt text='Block'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="blocks_blockid" name="block[blockid]"{if $block.blockid eq 'error'} class="form-error"{/if}>
                         <option value="" label="{gt text='Choose one'}">{gt text='Choose one'}</option>
                         {html_options options=$blockids selected=$block.blockid|default:''}
@@ -31,8 +31,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_language">{gt text='Language'} </label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_language">{gt text='Language'} </label>
+                <div class="col-sm-9">
                     {html_select_locales id='blocks_language' class='form-control' name='block[language]' installed=true all=true selected=$block.language|default:''}
                 </div>
             </div>
@@ -40,8 +40,8 @@
         <fieldset>
             <legend>{gt text='Block placement filtering'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_position">{gt text='Position(s)'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_position">{gt text='Position(s)'}</label>
+                <div class="col-sm-9">
                     <div>
                         {assign var='selectsize' value=$block_positions|@count}{if $selectsize gt 20}{assign var='selectsize' value=20}{/if}{if $selectsize lt 4}{assign var='selectsize' value=4}{/if}
                         <select class="form-control" id="blocks_position" name="block[positions][]" multiple="multiple" size="{$selectsize}">
@@ -55,8 +55,8 @@
             <fieldset>
                 <legend>{gt text='Collapsibility'}</legend>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="blocks_collapsable">{gt text='Collapsible'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="blocks_collapsable">{gt text='Collapsible'}</label>
+                    <div class="col-sm-9">
                         <div id="blocks_collapsable">
                             <label for="blocks_collapsable_yes">{gt text='Yes'}</label>
                             <input id="blocks_collapsable_yes" name="block[collapsable]" type="radio" value="1"{if $block.collapsable|default:0 eq 1} checked="checked"{/if} />
@@ -66,8 +66,8 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="blocks_defaultstate">{gt text='Default state'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="blocks_defaultstate">{gt text='Default state'}</label>
+                    <div class="col-sm-9">
                         <div id="blocks_defaultstate">
                             <label for="blocks_defaultstate_expanded">{gt text='Expanded'}</label>
                             <input id="blocks_defaultstate_expanded" name="block[defaultstate]" type="radio" value="1"{if $block.defaultstate|default:1 eq 1} checked="checked"{/if} />
@@ -80,7 +80,7 @@
         {/if}
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulablocksmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/newposition.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Admin/newposition.tpl
@@ -12,21 +12,21 @@
         <fieldset>
             <legend>{gt text='New block position'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_positionname">{gt text='Name'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_positionname">{gt text='Name'}</label>
+                <div class="col-sm-9">
                     <input type="text" class="form-control" id="blocks_positionname" name="position[name]" value="{$name|safetext}" size="50" maxlength="255" />
                     <em class="help-block sub">{gt text='Characters allowed: a-z, A-Z, 0-9, dash (-) and underscore (_).'}</em>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="blocks_positiondescription">{gt text='Description'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="blocks_positiondescription">{gt text='Description'}</label>
+                <div class="col-sm-9">
                     <textarea class="form-control" name="position[description]" id="blocks_positiondescription" rows="5" cols="30"></textarea>
                 </div>
             </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulablocksmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Extmenu/extmenu.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Extmenu/extmenu.tpl
@@ -10,7 +10,7 @@
         </a>
     </li>
     {else}
-    <li style="list-style: none; background: none">&nbsp;</li>
+    <li style="list-style: none; background: none;">&nbsp;</li>
     {/if}
     {/menu}
     {if $access_edit}

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Extmenu/modify.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Extmenu/modify.tpl
@@ -26,24 +26,24 @@
 
 <h4>{gt text='Template' domain='zikula'}</h4>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocks_menu_template">{gt text='Template for this block'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocks_menu_template">{gt text='Template for this block'}</label>
+    <div class="col-sm-9">
         <input id="blocks_menu_template" class="form-control" type="text" name="template" size="30" maxlength="60" value="{$template|safetext}" />
     </div>
 </div>
 
 <h4>{gt text='CSS styling' domain='zikula'}</h4>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocks_menu_stylesheet">{gt text='Style sheet' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocks_menu_stylesheet">{gt text='Style sheet' domain='zikula'}</label>
+    <div class="col-sm-9">
         <input id="blocks_menu_stylesheet" class="form-control" type="text" name="stylesheet" size="20" value="{$stylesheet|safetext}" />
     </div>
 </div>
 
 <h4>{gt text='Visibility within block'}</h4>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocks_menu_modules">{gt text='Display links to installed modules'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocks_menu_modules">{gt text='Display links to installed modules'}</label>
+    <div class="col-sm-9">
         <input id="blocks_menu_modules" type="checkbox" value="1" name="displaymodules"{if $displaymodules} checked="checked"{/if} />
     </div>
 </div>
@@ -53,8 +53,8 @@
 
 {foreach key='lang' item='blocktitle' from=$blocktitles}
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocktitle_{$lang}">{$lang}:</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocktitle_{$lang}">{$lang}:</label>
+    <div class="col-sm-9">
         <input class="form-control" type="text" id="blocktitle_{$lang}" name="blocktitles[{$lang}]" size="30" maxlength="60" value="{$blocktitle}" />
     </div>
 </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Extmenu/topnav.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Extmenu/topnav.tpl
@@ -10,7 +10,7 @@
         </a>
     </li>
     {else}
-    <li style="list-style: none; background: none">&nbsp;</li>
+    <li style="list-style: none; background: none;">&nbsp;</li>
     {/if}
     {/menu}
 </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Menutree/modify.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Menutree/modify.tpl
@@ -27,24 +27,24 @@
                 <legend>{gt text='Permissions'}</legend>
                 <p class="help-block alert alert-info">{gt text='You can restrict the access to certain settings higher than the default ("Edit") permissions level. Below is a list of these options.'}</p>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_titlesperms">{gt text='Block titles'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_titlesperms">{gt text='Block titles'}</label>
+                    <div class="col-sm-9">
                         <select id="menutree_titlesperms" name="menutree[titlesperms]" class="form-control">
                             {html_options options=$permlevels selected=$menutree_titlesperms}
                         </select>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_displayperms">{gt text='Block display settings'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_displayperms">{gt text='Block display settings'}</label>
+                    <div class="col-sm-9">
                         <select id="menutree_displayperms" name="menutree[displayperms]" class="form-control">
                             {html_options options=$permlevels selected=$menutree_displayperms}
                         </select>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_settingsperms">{gt text='Block editing settings'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_settingsperms">{gt text='Block editing settings'}</label>
+                    <div class="col-sm-9">
                         <select id="menutree_settingsperms" name="menutree[settingsperms]" class="form-control">
                             {html_options options=$permlevels selected=$menutree_settingsperms}
                         </select>
@@ -59,8 +59,8 @@
                 <p class="help-block alert alert-info">{gt text='You can specify a different a block title for each language. If left blank, the default block title will be displayed.'}</p>
                 {foreach key='langCode' item='langName' from=$languages}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_titles_{$langCode}">{$langName}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_titles_{$langCode}">{$langName}</label>
+                    <div class="col-sm-9">
                         <input id="menutree_titles_{$langCode}" type="text" name="menutree[titles][{$langCode}]" value="{$menutree_titles.$langCode|safehtml}" size="40" maxlength="255" class="form-control" />
                     </div>
                 </div>
@@ -75,16 +75,16 @@
                     <p class="help-block alert alert-info">{gt text='<strong>Note</strong>: some templates and/or stylesheets are found only in certain themes. These templates and stylesheets have been included in the "Only in some themes" group. Choosing a template or a stylesheet from this group you must take into account the fact that it might not be available in certain theme - in such situation default template and style ("Block/Menutree/default.tpl") is used.'}</p>
                 {/if}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_tpl">{gt text='Template'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_tpl">{gt text='Template'}</label>
+                    <div class="col-sm-9">
                         <select id="menutree_tpl" name="menutree[tpl]" class="form-control">
                             {html_options options=$tpls selected=$menutree_tpl}
                         </select>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_stylesheet">{gt text='Stylesheet'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_stylesheet">{gt text='Stylesheet'}</label>
+                    <div class="col-sm-9">
                         <select id="menutree_stylesheet" name="menutree[stylesheet]" class="form-control">
                             <option value="null">{gt text='Choose stylesheet'}</option>
                             {html_options options=$styles selected=$menutree_stylesheet}
@@ -93,8 +93,8 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_editlinks">{gt text='Show editing links'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_editlinks">{gt text='Show editing links'}</label>
+                    <div class="col-sm-9">
                         <input id="menutree_editlinks" type="checkbox" name="menutree[editlinks]" class="form-control"{if $menutree_editlinks} checked="checked"{/if} />
                         <em class="sub">{gt text='Display the links: "Add current URL" and "Edit this block".'}</em>
                     </div>
@@ -106,8 +106,8 @@
             <fieldset>
                 <legend>{gt text='Block editing settings'}</legend>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_stripbaseurl">{gt text='Strip base url from links'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_stripbaseurl">{gt text='Strip base url from links'}</label>
+                    <div class="col-sm-9">
                         <span>
                             <input id="menutree_stripbaseurl" type="checkbox" name="menutree[stripbaseurl]" class="form-control"{if $menutree_stripbaseurl} checked="checked"{/if} />
                             <em class="sub">{gt text='Base URL which will be removed: %s.' tag1=$baseurl}</em>
@@ -120,8 +120,8 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_maxdepth">{gt text='Maximum depth of tree'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_maxdepth">{gt text='Maximum depth of tree'}</label>
+                    <div class="col-sm-9">
                         <span>
                             <input id="menutree_maxdepth" type="text" name="menutree[maxdepth]" value="{$menutree_maxdepth|safehtml}" size="2" maxlength="2" class="form-control" />
                             <em class="sub">{gt text='Zero means no limit.'}</em>
@@ -129,8 +129,8 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="menutree_linkclass">{gt text='Construct class list for links'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="menutree_linkclass">{gt text='Construct class list for links'}</label>
+                    <div class="col-sm-9">
                         <input id="menutree_linkclass" type="checkbox" name="menutree[linkclass]" class="form-control"{if $menutree_linkclass} checked="checked"{/if} />
                         <p class="help-block alert alert-info">{gt text='You can assign a CSS class for each link in the menu. This option allows you to prepare a list of classes, from which you will be able to select for application.'}</p>
                     </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/finclude_modify.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/finclude_modify.tpl
@@ -1,12 +1,12 @@
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocks_finclude_filename">{gt text='File name (including relative path from Zikula root directory)' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocks_finclude_filename">{gt text='File name (including relative path from Zikula root directory)' domain='zikula'}</label>
+    <div class="col-sm-9">
         <input id="blocks_finclude_filename" class="form-control" type="text" name="filo" size="30" maxlength="255" value="{$filo|safetext}" />
     </div>
 </div>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocks_finclude_filetype">{gt text='File type' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocks_finclude_filetype">{gt text='File type' domain='zikula'}</label>
+    <div class="col-sm-9">
         <select class="form-control" name="typo">
             <option value="0"{if $typo eq 0} selected="selected"{/if}>{gt text='HTML' domain='zikula'}</option>
             <option value="1"{if $typo eq 1} selected="selected"{/if}>{gt text='Text' domain='zikula'}</option>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/menu_modify.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/menu_modify.tpl
@@ -1,14 +1,14 @@
 <h4>{gt text='CSS styling'}</h4>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocks_menu_stylesheet">{gt text='Style sheet' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocks_menu_stylesheet">{gt text='Style sheet' domain='zikula'}</label>
+    <div class="col-sm-9">
         <input id="blocks_menu_stylesheet" class="form-control" type="text" name="stylesheet" size="20" value="{$stylesheet|safetext}" />
     </div>
 </div>
 <h4>{gt text='Visibility within block'}</h4>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocks_menu_modules">{gt text='Modules manager' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocks_menu_modules">{gt text='Modules manager' domain='zikula'}</label>
+    <div class="col-sm-9">
         <input id="blocks_menu_modules" type="checkbox" value="1" name="displaymodules"{if $displaymodules} checked="checked"{/if} />
     </div>
 </div>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/thelang_modify.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/thelang_modify.tpl
@@ -1,6 +1,6 @@
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocks_thelang_format">{gt text='Form of display' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocks_thelang_format">{gt text='Form of display' domain='zikula'}</label>
+    <div class="col-sm-9">
         <select id="blocks_thelang_format" class="form-control" name="format">
             <option value="1"{if $format eq 1} selected="selected"{/if}>{gt text='Flags' domain='zikula'}</option>
             <option value="2"{if $format eq 2} selected="selected"{/if}>{gt text='Dropdown menu' domain='zikula'}</option>
@@ -9,8 +9,8 @@
     </div>
 </div>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="blocks_thelang_fulltranslation">{gt text='Translate options' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="blocks_thelang_fulltranslation">{gt text='Translate options' domain='zikula'}</label>
+    <div class="col-sm-9">
         <select id="blocks_thelang_fulltranslation" class="form-control" name="fulltranslation">
             <option value="1"{if $fulltranslation eq 1} selected="selected"{/if}>{gt text='No' domain='zikula'}</option>
             <option value="2"{if $fulltranslation eq 2} selected="selected"{/if}>{gt text='Yes' domain='zikula'}</option>

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/xslt_modify.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/xslt_modify.tpl
@@ -1,26 +1,26 @@
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="xslt_docurl">{gt text='Document URL'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="xslt_docurl">{gt text='Document URL'}</label>
+    <div class="col-sm-9">
         <input id="xslt_docurl" class="form-control" name="docurl" type="text" size="32" maxlength="255" value="{$docurl|default:''}" />
         <strong>{gt text='or' domain='zikula'}</strong>
     </div>
 </div>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="xslt_docurl">{gt text='Document contents' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="xslt_docurl">{gt text='Document contents' domain='zikula'}</label>
+    <div class="col-sm-9">
         <textarea id="xslt_doccontents" class="form-control" rows="20" cols="50" name="doccontents">{$doccontents|default:''|safetext}</textarea>
     </div>
 </div>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="xslt_styleurl">{gt text='Style sheet URL' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="xslt_styleurl">{gt text='Style sheet URL' domain='zikula'}</label>
+    <div class="col-sm-9">
         <input id="xslt_styleurl" class="form-control" name="styleurl" type="text" size="32" maxlength="255" value="{$styleurl|default:''}" />
         <strong>{gt text='or'}</strong>
     </div>
 </div>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="xslt_stylecontents">{gt text='Style sheet contents' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="xslt_stylecontents">{gt text='Style sheet contents' domain='zikula'}</label>
+    <div class="col-sm-9">
         <textarea id="xslt_stylecontents" class="form-control" rows="20" cols="50" name="stylecontents">{$stylecontents|default:''|safetext}</textarea>
     </div>
 </div>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/config.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/config.tpl
@@ -11,7 +11,7 @@
         <legend>{gt text='Confirmation prompt'}</legend>
         <input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 {button class='btn btn-success' __alt='Rebuild paths' __title='Rebuild paths' __text='Rebuild paths'}
                 <a class="btn btn-danger" href="{route name='zikulacategoriesmodule_admin_index'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/copy.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/copy.tpl
@@ -11,30 +11,30 @@
         <fieldset>
             <legend>{gt text='Category'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Name'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Name'}</label>
+                <div class="col-sm-9">
                     <div class="form-control-static">
                         <span>{$category.name}</span>
                     </div>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Path'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Path'}</label>
+                <div class="col-sm-9">
                     <div class="form-control-static">
                         <span>{$category.path}</span>
                     </div>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="subcat_copy">{gt text='Copy this category and all sub-categories of this category'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="subcat_copy">{gt text='Copy this category and all sub-categories of this category'}</label>
+                <div class="col-sm-9">
                     {$categorySelector}
                 </div>
             </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 {button class="btn btn-success" __alt='Copy' __title='Copy' __text='Copy'}
                 <a class="btn btn-danger" href="{route name='zikulacategoriesmodule_admin_index'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/delete.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/delete.tpl
@@ -35,7 +35,7 @@
                 <input type="hidden" name="subcat_action" id="subcat_action" value="delete" />
             {/if}
             <div class="form-group">
-                <div class="col-lg-offset-3 col-lg-9">
+                <div class="col-sm-offset-3 col-sm-9">
                     {button class='btn btn-success' __alt='Delete' __title='Delete' __text='Delete'}
                     <a class="btn btn-danger" href="{route name='zikulacategoriesmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
                 </div>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/edit.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/edit.tpl
@@ -21,15 +21,15 @@
         {/if}
         <legend>{gt text='General settings'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_name">{gt text='Name'}<span class="required"></span></label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_name">{gt text='Name'}<span class="required"></span></label>
+            <div class="col-sm-9">
                 {array_field assign='catName' array='category' field='name'}
                 <input id="category_name" name="category[name]" value="{$catName|safetext}" type="text" class="form-control" size="32" maxlength="255" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text="Parent"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text="Parent"}</label>
+            <div class="col-sm-9">
                 {if $catID ne 1}
                 {$categorySelector}
                 {else}
@@ -39,29 +39,29 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_is_locked">{gt text='Category is locked'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_is_locked">{gt text='Category is locked'}</label>
+            <div class="col-sm-9">
                 {array_field assign='catIsLocked' array='category' field='is_locked'}
                 <input type="checkbox" id="category_is_locked" name="category[is_locked]" value="1"{if $catIsLocked} checked="checked"{/if} />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_is_leaf">{gt text='Category is a leaf node'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_is_leaf">{gt text='Category is a leaf node'}</label>
+            <div class="col-sm-9">
                 {array_field assign='catIsLeaf' array='category' field='is_leaf'}
                 <input type="checkbox" id="category_is_leaf" name="category[is_leaf]" value="1"{if $catIsLeaf} checked="checked"{/if} />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_value">{gt text='Value'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_value">{gt text='Value'}</label>
+            <div class="col-sm-9">
                 {array_field assign='catValue' array='category' field='value'}
                 <input id="category_value" name="category[value]" value="{$catValue|safetext}" type="text" class="form-control" size="16" maxlength="255" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_status">{gt text='Active'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_status">{gt text='Active'}</label>
+            <div class="col-sm-9">
                 {array_field assign='catStatus' array='category' field='status'}
                 {if $mode ne 'edit'} {assign var='catStatus' value='A'}{/if}
                 <input id="category_status" name="category[status]" value="A" type="checkbox"{if $catStatus eq 'A'} checked="checked"{/if} />&nbsp;&nbsp;
@@ -71,8 +71,8 @@
     <fieldset>
         <legend>{gt text='Localised output'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Name'}<span class="required"></span></label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Name'}<span class="required"></span></label>
+            <div class="col-sm-9">
                 {array_field assign='displayNames' array='category' field='display_name'}
                 {foreach item='language' from=$languages}
                     {array_field assign='displayName' array='displayNames' field=$language}
@@ -84,8 +84,8 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Description'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Description'}</label>
+            <div class="col-sm-9">
                 {array_field assign='displayDescs' array='category' field='display_desc'}
                 {foreach item='language' from=$languages}
                     {array_field assign='displayDesc' array='displayDescs' field=$language}
@@ -108,24 +108,24 @@
         <legend><a href="#category-metadata" data-toggle="collapse">{gt text='Meta data'} <i class="fa fa-expand"></i></a></legend>
         <div class="collapse" id="category-metadata">
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="category_meta_id">{gt text='Internal ID'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="category_meta_id">{gt text='Internal ID'}</label>
+                <div class="col-sm-9">
                     <div class="form-control-static">
                         <span id="category_meta_id">{$category.id|safetext}</span>
                     </div>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="category_path">{gt text='Path'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="category_path">{gt text='Path'}</label>
+                <div class="col-sm-9">
                     <div class="form-control-static">
                         <span id="category_path">{$category.path|safetext}</span>
                     </div>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="category_ipath">{gt text='I-path'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="category_ipath">{gt text='I-path'}</label>
+                <div class="col-sm-9">
                     <div class="form-control-static">
                         <span id="category_ipath">{$category.ipath|safetext}</span>
                     </div>
@@ -135,7 +135,7 @@
     </fieldset>
     {/if}
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
         {if $mode eq 'edit'}
             <button class="btn btn-success" name="category_submit" value="update" title="{gt text='Save'}">{gt text='Save'}</button>
             <button class="btn btn-default" name="category_copy" value="copy" title="{gt text='Copy'}">{gt text='Copy'}</button>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/move.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/move.tpl
@@ -11,26 +11,26 @@
         <fieldset>
             <legend>{gt text='Category'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Name'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Name'}</label>
+                <div class="col-sm-9">
                     <span>{$category.name}</span>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Path'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Path'}</label>
+                <div class="col-sm-9">
                     <span>{$category.path}</span>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="subcat_move">{gt text='Move all sub-categories to next category'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="subcat_move">{gt text='Move all sub-categories to next category'}</label>
+                <div class="col-sm-9">
                     {$categorySelector}
                 </div>
             </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 {button class='btn btn-success' __alt='Move' __title='Move' __text='Move'}
                 <a class="btn btn-danger" href="{route name='zikulacategoriesmodule_admin_index'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/preferences.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/preferences.tpl
@@ -10,44 +10,44 @@
         <fieldset>
             <legend>{gt text='General settings'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="userrootcat">{gt text='Root category for user categories'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="userrootcat">{gt text='Root category for user categories'}</label>
+                <div class="col-sm-9">
                     {selector_category category=1 name='userrootcat' field='path' selectedValue=$userrootcat defaultValue='0' __defaultText='Choose one' includeLeaf=0 doReplaceRootCat=false editLink=0 cssClass="form-control"}
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="categories_allowusercatedit">{gt text='Allow users to edit their own categories'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="categories_allowusercatedit">{gt text='Allow users to edit their own categories'}</label>
+                <div class="col-sm-9">
                     <input id="categories_allowusercatedit" type="checkbox" name="allowusercatedit" value="1"{if $allowusercatedit} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="categories_autocreateusercat">{gt text='Automatically create user category root folder'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="categories_autocreateusercat">{gt text='Automatically create user category root folder'}</label>
+                <div class="col-sm-9">
                     <input id="categories_autocreateusercat" type="checkbox" name="autocreateusercat" value="1"{if $autocreateusercat} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="categories_autocreateuserdefaultcat">{gt text='Automatically create user default category'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="categories_autocreateuserdefaultcat">{gt text='Automatically create user default category'}</label>
+                <div class="col-sm-9">
                     <input id="categories_autocreateuserdefaultcat" type="checkbox" name="autocreateuserdefaultcat" value="1"{if $autocreateuserdefaultcat} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="categories_permissionsall">{gt text='Require access to all categories for one item (relevant when using multiple categories per content item)'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="categories_permissionsall">{gt text='Require access to all categories for one item (relevant when using multiple categories per content item)'}</label>
+                <div class="col-sm-9">
                     <input id="categories_permissionsall" type="checkbox" name="permissionsall" value="1"{if $permissionsall} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="categories_userdefaultcatname">{gt text='Default user category'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="categories_userdefaultcatname">{gt text='Default user category'}</label>
+                <div class="col-sm-9">
                     <input id="categories_userdefaultcatname" type="text" class="form-control" name="userdefaultcatname" value="{$userdefaultcatname}" />
                 </div>
             </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulacategoriesmodule_admin_preferences'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/registry_delete.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/registry_delete.tpl
@@ -19,7 +19,7 @@
         <fieldset>
             <legend>{gt text='Confirmation prompt'}</legend>
             <div class="form-group">
-                <div class="col-lg-offset-3 col-lg-9">
+                <div class="col-sm-offset-3 col-sm-9">
                     {button class='btn btn-success' __alt='Delete' __title='Delete' __text='Delete'}
                     <a class="btn btn-danger" href="{route name='zikulacategoriesmodule_admin_editregistry'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
                 </div>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/registry_edit.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/Admin/registry_edit.tpl
@@ -77,7 +77,7 @@
             </tbody>
         </table>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button id="category_submit" name="category_submit" value="1" class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulacategoriesmodule_admin_editregistry'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/Ajax/edit.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/Ajax/edit.tpl
@@ -14,52 +14,52 @@
             <input type="hidden" id="category_id" class="form-control" name="category[id]" value="{$category.id}" />
             {/if}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="category_name">{gt text='Name'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="category_name">{gt text='Name'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     {array_field assign='catName' array='category' field='name'}
                     <input id="category_name" name="category[name]" class="form-control" value="{$catName|safetext}" type="text" size="32" maxlength="255" />
                 </div>
             </div>
             <div class="form-group">
-                <span class="col-lg-3 control-label">{gt text='Parent'}</span>
-                <div class="col-lg-9">
+                <span class="col-sm-3 control-label">{gt text='Parent'}</span>
+                <div class="col-sm-9">
                     <div class="form-control-static">
                         <strong>{category_path id=$category.parent_id field='name'}</strong>
                     </div>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="category_is_locked">{gt text='Category is locked'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="category_is_locked">{gt text='Category is locked'}</label>
+                <div class="col-sm-9">
                     <div class="form-control-static">
                         <strong>{category_path id=$category.parent_id field='name'}</strong>
                     </div>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Parent'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Parent'}</label>
+                <div class="col-sm-9">
                     {array_field assign='catIsLocked' array='category' field='is_locked'}
                     <input type="checkbox" id="category_is_locked" name="category[is_locked]" value="1"{if $catIsLocked} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="category_is_leaf">{gt text='Category is a leaf node'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="category_is_leaf">{gt text='Category is a leaf node'}</label>
+                <div class="col-sm-9">
                     {array_field assign='catIsLeaf' array='category' field='is_leaf'}
                     <input type="checkbox" id="category_is_leaf" name="category[is_leaf]" value="1"{if $catIsLeaf} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="category_value">{gt text='Value'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="category_value">{gt text='Value'}</label>
+                <div class="col-sm-9">
                     {array_field assign='catValue' array='category' field='value'}
                     <input id="category_value" class="form-control" name="category[value]" value="{$catValue|safetext}" type="text" size="16" maxlength="255" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="category_status">{gt text='Active'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="category_status">{gt text='Active'}</label>
+                <div class="col-sm-9">
                     {array_field assign='catStatus' array='category' field='status'}
                     {if $mode ne 'edit'} {assign var='catStatus' value='A'}{/if}
                     <input id="category_status" name="category[status]" value="A" type="checkbox"{if $catStatus eq 'A'} checked="checked"{/if} />&nbsp;&nbsp;
@@ -69,8 +69,8 @@
         <fieldset>
             <legend>{gt text='Localised output'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Name'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Name'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     {array_field assign='displayNames' array='category' field='display_name'}
                     {foreach item='language' from=$languages}
                         {array_field assign='displayName' array='displayNames' field=$language}
@@ -80,8 +80,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Description'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Description'}</label>
+                <div class="col-sm-9">
                     {array_field assign='displayDescs' array='category' field='display_desc'}
                     {foreach item='language' from=$languages}
                         {array_field assign='displayDesc' array='displayDescs' field=$language}
@@ -102,24 +102,24 @@
             <legend><a href="#category-metadata" data-toggle="collapse">{gt text='Meta data'} <i class="fa fa-expand"></i></a></legend>
             <div class="collapse" id="category-metadata">
                 <div class="form-group">
-                    <label class="col-lg-3 control-label">{gt text='Internal ID'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label">{gt text='Internal ID'}</label>
+                    <div class="col-sm-9">
                         <div class="form-control-static">
                             <span id="category_meta_id">{$category.id|safetext}</span>
                         </div>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label">{gt text='Path'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label">{gt text='Path'}</label>
+                    <div class="col-sm-9">
                         <div class="form-control-static">
                             <span id="category_path">{$category.path|safetext}</span>
                         </div>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label">{gt text='I-path'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label">{gt text='I-path'}</label>
+                    <div class="col-sm-9">
                         <div class="form-control-static">
                             <span id="category_ipath">{$category.ipath|safetext}</span>
                         </div>

--- a/src/system/Zikula/Module/CategoriesModule/Resources/views/User/edit.tpl
+++ b/src/system/Zikula/Module/CategoriesModule/Resources/views/User/edit.tpl
@@ -40,22 +40,22 @@
         <input type="hidden" name="category[ipath]" value="{$category.ipath|safetext}" />
         {/if}
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_name">{gt text='Name'}<span class="required"></span></label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_name">{gt text='Name'}<span class="required"></span></label>
+            <div class="col-sm-9">
                 {array_field assign='catName' array='category' field='name'}
                 <input id="category_name" name="category[name]" value="{$catName|safetext}" type="text" class="form-control" size="32" maxlength="255" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_value">{gt text='Value'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_value">{gt text='Value'}</label>
+            <div class="col-sm-9">
                 {array_field assign='catValue' array='category' field='value'}
                 <input id="category_value" name="category[value]" value="{$catValue|safetext}" type="text" class="form-control" size="16" maxlength="255" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_status">{gt text='Active'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_status">{gt text='Active'}</label>
+            <div class="col-sm-9">
                 {array_field assign='catStatus' array='category' field='status'}
                 <input id="category_status" name="category[status]" value="A" type="checkbox"{if $catStatus eq 'A'} checked="checked"{/if} />
             </div>
@@ -64,8 +64,8 @@
     <fieldset>
         <legend>{gt text='Localised output'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Name'}<span class="required"></span></label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Name'}<span class="required"></span></label>
+            <div class="col-sm-9">
                 {array_field assign='displayNames' array='category' field='display_name'}
                 {if ($displayNames || !$catID)}
                 {foreach item='language' from=$languages}
@@ -79,8 +79,8 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Description'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Description'}</label>
+            <div class="col-sm-9">
                 {array_field assign='displayDescs' array='category' field='display_desc'}
                 {if ($displayDescs || !$catID)}
                 {foreach item='language' from=$languages}
@@ -102,27 +102,27 @@
     <fieldset>
         <legend>{gt text='Category system information'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_id">{gt text='Internal ID'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_id">{gt text='Internal ID'}</label>
+            <div class="col-sm-9">
                 <span id="category_id">{$category.id|safetext}</span>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_path">{gt text='Path'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_path">{gt text='Path'}</label>
+            <div class="col-sm-9">
                 <span id="category_path">{$category.path|safetext}</span>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="category_ipath">{gt text='I-path'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="category_ipath">{gt text='I-path'}</label>
+            <div class="col-sm-9">
                 <span id="category_ipath">{$category.ipath|safetext}</span>
             </div>
         </div>
     </fieldset>
     {/if}
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
         {if $category}
             <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
             <a class="btn btn-danger" href="{route name='zikulacategoriesmodule_user_edit' dr=$rootCat.id}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>

--- a/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/compinfo.tpl
+++ b/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/compinfo.tpl
@@ -12,7 +12,7 @@
     <div>{gt text='The maximal version of the core that this module supports is %s' tag1=$moduleInfo.core_max}</div>
 {/if}
 <div class="form-group">
-    <div class="col-lg-offset-3 col-lg-9">
+    <div class="col-sm-offset-3 col-sm-9">
         <a class="btn btn-danger" href="{route name='zikulaextensionsmodule_admin_view' startnum=$startnum letter=$letter state=$state}"><i class="fa fa-check"></i> {gt text='Ok'}</a>
     </div>
 </div>

--- a/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/initialise.tpl
+++ b/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/initialise.tpl
@@ -56,7 +56,7 @@
         {/if}
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
             {if !$fataldependency}
                 {button class='btn btn-success' __alt='Accept' __title='Accept' __text='Accept'}
             {/if}

--- a/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/modify.tpl
+++ b/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/modify.tpl
@@ -13,33 +13,33 @@
         <fieldset>
             <legend>{gt text='Module'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="modules_newdisplayname">{gt text='Module display name'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="modules_newdisplayname">{gt text='Module display name'}</label>
+                <div class="col-sm-9">
                     <input id="modules_newdisplayname" name="newdisplayname" type="text" class="form-control" size="30" maxlength="64" value="{$displayname|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="modules_newurl">{gt text='Module URL'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="modules_newurl">{gt text='Module URL'}</label>
+                <div class="col-sm-9">
                     <input id="modules_newurl" name="newurl" type="text" class="form-control" size="30" maxlength="64" value="{$url|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="modules_newdescription">{gt text='Description'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="modules_newdescription">{gt text='Description'}</label>
+                <div class="col-sm-9">
                     <textarea class="form-control" id="modules_newdescription" name="newdescription" cols="50" rows="10">{$description|safetext}</textarea>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Defaults'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Defaults'}</label>
+                <div class="col-sm-9">
                     <span><a id="restoreDefaults" href="{route name='zikulaextensionsmodule_admin_modify' id=$id restore=true}">{gt text='Restore now'}</a> ({gt text='This may break your existing indexed URLs'})</span>
                 </div>
             </div>
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulaextensionsmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>
@@ -51,7 +51,7 @@
 <script type="text/javascript">
     (function ($) {
         $(document).ready(function() {
-            $('#restoreDefaults').click( function(event) {
+            $('#restoreDefaults').click(function(event) {
                 event.preventDefault();
                 if (confirm(Zikula.__('Do you really want to reset displayname, url and description to defaults? This may break your existing indexed URLs.')) == false) {
                     return;

--- a/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/modifyconfig.tpl
@@ -12,14 +12,14 @@
     <fieldset>
         <legend>{gt text='General settings'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="modules_itemsperpage">{gt text='Items per page'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="modules_itemsperpage">{gt text='Items per page'}</label>
+            <div class="col-sm-9">
                 <input id="modules_itemsperpage" type="text" class="form-control" name="itemsperpage" size="3" value="{$itemsperpage|safetext}" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Module defaults'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Module defaults'}</label>
+            <div class="col-sm-9">
                 <div class="form-control-static">
                     <a id="restoreDefaults" href="{route name='zikulaextensionsmodule_admin_view' defaults=true csrftoken=$csrftoken}">{gt text='Hard module regenerate to reset displayname, url and description to defaults'}</a>
                 </div>
@@ -28,7 +28,7 @@
     </fieldset>
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
             <a class="btn btn-danger" href="{route name='zikulaextensionsmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
         </div>
@@ -39,7 +39,7 @@
 <script type="text/javascript">
     (function ($) {
         $(document).ready(function() {
-            $('#restoreDefaults').click( function(event) {
+            $('#restoreDefaults').click(function(event) {
                 event.preventDefault();
                 if (confirm(Zikula.__('Do you really want to reset displayname, url and description to defaults? This may break your existing indexed URLs.')) == false) {
                     return;

--- a/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/remove.tpl
+++ b/src/system/Zikula/Module/ExtensionsModule/Resources/views/Admin/remove.tpl
@@ -60,7 +60,7 @@
         {/if}
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-danger" title="{gt text='Uninstall'}">{gt text='Uninstall'}</button>
                 <a class="btn btn-default" href="{route name='zikulaextensionsmodule_admin_view'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/delete.tpl
+++ b/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/delete.tpl
@@ -16,7 +16,7 @@
         <input type="hidden" name="confirmation" value="1" />
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Delete'}">{gt text='Delete'}</button>
                 <a class="btn btn-danger" href="{route name='zikulagroupsmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/groupmembership.tpl
+++ b/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/groupmembership.tpl
@@ -50,8 +50,8 @@
             <input type="hidden" name="gid" value="{$group.gid|safetext}" />
             <fieldset>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="groups_uid">{gt text='Users to add'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="groups_uid">{gt text='Users to add'}</label>
+                    <div class="col-sm-9">
                         <select class="form-control" id="groups_uid" name="uid[]" multiple="multiple" size="10" placeholder="{gt text='Select...'}">
                             {html_options options=$uids}
                         </select>
@@ -59,7 +59,7 @@
                 </div>
             </fieldset>
             <div class="form-group">
-                <div class="col-lg-offset-3 col-lg-9">
+                <div class="col-sm-offset-3 col-sm-9">
                     {button class='btn btn-success' __alt='Add' __title='Add' __text='Add'}
                 </div>
             </div>

--- a/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/modify.tpl
+++ b/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/modify.tpl
@@ -11,43 +11,43 @@
         <input type="hidden" name="gid" value="{$item.gid}" />
         
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="groups_name">{gt text='Name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="groups_name">{gt text='Name'}</label>
+            <div class="col-sm-9">
                 <input id="groups_name" name="name" type="text" class="form-control" size="30" maxlength="30" value="{$item.name|safetext}" required="required" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="groups_gtype">{gt text='Type'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="groups_gtype">{gt text='Type'}</label>
+            <div class="col-sm-9">
                 <select class="form-control" id="groups_gtype" name="gtype">
                     {html_options options=$grouptype selected=$item.gtype}
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="groups_state">{gt text='State'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="groups_state">{gt text='State'}</label>
+            <div class="col-sm-9">
                 <select class="form-control" id="groups_state" name="state">
                     {html_options options=$groupstate selected=$item.state}
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="groups_nbumax">{gt text='Maximum membership'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="groups_nbumax">{gt text='Maximum membership'}</label>
+            <div class="col-sm-9">
                 <input id="groups_nbumax" name="nbumax" type="number" min="0" class="form-control" size="10" maxlength="10" value="{$item.nbumax}" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="groups_description">{gt text='Description'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="groups_description">{gt text='Description'}</label>
+            <div class="col-sm-9">
                 <textarea class="form-control" id="groups_description" name="description" rows="5">{$item.description|safetext}</textarea>
             </div>
         </div>
     </fieldset>
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
             <a class="btn btn-danger" href="{route name='zikulagroupsmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
         </div>

--- a/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/modifyconfig.tpl
@@ -12,35 +12,35 @@
         <fieldset>
             <legend>{gt text='General settings'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="groups_itemsperpage">{gt text='Items per page'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="groups_itemsperpage">{gt text='Items per page'}</label>
+                <div class="col-sm-9">
                     <input id="groups_itemsperpage" type="text" class="form-control" name="itemsperpage" size="3" value="{$modvars.ZikulaGroupsModule.itemsperpage|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="groups_defaultgroup">{gt text='Initial user group'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="groups_defaultgroup">{gt text='Initial user group'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="groups_defaultgroup" name="defaultgroup">
                         {html_options options=$groups selected=$modvars.ZikulaGroupsModule.defaultgroup}
                     </select>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="groups_hideclosed">{gt text='Hide closed groups'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="groups_hideclosed">{gt text='Hide closed groups'}</label>
+                <div class="col-sm-9">
                     <input id="groups_hideclosed" name="hideclosed" type="checkbox"{if $modvars.ZikulaGroupsModule.hideclosed eq 1} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="groups_mailwarning">{gt text='Receive e-mail alert when there are new applicants'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="groups_mailwarning">{gt text='Receive e-mail alert when there are new applicants'}</label>
+                <div class="col-sm-9">
                     <input id="groups_mailwarning" name="mailwarning" type="checkbox"{if $modvars.ZikulaGroupsModule.mailwarning eq 1} checked="checked"{/if} />
                 </div>
             </div>
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulagroupsmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/new.tpl
+++ b/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/new.tpl
@@ -8,36 +8,36 @@
     <fieldset>
         <input type="hidden" id="csrftoken" name="csrftoken" value="{insert name='csrftoken'}" />
         <div class="form-group">
-            <label class="col-lg-3 control-label required" for="group_name">{gt text='Name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label required" for="group_name">{gt text='Name'}</label>
+            <div class="col-sm-9">
                 <input id="group_name" name="name" type="text" class="form-control" size="30" maxlength="255" required="required" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="groups_gtype">{gt text='Type'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="groups_gtype">{gt text='Type'}</label>
+            <div class="col-sm-9">
                 <select class="form-control" id="groups_gtype" name="gtype">
                     {html_options options=$grouptype default='0'}
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="groups_state">{gt text='State'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="groups_state">{gt text='State'}</label>
+            <div class="col-sm-9">
                 <select class="form-control" id="groups_state" name="state">
                     {html_options options=$groupstate default='0'}
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="groups_nbumax">{gt text='Maximum membership'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="groups_nbumax">{gt text='Maximum membership'}</label>
+            <div class="col-sm-9">
                 <input id="groups_nbumax" name="nbumax" type="number" class="form-control" size="10" maxlength="10" min="0" value="0" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="groups_description">{gt text='Description'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="groups_description">{gt text='Description'}</label>
+            <div class="col-sm-9">
                 <textarea class="form-control" id="groups_description" name="description" rows="5"></textarea>
             </div>
         </div>
@@ -45,7 +45,7 @@
     <span class="required"></span>{gt text='Required values'}
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
             <a class="btn btn-danger" href="{route name='zikulagroupsmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
         </div>

--- a/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/removeuser.tpl
+++ b/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/removeuser.tpl
@@ -14,7 +14,7 @@
         <input type="hidden" name="confirmation" value="1" />
         <legend>{gt text='Confirmation prompt'}</legend>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class='btn btn-danger' title="{gt text='Remove'}">{gt text='Remove'}</button>
                 <a class="btn btn-default" href="{route name='zikulagroupsmodule_admin_groupmembership' gid=$gid}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/userpending.tpl
+++ b/src/system/Zikula/Module/GroupsModule/Resources/views/Admin/userpending.tpl
@@ -16,28 +16,28 @@
         <fieldset>
             <legend>{$templatetitle}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='User name'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='User name'}</label>
+                <div class="col-sm-9">
                     <span>{usergetvar name="uname" uid=$userid|safetext}</span>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Membership application'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Membership application'}</label>
+                <div class="col-sm-9">
                     <span>{$application|safehtml}</span>
                 </div>
             </div>
             {if $action eq 'deny'}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="groups_reason">{gt text='Reason'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="groups_reason">{gt text='Reason'}</label>
+                    <div class="col-sm-9">
                         <textarea class="form-control" id="groups_reason" name="reason" cols="50" rows="8">{gt text='Sorry! This is a message to inform you with regret that your application for membership of the aforementioned private group has been rejected.'}</textarea>
                     </div>
                 </div>
             {/if}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="groups_sendtag">{gt text='Notification type'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="groups_sendtag">{gt text='Notification type'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="groups_sendtag" name="sendtag">
                         {html_options options=$sendoptions}
                     </select>
@@ -46,7 +46,7 @@
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
             {if $action eq 'deny'}
             <button type="submit">{img modname='core' src='14_layer_deletelayer.png' set='icons/extrasmall' __alt='Deny' __title='Deny'} {gt text='Deny'}</button>
             {else}

--- a/src/system/Zikula/Module/GroupsModule/Resources/views/User/membership.tpl
+++ b/src/system/Zikula/Module/GroupsModule/Resources/views/User/membership.tpl
@@ -19,14 +19,14 @@
     <fieldset>
         <legend>{$templatetitle}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Group name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Group name'}</label>
+            <div class="col-sm-9">
                 <div class="form-control-static">{$gname}</div>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Description'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Description'}</label>
+            <div class="col-sm-9">
                 <div class="form-control-static">
                     {if $description}
                         {$description}
@@ -38,15 +38,15 @@
         </div>
         {if $action eq 'subscribe' && $gtype eq 2}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="groups_applytext">{gt text='Comment to attach to your application'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="groups_applytext">{gt text='Comment to attach to your application'}</label>
+                <div class="col-sm-9">
                     <textarea class="form-control" id="groups_applytext" name="applytext" cols="50" rows="8"></textarea>
                 </div>
             </div>
         {/if}
     </fieldset>
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             {button class="btn btn-success" value='Apply' __alt='Apply' __title='Apply' __text='Apply'}
             <a class="btn btn-danger" href="{route name='zikulagroupsmodule_user_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
         </div>

--- a/src/system/Zikula/Module/MailerModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/MailerModule/Resources/views/Admin/modifyconfig.tpl
@@ -20,44 +20,44 @@
     <fieldset>
         <legend>{gt text='General settings'}</legend>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='transport' __text='Mail transport' mandatorysym=true}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='transport' __text='Mail transport' mandatorysym=true}
+            <div class="col-sm-9">
                 {formdropdownlist id='transport' mandatory=true cssClass='form-control'}
             </div>
         </div>
         <div class="form-group">
             {charset assign=defaultcharset}
-            {formlabel cssClass="col-lg-3 control-label" for='charset' __text='Character set' mandatorysym=true}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='charset' __text='Character set' mandatorysym=true}
+            <div class="col-sm-9">
                 {formtextinput id='charset' size=10 maxLength=20 mandatory=true cssClass='form-control'}
                 <p class="help-block sub">{gt text="Default: '%s'" tag1=$defaultcharset}</p>
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='encoding' __text="Encoding" mandatorysym=true}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='encoding' __text="Encoding" mandatorysym=true}
+            <div class="col-sm-9">
                 {formdropdownlist id='encoding' mandatory=true cssClass='form-control'}
                 <p class="help-block sub">{gt text="Default: '%s'" tag1='8bit'}</p>
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='html' __text='HTML-formatted messages'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='html' __text='HTML-formatted messages'}
+            <div class="col-sm-9">
                 <div class="checkbox">
                     {formcheckbox id='html'}
                 </div>
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='wordwrap' __text='Word wrap' mandatorysym=true}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='wordwrap' __text='Word wrap' mandatorysym=true}
+            <div class="col-sm-9">
                 {formtextinput id='wordwrap' size=3 maxLength=3 mandatory=true cssClass='form-control'}
                 <p class="help-block sub">{gt text="Default: '%s'" tag1='50'}</p>
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='enableLogging' __text='Enable logging of sent mail'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='enableLogging' __text='Enable logging of sent mail'}
+            <div class="col-sm-9">
                 <div class="checkbox">
                     {formcheckbox id='enableLogging'}
                 </div>
@@ -68,41 +68,41 @@
     <fieldset data-switch="transport[]" data-switch-value="smtp">
         <legend>{gt text='SMTP settings'}</legend>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='host' __text='SMTP host server'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='host' __text='SMTP host server'}
+            <div class="col-sm-9">
                 {formtextinput id='host' size=30 maxLength=255 cssClass='form-control'}
                 <p class="help-block sub">{gt text="Default: '%s'" tag1='localhost'}</p>
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='port' __text='SMTP port'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='port' __text='SMTP port'}
+            <div class="col-sm-9">
                 {formtextinput id='port' size=5 maxLength=5 cssClass='form-control'}
                 <p class="help-block sub">{gt text="Default: '%s'" tag1='25'}</p>
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='encryption' __text='SMTP encryption method'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='encryption' __text='SMTP encryption method'}
+            <div class="col-sm-9">
                 {formdropdownlist id='encryption' cssClass='form-control'}
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='auth_mode' __text='SMTP authentication type'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='auth_mode' __text='SMTP authentication type'}
+            <div class="col-sm-9">
                 {formdropdownlist id='auth_mode' cssClass='form-control'}
             </div>
         </div>
         <div data-switch="auth_mode[]" data-switch-value="login">
             <div class="form-group">
-                {formlabel cssClass="col-lg-3 control-label" for='username' __text='SMTP user name'}
-                <div class="col-lg-9">
+                {formlabel cssClass="col-sm-3 control-label" for='username' __text='SMTP user name'}
+                <div class="col-sm-9">
                     {formtextinput id='username' size=30 maxLength=50 cssClass='form-control'}
                 </div>
             </div>
             <div class="form-group">
-                {formlabel cssClass="col-lg-3 control-label" for='password' __text='SMTP password'}
-                <div class="col-lg-9">
+                {formlabel cssClass="col-sm-3 control-label" for='password' __text='SMTP password'}
+                <div class="col-sm-9">
                     {formtextinput id='password' textMode='password' size=30 maxLength=50 cssClass='form-control'}
                 </div>
             </div>
@@ -112,21 +112,21 @@
     <fieldset data-switch="transport[]" data-switch-value="gmail">
         <legend>{gt text='Gmail settings'}</legend>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='usernameGmail' __text='Gmail user name'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='usernameGmail' __text='Gmail user name'}
+            <div class="col-sm-9">
                 {formtextinput id='usernameGmail' size=30 maxLength=50 cssClass='form-control'}
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass="col-lg-3 control-label" for='passwordGmail' __text='Gmail password'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='passwordGmail' __text='Gmail password'}
+            <div class="col-sm-9">
                 {formtextinput id='passwordGmail' textMode='password' size=30 maxLength=50 cssClass='form-control'}
             </div>
         </div>
     </fieldset>
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             {formbutton class='btn btn-success' commandName='save' __text='Save'}
             {formbutton class='btn btn-danger' commandName='cancel' __text='Cancel'}
         </div>

--- a/src/system/Zikula/Module/MailerModule/Resources/views/Admin/testconfig.tpl
+++ b/src/system/Zikula/Module/MailerModule/Resources/views/Admin/testconfig.tpl
@@ -13,45 +13,45 @@
     <fieldset>
         <legend>{gt text='Settings test'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text="Sender's name"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text="Sender's name"}</label>
+            <div class="col-sm-9">
                 <div class="well well-sm">
                     {$modvars.ZConfig.sitename}
                 </div>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text="Sender's e-mail address"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text="Sender's e-mail address"}</label>
+            <div class="col-sm-9">
                 <div class="well well-sm">
                     {$modvars.ZConfig.adminmail}
                 </div>
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass='col-lg-3 control-label' for='toname' __text="Recipient's name" mandatorysym=true}
-            <div class="col-lg-9">
+            {formlabel cssClass='col-sm-3 control-label' for='toname' __text="Recipient's name" mandatorysym=true}
+            <div class="col-sm-9">
                 {formtextinput id='toname' size=30 maxLength=50 mandatory=true cssClass='form-control'}
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass='col-lg-3 control-label' for='toaddress' __text="Recipient's e-mail address" mandatorysym=true}
-            <div class="col-lg-9">
+            {formlabel cssClass='col-sm-3 control-label' for='toaddress' __text="Recipient's e-mail address" mandatorysym=true}
+            <div class="col-sm-9">
                 {formemailinput id='toaddress' size=30 maxLength=50 mandatory=true cssClass='form-control'}
             </div>
         </div>
         <div class="form-group">
-            {formlabel cssClass='col-lg-3 control-label' for='subject' __text='Subject' mandatorysym=true}
-            <div class="col-lg-9">
+            {formlabel cssClass='col-sm-3 control-label' for='subject' __text='Subject' mandatorysym=true}
+            <div class="col-sm-9">
                 {formtextinput id='subject' size=30 maxLength=50 mandatory=true cssClass='form-control'}
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">
+            <label class="col-sm-3 control-label">
                 {gt text='Message Type'}
                 <span class="required"></span>
             </label>
-            <div id="message_type" class="col-lg-9">
+            <div id="message_type" class="col-sm-9">
                 {formradiobutton id='mailer_text' dataField='msgtype' value='text' mandatory=true}
                 {formlabel for='mailer_text' __text='Plain-text message'}
                 {formradiobutton id='mailer_html' dataField='msgtype' value='html' mandatory=true}
@@ -61,14 +61,14 @@
             </div>
         </div>
         <div class="form-group" data-switch="msgtype" data-switch-value="html,multipart">
-            {formlabel cssClass="col-lg-3 control-label" for='mailer_body' __text='HTML-formatted message'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='mailer_body' __text='HTML-formatted message'}
+            <div class="col-sm-9">
                 {formtextinput cssClass="form-control" id='mailer_body' textMode='multiline' cols=50 rows=10}
             </div>
         </div>
         <div class="form-group" data-switch="msgtype" data-switch-value="text,multipart">
-            {formlabel cssClass="col-lg-3 control-label" for='mailer_textbody' __text='Plain-text message'}
-            <div class="col-lg-9">
+            {formlabel cssClass="col-sm-3 control-label" for='mailer_textbody' __text='Plain-text message'}
+            <div class="col-sm-9">
                 {formtextinput cssClass="form-control" id='mailer_textbody' textMode='multiline' cols=50 rows=10}
             </div>
         </div>
@@ -77,7 +77,7 @@
     {notifydisplayhooks eventname='mailer.ui_hooks.htmlmail.form_edit' id=null}
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             {formbutton class='btn btn-success' commandName='save' __text='Send test email now'}
             {formbutton class='btn btn-danger' commandName='cancel' __text='Cancel'}
         </div>

--- a/src/system/Zikula/Module/PageLockModule/Resources/views/lockedWindow.tpl
+++ b/src/system/Zikula/Module/PageLockModule/Resources/views/lockedWindow.tpl
@@ -1,4 +1,3 @@
-
 <div class="modal fade" id="pageLockModal" tabindex="-1" role="dialog" aria-labelledby="pageLockModalLabel" aria-hidden="true">
     <div class="modal-dialog text-left">
         <div class="modal-content">

--- a/src/system/Zikula/Module/PermissionsModule/Resources/views/Admin/delete.tpl
+++ b/src/system/Zikula/Module/PermissionsModule/Resources/views/Admin/delete.tpl
@@ -13,7 +13,7 @@
         <fieldset>
             <legend>{gt text='Confirmation prompt'}</legend>
             <div class="form-group">
-                <div class="col-lg-offset-3 col-lg-9">
+                <div class="col-sm-offset-3 col-sm-9">
                     {button class='btn btn-success' __alt='Delete' __title='Delete' __text='Delete'}
                     <a class="btn btn-danger" href="{route name='zikulapermissionsmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
                 </div>

--- a/src/system/Zikula/Module/PermissionsModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/PermissionsModule/Resources/views/Admin/modifyconfig.tpl
@@ -13,26 +13,26 @@
         <fieldset>
             <legend>{$templatetitle}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="permissions_lockadmin">{gt text='Lock main administration permission rule'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="permissions_lockadmin">{gt text='Lock main administration permission rule'}</label>
+                <div class="col-sm-9">
                     <input id="permissions_lockadmin" name="lockadmin" type="checkbox" value="1"{if $lockadmin eq 1} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="permission_adminid">{gt text='ID of main administration permission rule'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="permission_adminid">{gt text='ID of main administration permission rule'}</label>
+                <div class="col-sm-9">
                     <input type="text" class="form-control" name="adminid" id="permission_adminid" size="3" maxlength="3" value="{$adminid}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="permissions_filter">{gt text='Enable filtering of group permissions'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="permissions_filter">{gt text='Enable filtering of group permissions'}</label>
+                <div class="col-sm-9">
                     <input id="permissions_filter" name="filter" type="checkbox" value="1"{if $filter eq 1} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="permissions_rowview">{gt text='Minimum row height for permission rules list view (in pixels)'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="permissions_rowview">{gt text='Minimum row height for permission rules list view (in pixels)'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="permissions_rowview" name="rowview" size="1">
                         <option value="20"{if $rowview eq 20} selected="selected"{/if}>20</option>
                         <option value="25"{if $rowview eq 25} selected="selected"{/if}>25</option>
@@ -43,8 +43,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="permissions_roweditheight">{gt text='Minimum row height for rule editing view (in pixels)'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="permissions_roweditheight">{gt text='Minimum row height for rule editing view (in pixels)'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="permissions_roweditheight" name="rowedit" size="1">
                         <option value="20"{if $rowedit eq 20} selected="selected"{/if}>20</option>
                         <option value="25"{if $rowedit eq 25} selected="selected"{/if}>25</option>
@@ -57,7 +57,7 @@
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulapermissionsmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/PermissionsModule/Resources/views/Admin/view.tpl
+++ b/src/system/Zikula/Module/PermissionsModule/Resources/views/Admin/view.tpl
@@ -109,33 +109,33 @@
     <fieldset>
         <legend>{gt text='User permission check'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="test_user">{gt text='User name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="test_user">{gt text='User name'}</label>
+            <div class="col-sm-9">
                 <input class="form-control" type="text" size="40" maxlength="50" name="test_user" id="test_user" value="{$testuser|safetext}" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="test_component">{gt text='Component to check'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="test_component">{gt text='Component to check'}</label>
+            <div class="col-sm-9">
                 <input class="form-control" type="text" size="40" maxlength="50" name="test_component" id="test_component" value="{$testcomponent|safetext}" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="test_instance">{gt text='Instance to check'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="test_instance">{gt text='Instance to check'}</label>
+            <div class="col-sm-9">
                 <input class="form-control" type="text" size="40" maxlength="50" name="test_instance" id="test_instance" value="{$testinstance|safetext}" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="test_level">{gt text='Permission level'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="test_level">{gt text='Permission level'}</label>
+            <div class="col-sm-9">
                 <select name="test_level" id="test_level" class="form-control" >
                     {html_options options=$permissionlevels selected=$testlevel}
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <div class="help-block col-lg-offset-3 col-lg-9" id="permission-test-info" data-testing="{gt text='Testing permission...'}">
+            <div class="help-block col-sm-offset-3 col-sm-9" id="permission-test-info" data-testing="{gt text='Testing permission...'}">
                 {if $testresult ne ''}
                     {gt text='Permission check result:'} {$testresult}
                 {else}
@@ -144,7 +144,7 @@
             </div>
         </div>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-default" id="test-permission" title="{gt text='Check permission'}">{gt text='Check permission'}</button>
                 <button class="btn btn-danger" type="reset" title="{gt text='Reset'}">{gt text='Reset'}</button>
             </div>

--- a/src/system/Zikula/Module/SearchModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/SearchModule/Resources/views/Admin/modifyconfig.tpl
@@ -10,14 +10,14 @@
         <fieldset>
             <legend>{gt text='General settings'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="search_itemsperpage">{gt text='Items per page'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="search_itemsperpage">{gt text='Items per page'}</label>
+                <div class="col-sm-9">
                     <input id="search_itemsperpage" type="text" class="form-control" name="itemsperpage" size="3" value="{$itemsperpage|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="search_limitsummary">{gt text='Number of characters to display in item summaries'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="search_limitsummary">{gt text='Number of characters to display in item summaries'}</label>
+                <div class="col-sm-9">
                     <input id="search_limitsummary" type="text" class="form-control" name="limitsummary" size="5" value="{$limitsummary|safetext}" />
                 </div>
             </div>
@@ -27,8 +27,8 @@
             {foreach item='plugin' from=$plugins}
                 {if isset($plugin.title)}
                     <div class="form-group">
-                        <label class="col-lg-3 control-label" for="search_disable{$plugin.title|safetext}">{modgetinfo info='displayname' modname=$plugin.title}</label>
-                        <div class="col-lg-9">
+                        <label class="col-sm-3 control-label" for="search_disable{$plugin.title|safetext}">{modgetinfo info='displayname' modname=$plugin.title}</label>
+                        <div class="col-sm-9">
                             <input id="search_disable{$plugin.title|safetext}" type="checkbox" name="disable[{$plugin.title|safetext}]" value="1"{if $plugin.disabled} checked="checked"{/if} />
                         </div>
                     </div>
@@ -41,21 +41,21 @@
                 {gt text='%1$s OpenSearch %2$s makes it possible for your site\'s users to use your site\'s search function as a search engine.' tag1='<a href="http://en.wikipedia.org/wiki/OpenSearch">' tag2='</a>'}
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="search_opensearch_enabled">{gt text='Enable OpenSearch'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="search_opensearch_enabled">{gt text='Enable OpenSearch'}</label>
+                <div class="col-sm-9">
                     <input id="search_opensearch_enabled" type="checkbox" name="opensearch_enabled"{if $opensearch_enabled|default:false} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="search_opensearch_adult_content">{gt text='This page contains adult content'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="search_opensearch_adult_content">{gt text='This page contains adult content'}</label>
+                <div class="col-sm-9">
                     <input id="search_opensearch_adult_content" type="checkbox" name="opensearch_adult_content"{if $opensearch_adult_content|default:false} checked="checked"{/if} />
                 </div>
             </div>
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulasearchmodule_admin_index'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/SearchModule/Resources/views/Block/search_modify.tpl
+++ b/src/system/Zikula/Module/SearchModule/Resources/views/Block/search_modify.tpl
@@ -1,12 +1,12 @@
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="search_displaySearchBtn">{gt text="Show 'Search now' button" domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="search_displaySearchBtn">{gt text="Show 'Search now' button" domain='zikula'}</label>
+    <div class="col-sm-9">
         <input id="search_displaySearchBtn" type="checkbox" name="displaySearchBtn" value="1"{if $searchvars.displaySearchBtn eq 1} checked="checked"{/if} />
     </div>
 </div>
 <div class="form-group">
-    <label class="col-lg-3 control-label">{gt text='Search options' domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label">{gt text='Search options' domain='zikula'}</label>
+    <div class="col-sm-9">
     {section name='searchmodules' loop=$searchmodules}
         <div class="z-formlist">{$searchmodules[searchmodules].module}</div>
     {/section}

--- a/src/system/Zikula/Module/SearchModule/Resources/views/User/form.tpl
+++ b/src/system/Zikula/Module/SearchModule/Resources/views/User/form.tpl
@@ -5,24 +5,24 @@
 <form class="form-horizontal" role="form" id="search_form" method="post" action="{route name='zikulasearchmodule_user_search'}">
     <fieldset>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="search_q" id="search_q_label">{gt text='Search keywords' domain='zikula'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="search_q" id="search_q_label">{gt text='Search keywords' domain='zikula'}</label>
+            <div class="col-sm-9">
                 <input type="search" id="search_q" class="form-control" name="q" size="20" maxlength="255" results="10" autosave="Search" value="{$q|safetext}" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="searchtype">{gt text='Keyword settings' domain='zikula'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="searchtype">{gt text='Keyword settings' domain='zikula'}</label>
+            <div class="col-sm-9">
                 <select class="form-control" name="searchtype" id="searchtype" size="1">
                     <option value="AND"{if $searchtype eq 'AND'} selected="selected"{/if}>{gt text='All words' domain='zikula'}</option>
-                    <option value="OR"{if $searchtype eq 'OR'}selected="selected""{/if}>{gt text='Any words' domain='zikula'}</option>
-                    <option value="EXACT"{if $searchtype eq 'EXACT'}selected="selected""{/if}>{gt text='Exact phrase' domain='zikula'}</option>
+                    <option value="OR"{if $searchtype eq 'OR'}selected="selected"{/if}>{gt text='Any words' domain='zikula'}</option>
+                    <option value="EXACT"{if $searchtype eq 'EXACT'}selected="selected"{/if}>{gt text='Exact phrase' domain='zikula'}</option>
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="searchorder">{gt text='Order of results' domain='zikula'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="searchorder">{gt text='Order of results' domain='zikula'}</label>
+            <div class="col-sm-9">
                 <select class="form-control" name="searchorder" id="searchorder" size="1">
                     <option value="newest"{if $searchorder eq 'newest'} selected="selected"{/if}>{gt text="Newest first" domain='zikula'}</option>
                     <option value="oldest"{if $searchorder eq 'oldest'} selected="selected"{/if}>{gt text="Oldest first" domain='zikula'}</option>
@@ -31,7 +31,7 @@
             </div>
         </div>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Search now'}">{gt text='Search now'}</button>
             </div>
         </div>

--- a/src/system/Zikula/Module/SearchModule/Resources/views/User/menu.tpl
+++ b/src/system/Zikula/Module/SearchModule/Resources/views/User/menu.tpl
@@ -1,2 +1,2 @@
-{gt text="Site search" assign=title domain='zikula'}
+{gt text='Site search' assign='title' domain='zikula'}
 {moduleheader modname='Search' type='user' title=$title setpagetitle=true insertstatusmsg=true}

--- a/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/allowedhtml.tpl
+++ b/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/allowedhtml.tpl
@@ -12,7 +12,7 @@
         <legend>{gt text='HTML entities'}</legend>
         <input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
         <div class="form-group" id="securitycenter_htmlentities">
-            <div class="col-lg-12">
+            <div class="col-sm-12">
                 <label>{gt text='Translate embedded HTML entities into real characters'}</label>
                 <input id="securitycenter_htmlentities_yes" type="radio" name="xhtmlentities" value="1"{if $htmlentities eq 1} checked="checked"{/if} />
                 <label for="securitycenter_htmlentities_yes">{gt text='Yes'}</label>
@@ -60,7 +60,7 @@
         </table>
     </fieldset>
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
             <a class="btn btn-danger" href="{route name='zikulasecuritycentermodule_admin_index'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
         </div>

--- a/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/exportidslog.tpl
+++ b/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/exportidslog.tpl
@@ -18,20 +18,20 @@
         <input type="hidden" name="confirmed" value="1" />
         <legend>{gt text='Export Options'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_export_titles">{gt text='Export Title Row'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_export_titles">{gt text='Export Title Row'}</label>
+            <div class="col-sm-9">
                 <input id="securitycenter_export_titles" type="checkbox" name="exportTitles" value="1" checked="checked" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_export_file">{gt text='CSV filename'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_export_file">{gt text='CSV filename'}</label>
+            <div class="col-sm-9">
                 <input id="securitycenter_export_file" type="text" class="form-control" name="exportFile" size="30" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_export_delimiter">{gt text='CSV delimiter'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_export_delimiter">{gt text='CSV delimiter'}</label>
+            <div class="col-sm-9">
                 <select class="form-control" id="securitycenter_export_delimiter" name="delimiter">
                     <option value="1">{gt text='Comma'} (,)</option>
                     <option value="2">{gt text='Semicolon'} (;)</option>
@@ -42,7 +42,7 @@
         </div>
     </fieldset>
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text='Export'}">{gt text='Export'}</button>
             <a class="btn btn-default" href="{route name='zikulasecuritycentermodule_admin_viewidslog'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
         </div>

--- a/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/modifyconfig.tpl
@@ -11,8 +11,8 @@
         <input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
 
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Check for updates'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Check for updates'}</label>
+            <div class="col-sm-9">
                 <div id="securitycenter_updatecheck">
                     <input id="securitycenter_updatecheck_yes" type="radio" name="updatecheck" value="1"{if $modvars.ZConfig.updatecheck eq 1} checked="checked"{/if} />
                     <label for="securitycenter_updatecheck_yes">{gt text='Yes'}</label>
@@ -22,8 +22,8 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_updatefrequency">{gt text='How often'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_updatefrequency">{gt text='How often'}</label>
+            <div class="col-sm-9">
                 <select class="form-control" id="securitycenter_updatefrequency" name="updatefrequency" size="1">
                     <option value="30"{if $modvars.ZConfig.updatefrequency eq 30} selected="selected"{/if}>{gt text='Monthly'}</option>
                     <option value="7"{if $modvars.ZConfig.updatefrequency eq 7} selected="selected"{/if}>{gt text='Weekly'}</option>
@@ -35,14 +35,14 @@
     <fieldset>
         <legend>{gt text='Host settings'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_keyexpiry">{gt text="Time limit for authorisation keys ('authkeys') in seconds (default: 0)"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_keyexpiry">{gt text="Time limit for authorisation keys ('authkeys') in seconds (default: 0)"}</label>
+            <div class="col-sm-9">
                 <input id="securitycenter_keyexpiry" type="text" class="form-control" name="keyexpiry" value="{$modvars.ZConfig.keyexpiry|safetext}" size="10" maxlength="15" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text="Bind authkey to user agent ('UserAgent')"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text="Bind authkey to user agent ('UserAgent')"}</label>
+            <div class="col-sm-9">
                 <div id="securitycenter_sessionauthkeyua">
                     <input id="sessionauthkeyua1" type="radio" name="sessionauthkeyua" value="1"{if $modvars.ZConfig.sessionauthkeyua eq 1} checked="checked"{/if} />
                     <label for="sessionauthkeyua1">{gt text='Yes'}</label>
@@ -52,8 +52,8 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_secure_domain">{gt text='Secure host name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_secure_domain">{gt text='Secure host name'}</label>
+            <div class="col-sm-9">
                 <input id="securitycenter_secure_domain" type="text" class="form-control" name="secure_domain" value="{$modvars.ZConfig.secure_domain|safetext}" size="50" maxlength="100" />
                 <p class="help-block alert alert-info">{gt text="Notice: If you use a different host name for HTTPS secure sessions and you insert an address in the 'Secure host name' box, make sure you include a trailing slash at the end of the address."}</p>
             </div>
@@ -62,8 +62,8 @@
     <fieldset>
         <legend>{gt text='Cookies settings'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Sign cookies'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Sign cookies'}</label>
+            <div class="col-sm-9">
                 <div id="securitycenter_signcookies">
                     <input id="securitycenter_signcookies_yes" type="radio" name="signcookies" value="1"{if $modvars.ZConfig.signcookies eq 1} checked="checked"{/if} />
                     <label for="securitycenter_signcookies_yes">{gt text='Yes'}</label>
@@ -73,8 +73,8 @@
             </div>
         </div>
         <div data-switch="signcookies" data-switch-value="1" class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_signingkey">{gt text='Signing key'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_signingkey">{gt text='Signing key'}</label>
+            <div class="col-sm-9">
                 <input id="securitycenter_signingkey" name="signingkey" type="text" class="form-control" value="{$modvars.ZConfig.signingkey|safetext}" size="50" maxlength="100" />
             </div>
         </div>
@@ -82,8 +82,8 @@
     <fieldset>
         <legend>{gt text='Session settings'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_seclevel">{gt text='Security level'} <a href="http://www.php.net/manual/en/session.configuration.php#ini.session.cookie-lifetime">(?)</a></label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_seclevel">{gt text='Security level'} <a href="http://www.php.net/manual/en/session.configuration.php#ini.session.cookie-lifetime">(?)</a></label>
+            <div class="col-sm-9">
                 <select class="form-control" id="securitycenter_seclevel" name="seclevel" size="1">
                     <option value="High"{if $modvars.ZConfig.seclevel eq 'High'} selected="selected"{/if}>{gt text='High (user is logged-out after X minutes of inactivity)'}</option>
                     <option value="Medium"{if $modvars.ZConfig.seclevel eq 'Medium'} selected="selected"{/if}>{gt text="Medium (user is logged-out after X minutes of inactivity, unless 'Remember me' checkbox is activated during log-in)"}</option>
@@ -92,22 +92,22 @@
             </div>
         </div>
         <div data-switch="seclevel" data-switch-value="Medium" class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_secmeddays">{gt text='Automatically log user out after'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_secmeddays">{gt text='Automatically log user out after'}</label>
+            <div class="col-sm-9">
                 <input id="securitycenter_secmeddays" type="text" class="form-control" name="secmeddays" value="{$modvars.ZConfig.secmeddays|safetext}" size="4" />
                 <em>{gt text="days (if 'Remember me' is activated)"}</em>
             </div>
         </div>
         <div data-switch="seclevel" data-switch-value="Medium,High"  class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_secinactivemins">{gt text='Expire session after'} <a href="http://www.php.net/manual/en/session.configuration.php#ini.session.gc-maxlifetime">(?)</a></label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_secinactivemins">{gt text='Expire session after'} <a href="http://www.php.net/manual/en/session.configuration.php#ini.session.gc-maxlifetime">(?)</a></label>
+            <div class="col-sm-9">
                 <input id="securitycenter_secinactivemins" type="text" class="form-control" name="secinactivemins" value="{$modvars.ZConfig.secinactivemins|safetext}" size="4" />
                 <em>{gt text='minutes of inactivity'}</em>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Store sessions'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Store sessions'}</label>
+            <div class="col-sm-9">
                 <div id="securitycenter_sessionstoretofile">
                     <input id="securitycenter_sessionstoretofile_file" type="radio" name="sessionstoretofile" value="1"{if $modvars.ZConfig.sessionstoretofile eq 1} checked="checked"{/if} />
                     <label for="securitycenter_sessionstoretofile_file">{gt text='File'}</label>
@@ -119,15 +119,15 @@
         </div>
 
         <div data-switch="sessionstoretofile" data-switch-value="1" class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_sessionsavepath">{gt text='Path for saving session files'} <a href="http://www.php.net/manual/en/session.configuration.php#ini.session.save-path">(?)</a></label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_sessionsavepath">{gt text='Path for saving session files'} <a href="http://www.php.net/manual/en/session.configuration.php#ini.session.save-path">(?)</a></label>
+            <div class="col-sm-9">
                 <input id="securitycenter_sessionsavepath" type="text" class="form-control" name="sessionsavepath" size="50" value="{$modvars.ZConfig.sessionsavepath|safetext}" />
                 <p class="help-block alert alert-info">{gt text="Notice: If you change 'Where to save sessions' to 'File' then you must enter a path in the 'Path for saving session files' box above. The path must be writeable."}</p>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_gc_probability">{gt text='Garbage collection probability'} <a href="http://www.php.net/manual/en/session.configuration.php#ini.session.gc-probability">(?)</a></label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_gc_probability">{gt text='Garbage collection probability'} <a href="http://www.php.net/manual/en/session.configuration.php#ini.session.gc-probability">(?)</a></label>
+            <div class="col-sm-9">
                 <div class="input-group">
                     <input id="securitycenter_gc_probability" type="text" class="form-control" name="gc_probability" value="{$modvars.ZConfig.gc_probability|safetext}" size="4" maxlength="5" />
                     <span class="input-group-addon">{gt text='/10000'}</span>
@@ -136,8 +136,8 @@
         </div>
 
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='CSRF Token'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='CSRF Token'}</label>
+            <div class="col-sm-9">
                 <div id="securitycenter_sessioncsrftokenonetime">
                     <input id="securitycenter_sessioncsrftokenonetime_persession" type="radio" name="sessioncsrftokenonetime" value="1"{if $modvars.ZConfig.sessioncsrftokenonetime eq 1} checked="checked"{/if} />
                     <label for="securitycenter_sessioncsrftokenonetime_persession">{gt text='Per session'}</label>
@@ -149,8 +149,8 @@
         </div>
 
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Use sessions for anonymous guests'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Use sessions for anonymous guests'}</label>
+            <div class="col-sm-9">
             <div id="securitycenter_anonymoussessions">
                 <input id="anonymoussessions1" type="radio" name="anonymoussessions" value="1"{if $modvars.ZConfig.anonymoussessions eq 1} checked="checked"{/if} />
                 <label for="anonymoussessions1">{gt text='Yes'}</label>
@@ -160,8 +160,8 @@
         </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Periodically regenerate session ID'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Periodically regenerate session ID'}</label>
+            <div class="col-sm-9">
             <div id="securitycenter_sessionrandregenerate">
                 <input id="sessionrandregenerate1" type="radio" name="sessionrandregenerate" value="1"{if $modvars.ZConfig.sessionrandregenerate eq 1} checked="checked"{/if} />
                 <label for="sessionrandregenerate1">{gt text='Yes'}</label>
@@ -171,8 +171,8 @@
         </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Regenerate session ID during log-in and log-out'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Regenerate session ID during log-in and log-out'}</label>
+            <div class="col-sm-9">
             <div id="securitycenter_sessionregenerate">
                 <input id="sessionregenerate1" type="radio" name="sessionregenerate" value="1"{if $modvars.ZConfig.sessionregenerate eq 1} checked="checked"{/if} />
                 <label for="sessionregenerate1">{gt text='Yes'}</label>
@@ -182,8 +182,8 @@
         </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_sessionregeneratefreq">{gt text='Regeneration probability'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_sessionregeneratefreq">{gt text='Regeneration probability'}</label>
+            <div class="col-sm-9">
                 <div class="input-group">
                     <input id="securitycenter_sessionregeneratefreq" type="text" class="form-control" name="sessionregeneratefreq" value="{$modvars.ZConfig.sessionregeneratefreq|safetext}" size="3" maxlength="3" />
                     <span class="input-group-addon">{gt text='% (0 to disable)'}</span>
@@ -191,8 +191,8 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='IP checks on session (may cause problems for AOL users)'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='IP checks on session (may cause problems for AOL users)'}</label>
+            <div class="col-sm-9">
             <div id="securitycenter_sessionipcheck">
                 <input id="sessionipcheck1" type="radio" name="sessionipcheck" value="1"{if $modvars.ZConfig.sessionipcheck eq 1} checked="checked"{/if} />
                 <label for="sessionipcheck1">{gt text='Yes'}</label>
@@ -202,8 +202,8 @@
         </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_sessionname">{gt text='Session cookie name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_sessionname">{gt text='Session cookie name'}</label>
+            <div class="col-sm-9">
                 <input id="securitycenter_sessionname" type="text" class="form-control" name="sessionname" value="{$modvars.ZConfig.sessionname|safetext}" size="20" />
                 <p class="help-block alert alert-warning">{gt text="Notice: If you change the 'Session cookie name' setting, all registered users who are currently logged-in will then be logged-out automatically, and they will have to log back in again."}</p>
             </div>
@@ -212,8 +212,8 @@
     <fieldset id="securitycenter_ids">
         <legend>{gt text='Intrusion Detection System'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='Use PHPIDS'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='Use PHPIDS'}</label>
+            <div class="col-sm-9">
                 <div id="securitycenter_useids">
                     <input id="useidsyes" type="radio" name="useids" value="1"{if $modvars.ZConfig.useids eq 1} checked="checked"{/if} />
                     <label for="useidsyes">{gt text='Yes'}</label>
@@ -224,13 +224,13 @@
         </div>
 
         <div data-switch="useids" data-switch-value="1">
-            <p class="col-lg-offset-3 col-lg-9 help-block alert alert-info">
+            <p class="col-sm-offset-3 col-sm-9 help-block alert alert-info">
                 {gt text='PHPIDS performs many different checks which return an impact value for scoring the treated request. Depending on the sum of all impacts performed actions are selected.'}
                 {gt text='Read more about this system on the <a href="http://phpids.org" title="PHPIDS homepage">PHPIDS homepage</a>.'}
             </p>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Block action'}</label>
-                <div class="col-lg-9" id="securitycenter_idssoftblock">
+                <label class="col-sm-3 control-label">{gt text='Block action'}</label>
+                <div class="col-sm-9" id="securitycenter_idssoftblock">
                     <input id="idssoftblockyes" type="radio" name="idssoftblock" value="1"{if $modvars.ZConfig.idssoftblock eq 1} checked="checked"{/if} />
                     <label for="idssoftblockyes">{gt text='Warn only'}</label>
                     <input id="idssoftblockno" type="radio" name="idssoftblock" value="0"{if $modvars.ZConfig.idssoftblock neq 1} checked="checked"{/if} />
@@ -238,8 +238,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Send email on block action'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Send email on block action'}</label>
+                <div class="col-sm-9">
                     <div id="securitycenter_idsmail">
                         <input id="idsmailyes" type="radio" name="idsmail" value="1"{if $modvars.ZConfig.idsmail eq 1} checked="checked"{/if} />
                         <label for="idsmailyes">{gt text='Yes'}</label>
@@ -249,8 +249,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_idsfilter">{gt text='Select filter rules to use'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_idsfilter">{gt text='Select filter rules to use'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="securitycenter_idsfilter" name="idsfilter">
                         <option value="xml"{if $modvars.ZConfig.idsfilter ne "json"} selected="selected"{/if}>{gt text='XML'}</option>
                         <option value="json"{if $modvars.ZConfig.idsfilter eq "json"} selected="selected"{/if}>{gt text='JSON'}</option>
@@ -258,39 +258,39 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_idsrulepath">{gt text='IDS Rule path'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_idsrulepath">{gt text='IDS Rule path'}</label>
+                <div class="col-sm-9">
                     <input id="securitycenter_idsrulepath" type="text" class="form-control" name="idsrulepath" size="3" value="{$modvars.ZConfig.idsrulepath|safetext}" />
                     {gt text='Default: config/phpids_zikula_default.xml'}
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_impactthresholdone">{gt text='Minimum impact to log intrusion in the database'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_impactthresholdone">{gt text='Minimum impact to log intrusion in the database'}</label>
+                <div class="col-sm-9">
                     <input id="securitycenter_impactthresholdone" type="text" class="form-control" name="idsimpactthresholdone" size="3" value="{$modvars.ZConfig.idsimpactthresholdone|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_impactthresholdtwo">{gt text='Minimum impact to email the administrator'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_impactthresholdtwo">{gt text='Minimum impact to email the administrator'}</label>
+                <div class="col-sm-9">
                     <input id="securitycenter_impactthresholdtwo" type="text" class="form-control" name="idsimpactthresholdtwo" size="3" value="{$modvars.ZConfig.idsimpactthresholdtwo|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_impactthresholdthree">{gt text='Minimum impact to block the request'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_impactthresholdthree">{gt text='Minimum impact to block the request'}</label>
+                <div class="col-sm-9">
                     <input id="securitycenter_impactthresholdthree" type="text" class="form-control" name="idsimpactthresholdthree" size="3" value="{$modvars.ZConfig.idsimpactthresholdthree|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_impactthresholdfour">{gt text='Minimum impact to kick the user (destroy the session)'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_impactthresholdfour">{gt text='Minimum impact to kick the user (destroy the session)'}</label>
+                <div class="col-sm-9">
                     <input id="securitycenter_impactthresholdfour" type="text" class="form-control" name="idsimpactthresholdfour" size="3" value="{$modvars.ZConfig.idsimpactthresholdfour|safetext}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_impactmode">{gt text='Select the way the impact thresholds are used in Zikula'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_impactmode">{gt text='Select the way the impact thresholds are used in Zikula'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="securitycenter_impactmode" name="idsimpactmode">
                         <option value="1"{if $modvars.ZConfig.idsimpactmode ne 2 && $modvars.ZConfig.idsimpactmode ne 3} selected="selected"{/if}>{gt text='React on impact per request (uses the values from above)'}</option>
                         <option value="2"{if $modvars.ZConfig.idsimpactmode eq 2} selected="selected"{/if}>{gt text='React on impact sum per session [loose] (uses the values from above * 10)'}</option>
@@ -299,22 +299,22 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_idshtmlfields">{gt text='Define which fields contain HTML and need preparation'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_idshtmlfields">{gt text='Define which fields contain HTML and need preparation'}</label>
+                <div class="col-sm-9">
                     <textarea class="form-control" id="securitycenter_idshtmlfields" name="idshtmlfields" cols="50" rows="8">{$idshtmlfields|safetext}</textarea>
                     <em class="help-block sub">{gt text='(Place each value on a separate line.)'}</em>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_idsjsonfields">{gt text='Define which fields contain JSON data and should be treated as such'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_idsjsonfields">{gt text='Define which fields contain JSON data and should be treated as such'}</label>
+                <div class="col-sm-9">
                     <textarea class="form-control" id="securitycenter_idsjsonfields" name="idsjsonfields" cols="50" rows="8">{$idsjsonfields|safetext}</textarea>
                     <em class="help-block sub">{gt text='(Place each value on a separate line.)'}</em>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="securitycenter_idsexceptions">{gt text='Define which fields should not be monitored'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="securitycenter_idsexceptions">{gt text='Define which fields should not be monitored'}</label>
+                <div class="col-sm-9">
                     <textarea class="form-control" id="securitycenter_idsexceptions" name="idsexceptions" cols="50" rows="8">{$idsexceptions|safetext}</textarea>
                     <em class="help-block sub">{gt text='(Place each value on a separate line.)'}</em>
                 </div>
@@ -324,8 +324,8 @@
     <fieldset>
         <legend>{gt text='Output filter settings'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="securitycenter_outputfilter">{gt text='Select output filter'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="securitycenter_outputfilter">{gt text='Select output filter'}</label>
+            <div class="col-sm-9">
                 <select class="form-control" id="securitycenter_outputfilter" name="outputfilter">
                     <option value="0"{if $modvars.ZConfig.outputfilter eq 0} selected="selected"{/if}>{gt text='Use internal output filter only'}</option>
                     <option value="1"{if $modvars.ZConfig.outputfilter eq 1} selected="selected"{/if}>{gt text="Use 'HTML Purifier' + internal mechanism as output filter"}</option>
@@ -335,7 +335,7 @@
     </fieldset>
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
             <a class="btn btn-danger" href="{route name='zikulasecuritycentermodule_admin_index'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
         </div>

--- a/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/purgeidslog.tpl
+++ b/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/purgeidslog.tpl
@@ -19,7 +19,7 @@
         <fieldset>
             <legend>{gt text='Confirmation prompt'}</legend>
             <div class="form-group">
-                <div class="col-lg-offset-3 col-lg-9">
+                <div class="col-sm-offset-3 col-sm-9">
                     {button class='btn btn-success' __alt='Delete' __title='Delete' __text='Delete'}
                     <a class="btn btn-danger" href="{route name='zikulasecuritycentermodule_admin_viewidslog'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
                 </div>

--- a/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/purifierconfig.tpl
+++ b/src/system/Zikula/Module/SecurityCenterModule/Resources/views/Admin/purifierconfig.tpl
@@ -32,10 +32,10 @@
 
             {if $directive.allowNull}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="purifierConfig_div_{$directive.key}">
+                <label class="col-sm-3 control-label" for="purifierConfig_div_{$directive.key}">
                     {$directiveName|safetext} <a href="http://htmlpurifier.org/live/configdoc/plain.html#{$directive.key|urlencode}">(?)</a>
                 </label>
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <div id="purifierConfig_div_{$directive.key}">
                         <input id="purifierConfig_Null_{$directive.key}" name="purifierConfig[Null_{$directive.key}]" type="checkbox" value="1"{if is_null($directive.value)} checked="checked"{/if} onclick="{if ($directive.type != $purifierTypes.bool)}toggleWriteability('{$idVal}', checked);{else}toggleWriteability('{$idVal}_Yes', checked); toggleWriteability('{$idVal}_No', checked);{/if}" />
                         <label for="purifierConfig_Null_{$directive.key}">{gt text='Use default value (if checked) or override value'}</label>
@@ -43,16 +43,16 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="{$idVal}">&nbsp;</label>
+                <label class="col-sm-3 control-label" for="{$idVal}">&nbsp;</label>
             {else}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="{$idVal}">{$directiveName|safetext} <a href="http://htmlpurifier.org/live/configdoc/plain.html#{$directive.key|urlencode}">(?)</a></label>
+                <label class="col-sm-3 control-label" for="{$idVal}">{$directiveName|safetext} <a href="http://htmlpurifier.org/live/configdoc/plain.html#{$directive.key|urlencode}">(?)</a></label>
             {/if}
 
                 {if is_null($directive.value)}{assign var='disabledVal' value=' disabled="disabled"'}{else}{assign var='disabledVal' value=''}{/if}
 
                 {if isset($directive.allowedValues)}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <select id="{$idVal}" class="form-control" name="{$nameVal}"{$disabledVal} style="min-width: 5em;">
                         {foreach from=$directive.allowedValues item='allowedVal'}
                         <option value="{$allowedVal}"{if ($directive.value == $allowedVal)} selected="selected"{/if}>{$allowedVal|safetext}</option>
@@ -60,7 +60,7 @@
                     </select>
                 </div>
                 {elseif (($directive.type eq $purifierTypes.text) || ($directive.type eq $purifierTypes.itext) || ($directive.type eq $purifierTypes.list) || ($directive.type eq $purifierTypes.hash) || ($directive.type == $purifierTypes.lookup))}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <textarea id="{$idVal}" class="form-control" name="{$nameVal}" cols="50" rows="8"{$disabledVal}>{$directive.value|safetext}</textarea>
 
                     {if (($directive.type eq $purifierTypes.list) || ($directive.type eq $purifierTypes.lookup))}
@@ -70,18 +70,18 @@
                     {/if}
                 </div>
                 {elseif (($directive.type eq $purifierTypes.string) || ($directive.type eq $purifierTypes.istring) || ($directive.type eq $purifierTypes.int) || ($directive.type eq $purifierTypes.float))}
-                <div class="col-lg-9">  
+                <div class="col-sm-9">  
                     <input id="{$idVal}" name="{$nameVal}" class="form-control" type="text" value="{$directive.value}"{$disabledVal} />
                 </div>
                 {elseif ($directive.type eq $purifierTypes.bool)}
-                <div id="{$idVal}" class="col-lg-9"> 
+                <div id="{$idVal}" class="col-sm-9"> 
                     <input id="{$idVal}_Yes" name="{$nameVal}" type="radio" value="1"{if $directive.value === true} checked="checked"{/if}{$disabledVal} />
                     <label for="{$idVal}_Yes">{gt text='Yes'}</label>
                     <input id="{$idVal}_No" name="{$nameVal}" type="radio" value="0"{if $directive.value === false} checked="checked"{/if}{$disabledVal} />
                     <label for="{$idVal}_No">{gt text='No'}</label>
                 </div>
                 {else}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <em class="help-block sub">{gt text='(Modification not supported.)'} {gt text='Value:'} {$directive.value|serialize|safetext}</em>
                 </div>
                 {/if}
@@ -92,7 +92,7 @@
     {/foreach}
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
             <a class="btn btn-danger" href="{route name='zikulasecuritycentermodule_admin_index'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             <a class="btn btn-danger" href="{route name='zikulasecuritycentermodule_admin_purifierconfig' reset='default'}" title="{gt text='Reset to default values'}">{gt text='Reset to default values'}</a>

--- a/src/system/Zikula/Module/SettingsModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/SettingsModule/Resources/views/Admin/modifyconfig.tpl
@@ -15,15 +15,15 @@
                     <legend>{$language}</legend>
                     {assign var='varname' value='sitename_'|cat:$code}
                     <div class="form-group">
-                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Site name'}</label>
-                        <div class="col-lg-9">
+                        <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Site name'}</label>
+                        <div class="col-sm-9">
                             <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|default:''|safetext}" size="50" maxlength="100" />
                         </div>
                     </div>
                     {assign var='varname' value='slogan_'|cat:$code}
                     <div class="form-group">
-                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Description line'}</label>
-                        <div class="col-lg-9">
+                        <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Description line'}</label>
+                        <div class="col-sm-9">
                             <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|default:''|safetext}" size="50" maxlength="100" />
                         </div>
                     </div>
@@ -32,35 +32,35 @@
             {else}
                 {assign var='varname' value='sitename_'|cat:$lang}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Site name'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Site name'}</label>
+                    <div class="col-sm-9">
                         <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|default:''|safetext}" size="50" maxlength="100" />
                     </div>
                 </div>
                 {assign var='varname' value='slogan_'|cat:$lang}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Description line'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Description line'}</label>
+                    <div class="col-sm-9">
                         <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|default:''|safetext}" size="50" maxlength="100" />
                     </div>
                 </div>
             {/if}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_pagetitle">{gt text='Page title structure'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="settings_pagetitle">{gt text='Page title structure'}</label>
+                <div class="col-sm-9">
                     <input id="settings_pagetitle" type="text" class="form-control" name="settings[pagetitle]" value="{$pagetitle|safetext}" size="50" maxlength="100" />
                     <em class="help-block">{gt text='Possible tags: %pagetitle%, %sitename%, %modulename%'}</em>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_adminmail">{gt text="Admin's e-mail address"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="settings_adminmail">{gt text="Admin's e-mail address"}</label>
+                <div class="col-sm-9">
                     <input id="settings_adminmail" type="text" class="form-control" name="settings[adminmail]" value="{$modvars.ZConfig.adminmail|safetext}" size="30" maxlength="100" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Disable site'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Disable site'}</label>
+                <div class="col-sm-9">
                     <div id="settings_siteoff">
                         <input id="settings_siteoff_yes" type="radio" name="settings[siteoff]" value="1"{if $modvars.ZConfig.siteoff eq 1} checked="checked"{/if} />
                         <label for="settings_siteoff_yes">{gt text='Yes'}</label>
@@ -71,8 +71,8 @@
             </div>
             <div id="settings_siteoff_container">
                 <div class="form-group" data-switch="settings[siteoff]" data-switch-value="1">
-                    <label class="col-lg-3 control-label" for="settings_siteoffreason">{gt text='Reason for disabling site'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_siteoffreason">{gt text='Reason for disabling site'}</label>
+                    <div class="col-sm-9">
                         <textarea class="form-control" id="settings_siteoffreason" name="settings[siteoffreason]" cols="50" rows="5">{$modvars.ZConfig.siteoffreason|safetext}</textarea>
                     </div>
                 </div>
@@ -86,22 +86,22 @@
                     <legend>{$language}</legend>
                     {assign var='varname' value='defaultpagetitle_'|cat:$code}
                     <div class="form-group">
-                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default page title'}</label>
-                        <div class="col-lg-9">
+                        <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Default page title'}</label>
+                        <div class="col-sm-9">
                             <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|default:''|safetext}" size="50" maxlength="255" />
                         </div>
                     </div>
                     {assign var='varname' value='defaultmetadescription_'|cat:$code}
                     <div class="form-group">
-                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta description'}</label>
-                        <div class="col-lg-9">
+                        <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Default meta description'}</label>
+                        <div class="col-sm-9">
                             <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|default:''|safetext}" size="50" maxlength="255" />
                         </div>
                     </div>
                     {assign var='varname' value='metakeywords_'|cat:$code}
                     <div class="form-group">
-                        <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta keywords'}</label>
-                        <div class="col-lg-9">
+                        <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Default meta keywords'}</label>
+                        <div class="col-sm-9">
                             <textarea class="form-control" id="settings_{$varname}" name="settings[{$varname}]" cols="60" rows="3">{$modvars.ZConfig.$varname|default:''|safetext}</textarea>
                         </div>
                     </div>
@@ -110,22 +110,22 @@
             {else}
                 {assign var='varname' value='defaultpagetitle_'|cat:$lang}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default page title'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Default page title'}</label>
+                    <div class="col-sm-9">
                         <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|default:''|safetext}" size="50" maxlength="255" />
                     </div>
                 </div>
                 {assign var='varname' value='defaultmetadescription_'|cat:$lang}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta description'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Default meta description'}</label>
+                    <div class="col-sm-9">
                         <input id="settings_{$varname}" type="text" class="form-control" name="settings[{$varname}]" value="{$modvars.ZConfig.$varname|default:''|safetext}" size="50" maxlength="255" />
                     </div>
                 </div>
                 {assign var='varname' value='metakeywords_'|cat:$lang}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_{$varname}">{gt text='Default meta keywords'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_{$varname}">{gt text='Default meta keywords'}</label>
+                    <div class="col-sm-9">
                         <textarea class="form-control" id="settings_{$varname}" name="settings[{$varname}]" cols="60" rows="3">{$modvars.ZConfig.$varname|default:''|safetext}</textarea>
                     </div>
                 </div>
@@ -134,8 +134,8 @@
         <fieldset>
             <legend>{gt text='Start page settings'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_startpage">{gt text='Start module'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="settings_startpage">{gt text='Start module'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="settings_startpage" name="settings[startpage]">
                         <option value="">{gt text='No start module (static frontpage)'}</option>
                         {html_select_modules selected=$modvars.ZConfig.startpage type='user'}
@@ -145,28 +145,28 @@
             </div>    
             <div id="settings_startpage_container" style="overflow: hidden">
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_starttype">{gt text='Start function type (required)'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_starttype">{gt text='Start function type (required)'}</label>
+                    <div class="col-sm-9">
                         <input id="settings_starttype" type="text" class="form-control" name="settings[starttype]" value="{$modvars.ZConfig.starttype|safetext}" size="10" maxlength="300" />
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_startfunc">{gt text='Start function (required)'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_startfunc">{gt text='Start function (required)'}</label>
+                    <div class="col-sm-9">
                         <input id="settings_startfunc" type="text" class="form-control" name="settings[startfunc]" value="{$modvars.ZConfig.startfunc|safetext}" size="20" maxlength="300" />
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_startargs">{gt text='Start function arguments'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_startargs">{gt text='Start function arguments'}</label>
+                    <div class="col-sm-9">
                         <input id="settings_startargs" type="text" class="form-control" name="settings[startargs]" value="{$modvars.ZConfig.startargs|safetext}" size="20" maxlength="300" />
                         <em class="help-block">{gt text='(Comma-separated)'}</em>
                     </div>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_entrypoint">{gt text='Site entry point'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="settings_entrypoint">{gt text='Site entry point'}</label>
+                <div class="col-sm-9">
                     <input id="settings_entrypoint" type="text" class="form-control" name="settings[entrypoint]" value="{$modvars.ZConfig.entrypoint|safetext}" size="20" maxlength="60" />
                     <em class="help-block">{gt text='(Default: index.php)'}</em>
                     <p class="help-block alert alert-info">{gt text="Notice: The entry point file must be present in the Zikula root directory before you set it here as your site's start page."}</p>
@@ -176,8 +176,8 @@
         <fieldset>
             <legend>{gt text='General settings'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Activate compression'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Activate compression'}</label>
+                <div class="col-sm-9">
                     <div id="settings_usecompression">
                         <input id="UseCompression1" type="radio" name="settings[UseCompression]" value="1"{if $modvars.ZConfig.UseCompression eq 1} checked="checked"{/if} />
                         <label for="UseCompression1">{gt text='Yes'}</label>
@@ -190,8 +190,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_profilemodule">{gt text='Module used for managing user profiles'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="settings_profilemodule">{gt text='Module used for managing user profiles'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="settings_profilemodule" name="settings[profilemodule]">
                         <option value="">{gt text='No user profiles'}</option>
                         {html_select_modules selected=$modvars.ZConfig.profilemodule type='profile'}
@@ -199,8 +199,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_messagemodule">{gt text='Module used for private messaging'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="settings_messagemodule">{gt text='Module used for private messaging'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="settings_messagemodule" name="settings[messagemodule]">
                         <option value="">{gt text='No private messaging'}</option>
                         {html_select_modules selected=$modvars.ZConfig.messagemodule type='message'}
@@ -208,8 +208,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_ajaxtimeout">{gt text='Time-out for Ajax connections'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="settings_ajaxtimeout">{gt text='Time-out for Ajax connections'}</label>
+                <div class="col-sm-9">
                     <input class="form-control" id="settings_ajaxtimeout" name="settings[ajaxtimeout]" value="{$modvars.ZConfig.ajaxtimeout}" />
                     <em>{gt text='(in milliseconds, default 5000 = 5 seconds)'}</em>
                     <p class="help-block alert alert-info">{gt text='Notice: Increase this value if mobile appliances experience problems with using the site.'}</p>
@@ -220,16 +220,16 @@
             <legend>{gt text='Permalinks settings'}</legend>
             <p class="alert alert-warning">{gt text="Notice: The following settings will rewrite your permalinks. Sometimes, international characters like 'ñ' and 'ß' may be re-encoded by your browser. Although this is technically the correct action, it may not be aesthetically pleasing.  These settings allow you to replace those characters, using a pair of comma-separated lists. The two fields below should resemble the examples provided: The first element of 'List to search for' will replace the first element in the 'List to replace with' and so on. In the example below, 'À' would be replace with 'A', and 'Á' with 'A'. If you do not want to use this feature, leave both fields blank."}</p>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_permasearch">{gt text='List to search for'} </label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="settings_permasearch">{gt text='List to search for'} </label>
+                <div class="col-sm-9">
                     <input id="settings_permasearch" class="form-control" type="text" name="settings[permasearch]" value="{$modvars.ZConfig.permasearch}" size="60" /><br />
                     <label for="settings_permasearch_default">{gt text='Default'}</label>
                     <input id="settings_permasearch_default" type="text" class="form-control" readonly="readonly" value="{gt text='À,Á,Â,Ã,Å,à,á,â,ã,å,Ò,Ó,Ô,Õ,Ø,ò,ó,ô,õ,ø,È,É,Ê,Ë,è,é,ê,ë,Ç,ç,Ì,Í,Î,Ï,ì,í,î,ï,Ù,Ú,Û,ù,ú,û,ÿ,Ñ,ñ,ß,ä,Ä,ö,Ö,ü,Ü'}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="settings_permareplace">{gt text='List to replace with'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="settings_permareplace">{gt text='List to replace with'}</label>
+                <div class="col-sm-9">
                     <input id="settings_permareplace" class="form-control" type="text" name="settings[permareplace]" value="{$modvars.ZConfig.permareplace}" size="60" /><br />
                     <label for="settings_permareplace_default">{gt text='Default'}</label>
                     <input id="settings_permareplace_default" type="text" class="form-control" readonly="readonly" value="{gt text='A,A,A,A,A,a,a,a,a,a,O,O,O,O,O,o,o,o,o,o,E,E,E,E,e,e,e,e,C,c,I,I,I,I,i,i,i,i,U,U,U,u,u,u,y,N,n,ss,ae,Ae,oe,Oe,ue,Ue'}" />
@@ -241,8 +241,8 @@
             <p class="alert alert-warning">{gt text="Notice: This feature is deprecated in favor of Symfony routing. This site may have a mixture of modules of both types; those capable of using the old functionality, and those using routing."}</p>
             <input type="hidden" id="settings_shorturlstype_directory" name="settings[shorturlstype]" value="0" />
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Enable directory-based short URLs'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Enable directory-based short URLs'}</label>
+                <div class="col-sm-9">
                     <input id="settings_shorturls_yes" type="radio" name="settings[shorturls]" value="1"{if $modvars.ZConfig.shorturls eq 1} checked="checked"{/if} />
                     <label for="settings_shorturls_yes">{gt text='Yes'}</label>
                     <input id="settings_shorturls_no" type="radio" name="settings[shorturls]" value="0"{if $modvars.ZConfig.shorturls eq 0} checked="checked"{/if} />
@@ -251,8 +251,8 @@
             </div>
             <div data-switch="settings[shorturls]" data-switch-value="1">
                 <div class="form-group">
-                    <label class="col-lg-3 control-label">{gt text='Strip entry point from directory-based URLs'}</label>
-                    <div id="settings_shorturlsstripentrypoint" class="col-lg-9">
+                    <label class="col-sm-3 control-label">{gt text='Strip entry point from directory-based URLs'}</label>
+                    <div id="settings_shorturlsstripentrypoint" class="col-sm-9">
                         <input id="shorturlsstripentrypoint1" type="radio" name="settings[shorturlsstripentrypoint]" value="1"{if $modvars.ZConfig.shorturlsstripentrypoint eq 1} checked="checked"{/if} />
                         <label for="shorturlsstripentrypoint1">{gt text='Yes (recommended)'}</label>
                         <input id="shorturlsstripentrypoint0" type="radio" name="settings[shorturlsstripentrypoint]" value="0"{if $modvars.ZConfig.shorturlsstripentrypoint eq 0} checked="checked"{/if} />
@@ -260,14 +260,14 @@
                     </div>
                 </div>
                 <div id="settings_shorturlsseparator_container" class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_shorturlsseparator">{gt text='Separator for permalink titles'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_shorturlsseparator">{gt text='Separator for permalink titles'}</label>
+                    <div class="col-sm-9">
                         <input id="settings_shorturlsseparator" class="form-control" type="text" size="1" maxlength="1" name="settings[shorturlsseparator]" value="{$modvars.ZConfig.shorturlsseparator}" />
                     </div>
                 </div>
                 <div id="settings_shorturls_defaultmodule_container" class="form-group">
-                    <label class="col-lg-3 control-label" for="settings_shorturls_defaultmodule">{gt text='Do not display module name in short URLs for'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="settings_shorturls_defaultmodule">{gt text='Do not display module name in short URLs for'}</label>
+                    <div class="col-sm-9">
                         <select class="form-control" id="settings_shorturls_defaultmodule" name="settings[shorturlsdefaultmodule]">
                             <option value="">{gt text='(disabled)'}</option>
                             {html_options options=$modulesList selected=$modvars.ZConfig.shorturlsdefaultmodule|default:null}
@@ -279,7 +279,7 @@
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulasettingsmodule_admin_index'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/SettingsModule/Resources/views/Admin/multilingual.tpl
+++ b/src/system/Zikula/Module/SettingsModule/Resources/views/Admin/multilingual.tpl
@@ -11,8 +11,8 @@
         <fieldset>
             <legend>{gt text='Language system'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Activate multi-lingual features'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Activate multi-lingual features'}</label>
+                <div class="col-sm-9">
                     <span id="mlsettings_multilingual">
                         <input id="multilingual1" type="radio" name="mlsettings_multilingual" value="1"{if $modvars.ZConfig.multilingual eq 1} checked="checked"{/if} />
                         <label for="multilingual1">{gt text='Yes'}</label>
@@ -22,8 +22,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Prepend language to URL'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Prepend language to URL'}</label>
+                <div class="col-sm-9">
                     <span id="mlsettings_languageurl">
                         <input id="languageurl0" type="radio" name="mlsettings_languageurl" value="1"{if $modvars.ZConfig.languageurl eq 1} checked="checked"{/if} />
                         <label for="languageurl0">{gt text='Always'}</label>
@@ -36,8 +36,8 @@
         <fieldset>
             <legend>{gt text='Browser'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Automatically detect language from browser settings'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Automatically detect language from browser settings'}</label>
+                <div class="col-sm-9">
                     <span>
                         <input id="language_detect1" type="radio" name="mlsettings_language_detect" value="1"{if $modvars.ZConfig.language_detect eq 1} checked="checked"{/if} />
                         <label for="language_detect1">{gt text='Yes'}</label>
@@ -53,22 +53,22 @@
         <fieldset>
             <legend>{gt text='Server'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="mlsettings_language_i18n">{gt text='Default language to use for this site'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="mlsettings_language_i18n">{gt text='Default language to use for this site'}</label>
+                <div class="col-sm-9">
                     {html_select_locales id='mlsettings_language_i18n' name='mlsettings_language_i18n' selected=$modvars.ZConfig.language_i18n installed=1 all=false class='form-control'}
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="mlsettings_timezone_offset">{gt text='Time zone for anonymous guests'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="mlsettings_timezone_offset">{gt text='Time zone for anonymous guests'}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="mlsettings_timezone_offset" size="1" name="mlsettings_timezone_offset">
                         {timezoneselect selected=$modvars.ZConfig.timezone_offset class='form-control'}
                     </select>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Server time zone'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Server time zone'}</label>
+                <div class="col-sm-9">
                     <div class="form-control-static">{$timezone_server_abbr}</div>
                     <input type="hidden" name="mlsettings_timezone_server" value="{$timezone_server|default:0}" />
                 </div>
@@ -77,8 +77,8 @@
         <fieldset>
             <legend>{gt text='Variable validation'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='Allow IDN domain names'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Allow IDN domain names'}</label>
+                <div class="col-sm-9">
                     <div>
                         <input id="idnnamesyes" type="radio" name="idnnames" value="1"{if $modvars.ZConfig.idnnames eq 1} checked="checked"{/if} />
                         <label for="idnnamesyes">{gt text='Yes'}</label>
@@ -91,7 +91,7 @@
             </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">{gt text='Save'}</button>
                 <a class="btn btn-danger" href="{route name='zikulasettingsmodule_admin_index'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/delete.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/delete.tpl
@@ -11,15 +11,15 @@
         <input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
         <input type="hidden" name="confirmation" value="1" />
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="deletefiles">{gt text="Also delete theme files, if possible"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="deletefiles">{gt text="Also delete theme files, if possible"}</label>
+            <div class="col-sm-9">
                 <input type="checkbox" id="deletefiles" name="deletefiles" value="1" />
             </div>
             <div class="alert alert-info">{gt text="Please delete the Theme folder before pressing OK or the Theme will not be deleted."}</div>
         </div>
     </fieldset>
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             {button class="btn btn-success" __alt="Delete" __title="Delete" __text="Delete"}
             <a class="btn btn-danger" href="{route name='zikulathememodule_admin_view'}" title="{gt text="Cancel"}">{gt text="Cancel"}</a>
         </div>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/deletepageconfigurationassignment.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/deletepageconfigurationassignment.tpl
@@ -11,7 +11,7 @@
         <input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
         <input type="hidden" name="confirmation" value="1" />
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Delete'}">
                     {gt text='Delete'}
                 </button>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/modify.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/modify.tpl
@@ -10,14 +10,14 @@
         <fieldset>
             <legend>{gt text="General settings"}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_displayname">{gt text="Display name"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_displayname">{gt text="Display name"}</label>
+                <div class="col-sm-9">
                 <input id="theme_displayname" type="text" class="form-control" name="themeinfo[displayname]" size="30" maxlength="64" value="{$themeinfo.displayname}" />
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_usertheme">{gt text="User theme"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_usertheme">{gt text="User theme"}</label>
+                <div class="col-sm-9">
                 <div>
                     <input id="theme_usertheme" type="checkbox" name="themeinfo[user]" value="1"{if $themeinfo.user} checked="checked"{/if} />
                     <span class="sub help-block">{gt text="Notice: This category is for 'browser-oriented' themes that can be selected by users for their sessions on the site."}</span>
@@ -25,8 +25,8 @@
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_systemtheme">{gt text="System theme"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_systemtheme">{gt text="System theme"}</label>
+                <div class="col-sm-9">
                 <div>
                     <input id="theme_systemtheme" type="checkbox" name="themeinfo[system]" value="1"{if $themeinfo.system} checked="checked"{/if} />
                     <span class="sub help-block">{gt text="Notice: This category is for themes used to deliver back-end services (such as RSS feeds, etc.)."}</span>
@@ -34,8 +34,8 @@
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_admintheme">{gt text="Admin panel theme"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_admintheme">{gt text="Admin panel theme"}</label>
+                <div class="col-sm-9">
                 <div>
                     <input id="theme_admintheme" type="checkbox" name="themeinfo[admin]" value="1"{if $themeinfo.admin} checked="checked"{/if} />
                     <span class="sub help-block">{gt text="Notice: This category is for themes used to display the site admin panel."}</span>
@@ -44,7 +44,7 @@
         </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text="Save"}">{gt text="Save"}</button>
                 <a class="btn btn-danger" href="{route name='zikulathememodule_admin_view'}" title="{gt text="Cancel"}">{gt text="Cancel"}</a>
             </div>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/modifyconfig.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/modifyconfig.tpl
@@ -12,20 +12,20 @@
         <fieldset>
             <legend>{gt text="General settings"}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="themeswitcher_itemsperpage">{gt text="Items per page"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="themeswitcher_itemsperpage">{gt text="Items per page"}</label>
+                <div class="col-sm-9">
                     <input id="themeswitcher_itemsperpage" type="text" class="form-control" name="itemsperpage" value="{$itemsperpage|safetext}" size="4" maxlength="4" tabindex="2" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_change">{gt text="Allow users to change themes"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_change">{gt text="Allow users to change themes"}</label>
+                <div class="col-sm-9">
                     <input id="theme_change" name="theme_change" type="checkbox" value="1" {if $theme_change}checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="admintheme">{gt text="Admin theme"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="admintheme">{gt text="Admin theme"}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="admintheme" name="admintheme">
                         <option value="">{gt text="Use site's theme"}</option>
                         {html_select_themes state='ThemeUtil::STATE_ACTIVE'|const filter='ThemeUtil::FILTER_ADMIN'|const selected=$admintheme}
@@ -34,8 +34,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="alt_theme_name">{gt text="Theme for alternative site view"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="alt_theme_name">{gt text="Theme for alternative site view"}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="alt_theme_name" name="alt_theme_name">
                         <option value="">{gt text="Not set"}</option>
                         {html_select_themes state='ThemeUtil::STATE_ACTIVE'|const selected=$alt_theme_name|default:''}
@@ -43,8 +43,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="alt_theme_domain">{gt text="Domain for alternative site view"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="alt_theme_domain">{gt text="Domain for alternative site view"}</label>
+                <div class="col-sm-9">
                     <input id="alt_theme_domain" type="text" class="form-control" name="alt_theme_domain" value="{$alt_theme_domain|default:''|safetext}" size="50" />
                 </div>
             </div>
@@ -52,35 +52,35 @@
         <fieldset>
             <legend>{gt text="Compilation"}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_compile_check">{gt text="Check for updated version of theme templates"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_compile_check">{gt text="Check for updated version of theme templates"}</label>
+                <div class="col-sm-9">
                     <input id="theme_compile_check" name="compile_check" type="checkbox" value="1" {if $compile_check eq 1}checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_force_compile">{gt text="Force re-compilation of theme templates"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_force_compile">{gt text="Force re-compilation of theme templates"}</label>
+                <div class="col-sm-9">
                     <input id="theme_force_compile" name="force_compile" type="checkbox" value="1" {if $force_compile eq 1}checked="checked"{/if} />
                     <a class="zikulathememodule-indented" href="{route name='zikulathememodule_admin_clearcompiled' csrftoken=$csrftoken}">{gt text="Delete compiled theme templates"}</a>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text="Compiled render templates directory"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text="Compiled render templates directory"}</label>
+                <div class="col-sm-9">
                     <div class="form-control-static">
                         <em>{render->compile_dir}</em>
                     </div>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="render_compile_check">{gt text="Check for updated version of render templates"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="render_compile_check">{gt text="Check for updated version of render templates"}</label>
+                <div class="col-sm-9">
                     <input id="render_compile_check" type="checkbox" name="render_compile_check" value="1"{if $render_compile_check} checked="checked"{/if} />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="render_force_compile">{gt text="Force re-compilation of render templates"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="render_force_compile">{gt text="Force re-compilation of render templates"}</label>
+                <div class="col-sm-9">
                     <input id="render_force_compile" type="checkbox" name="render_force_compile" value="1"{if $render_force_compile} checked="checked"{/if} />
                     <a class="zikulathememodule-indented" href="{route name='zikulathememodule_admin_renderclearcompiled' csrftoken=$csrftoken}">{gt text="Delete compiled render templates"}</a>
                 </div>
@@ -89,16 +89,16 @@
         <fieldset>
             <legend>{gt text="Caching"}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="enablecache">{gt text="Enable theme caching"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="enablecache">{gt text="Enable theme caching"}</label>
+                <div class="col-sm-9">
                     <input id="enablecache" name="enablecache" type="checkbox" value="1" {if $enablecache eq 1}checked="checked"{/if} />
                     <a class="zikulathememodule-indented" href="{route name='zikulathememodule_admin_clearcache' csrftoken=$csrftoken}">{gt text="Delete cached theme pages"}</a>
                 </div>
             </div>
             <div data-switch="enablecache" data-switch-value="1">
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="cache_lifetime">{gt text="Length of time to keep cached theme pages"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="cache_lifetime">{gt text="Length of time to keep cached theme pages"}</label>
+                    <div class="col-sm-9">
                         <p class="help-block alert alert-info">{gt text="Notice: A cache lifetime of 0 will set the cache to continually regenerate; this is equivalent to no caching."}<br />{gt text="A cache lifetime of -1 will set the cache output to never expire."}</p>
                         <label for="cache_lifetime">{gt text="For homepage"}</label>
                         <span>
@@ -109,8 +109,8 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="cache_lifetime_mods">{gt text="For modules"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="cache_lifetime_mods">{gt text="For modules"}</label>
+                    <div class="col-sm-9">
                         <span>
                             <input type="text" class="form-control" name="cache_lifetime_mods" id="cache_lifetime_mods" value="{$cache_lifetime_mods|safetext}" size="6" tabindex="2" />
                             {gt text="seconds"}
@@ -119,8 +119,8 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label">{gt text="Modules to exclude from theme caching"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label">{gt text="Modules to exclude from theme caching"}</label>
+                    <div class="col-sm-9">
                         <div id="theme_nocache">
                             {foreach from=$mods key=modname item=moddisplayname}
                             <div class="z-formlist">
@@ -134,24 +134,24 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text="Cached templates directory"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text="Cached templates directory"}</label>
+                <div class="col-sm-9">
                     <div class="form-control-static">
                         <em>{render->cache_dir}</em>
                     </div>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="render_cache">{gt text="Enable render caching"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="render_cache">{gt text="Enable render caching"}</label>
+                <div class="col-sm-9">
                     <input id="render_cache" type="checkbox" name="render_cache" value="1"{if $render_cache}checked="checked"{/if} />
                     <a class="zikulathememodule-indented" href="{route name='zikulathememodule_admin_renderclearcache' csrftoken=$csrftoken}">{gt text="Delete cached render pages"}</a>
                 </div>
             </div>
             <div data-switch="render_cache" data-switch-value="1">
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="render_lifetime">{gt text="Length of time to keep cached render pages"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="render_lifetime">{gt text="Length of time to keep cached render pages"}</label>
+                    <div class="col-sm-9">
                         <span>
                             <input id="render_lifetime" type="text" class="form-control" name="render_lifetime" value="{$render_lifetime|safetext}" size="6" />
                             {gt text="seconds"}
@@ -165,22 +165,22 @@
             <legend>{gt text="CSS/JS optimisation"}</legend>
             <p class="help-block alert alert-info">{gt text="Notice: Combining and compressing JavaScript (JS) and CSS can considerably speed-up the performances of your site."}</p>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="cssjscombine">{gt text="Enable CSS/JS combination"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="cssjscombine">{gt text="Enable CSS/JS combination"}</label>
+                <div class="col-sm-9">
                     <input id="cssjscombine" name="cssjscombine" type="checkbox" value="1" {if $cssjscombine eq 1}checked="checked"{/if} />
                     <a class="zikulathememodule-indented" href="{route name='zikulathememodule_admin_clearcssjscombinecache' csrftoken=$csrftoken}">{gt text="Delete combination cache"}</a>
                 </div>
             </div>
             <div data-switch="cssjscombine" data-switch-value="1">
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="cssjscompress">{gt text="Use GZ compression"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="cssjscompress">{gt text="Use GZ compression"}</label>
+                    <div class="col-sm-9">
                         <input id="cssjscompress" name="cssjscompress" type="checkbox" value="1" {if $cssjscompress eq 1}checked="checked"{ /if } />
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="cssjsminify">{gt text="Minify CSS"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="cssjsminify">{gt text="Minify CSS"}</label>
+                    <div class="col-sm-9">
                         <input id="cssjsminify" name="cssjsminify" type="checkbox" value="1" {if $cssjsminify eq 1}checked="checked"{/if} />
                         <div data-switch="cssjsminify" data-switch-value="1">
                             <p class="alert alert-warning help-block">{gt text="The 'Minify CSS' option may require more PHP memory. If errors occur, you should increase the 'memory_limit' setting in your PHP installation's 'php.ini' configuration file. Alternatively, you should add the following entry to the '.htaccess' file in your site's web root (without the quotation marks): 'php_value memory_limit 64M'. 64M is just a suggested value. You should experiment to find the lowest value that resolves the problem."}</p>
@@ -188,8 +188,8 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="cssjscombine_lifetime">{gt text="Length of time to keep combination cache"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="cssjscombine_lifetime">{gt text="Length of time to keep combination cache"}</label>
+                    <div class="col-sm-9">
                         <span>
                             <input type="text" class="form-control" name="cssjscombine_lifetime" id="cssjscombine_lifetime" value="{$cssjscombine_lifetime|safetext}" size="6" />
                             {gt text="seconds"}
@@ -207,8 +207,8 @@
             <legend>{gt text="Filters"}</legend>
             <p class="help-block alert alert-info">{gt text="Notice: The 'trimwhitespace' output filter trims leading white space and blank lines from the template source code after it is interpreted, which cleans-up the code and saves bandwidth."}</p>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="trimwhitespace">{gt text="Use 'trimwhitespace' output filter"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="trimwhitespace">{gt text="Use 'trimwhitespace' output filter"}</label>
+                <div class="col-sm-9">
                     <input id="trimwhitespace" name="trimwhitespace" type="checkbox" value="1" {if $trimwhitespace eq 1}checked="checked"{/if} />
                 </div>
             </div>
@@ -217,15 +217,15 @@
             <legend>{gt text="Debug settings"}</legend>
             <p class="alert alert-warning help-block">{gt text="Warning! When auxiliary themes like RSS are used, enabling this option can corrupt the page output until you disable it again (for instance, with RSS, the feed will be broken)."}</p> 
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="render_expose_template">{gt text="Embed template information within comments inside the source code of pages"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="render_expose_template">{gt text="Embed template information within comments inside the source code of pages"}</label>
+                <div class="col-sm-9">
                     <input id="render_expose_template" type="checkbox" name="render_expose_template" value="1"{if $render_expose_template}checked="checked"{/if} />
                 </div>
             </div>
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text="Save"}">{gt text="Save"}</button>
                 <a class="btn btn-danger" href="{route name='zikulathememodule_admin_view'}" title="{gt text="Cancel"}">{gt text="Cancel"}</a>
             </div>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/modifypageconfigtemplates.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/modifypageconfigtemplates.tpl
@@ -14,16 +14,16 @@
             <legend>{gt text="Page settings"}</legend>
 
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagetemplate">{gt text="Page template"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagetemplate">{gt text="Page template"}</label>
+                <div class="col-sm-9">
 					<select class="form-control" id="theme_pagetemplate" name="pagetemplate">
 						{html_options values=$moduletemplates output=$moduletemplates selected=$pageconfiguration.page}
 					</select>
 				</div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_blocktemplate">{gt text="Block template"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_blocktemplate">{gt text="Block template"}</label>
+                <div class="col-sm-9">
 					<select class="form-control" id="theme_blocktemplate" name="blocktemplate">
 						<option value="">{gt text="Default template"}</option>
 						{html_options values=$blocktemplates output=$blocktemplates selected=$pageconfiguration.block}
@@ -31,8 +31,8 @@
 				</div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagepalette">{gt text="Palette"}</label>
-					<div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagepalette">{gt text="Palette"}</label>
+					<div class="col-sm-9">
 					<select class="form-control" id="theme_pagepalette" name="pagepalette">
 						<option value="">&nbsp;</option>
 						{html_options values=$palettes output=$palettes selected=$pageconfiguration.palette}
@@ -45,8 +45,8 @@
             <legend>{gt text="Wrappers settings"}</legend>
 
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_modulewrapper">{gt text="Enable main content wrapper"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_modulewrapper">{gt text="Enable main content wrapper"}</label>
+                <div class="col-sm-9">
 					<div id="theme_modulewrapper">
 						<input id="theme_modulewrapper_yes" type="radio" name="modulewrapper" value="1" {if $pageconfiguration.modulewrapper eq 1}checked="checked"{/if} />
 						<label for="theme_modulewrapper_yes">{gt text="Yes"}</label>
@@ -60,8 +60,8 @@
 				</div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_blockwrapper">{gt text="Enable block wrappers"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_blockwrapper">{gt text="Enable block wrappers"}</label>
+                <div class="col-sm-9">
 					<div id="theme_blockwrapper">
 						<input id="theme_blockwrapper_yes" type="radio" name="blockwrapper" value="1" {if $pageconfiguration.blockwrapper eq 1}checked="checked"{/if} />
 						<label for="theme_blockwrapper_yes">{gt text="Yes"}</label>
@@ -81,20 +81,20 @@
 
             <p class="alert alert-info help-block">{gt text='Comma separated list of filters, eg. myfilter (for outputfilters) represents outputfilter.myfilter.php file, see <a href="http://www.smarty.net/manual/en/advanced.features.php">the documentation</a> for more information about filters.'}</p>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_filters_outputfilters">{gt text="Output filters"}</label>
-					<div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_filters_outputfilters">{gt text="Output filters"}</label>
+					<div class="col-sm-9">
 					<input type="text" class="form-control" id="theme_filters_outputfilters" name="filters[outputfilters]" size="40" maxlength="255" value="{$pageconfiguration.filters.outputfilters|safetext}" />
 				</div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_filters_prefilters">{gt text="Pre-filters"}</label>
-					<div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_filters_prefilters">{gt text="Pre-filters"}</label>
+					<div class="col-sm-9">
 					<input type="text" class="form-control" id="theme_filters_prefilters" name="filters[prefilters]" size="40" maxlength="255" value="{$pageconfiguration.filters.prefilters|safetext}" />
 				</div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_filters_postfilters">{gt text="Post-filters"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_filters_postfilters">{gt text="Post-filters"}</label>
+                <div class="col-sm-9">
 					<input type="text" class="form-control" id="theme_filters_postfilters" name="filters[postfilters]" size="40" maxlength="255" value="{$pageconfiguration.filters.postfilters|safetext}" />
 				</div>
 			</div>
@@ -114,8 +114,8 @@
 
                 {foreach from=$blockpositions key='position' item='description'}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="theme_blockpositiontemplate_{$position|safetext}" title="{$description|safetext}">{$position}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="theme_blockpositiontemplate_{$position|safetext}" title="{$description|safetext}">{$position}</label>
+                    <div class="col-sm-9">
 						<select class="form-control" id="theme_blockpositiontemplate_{$position|safetext}" name="blockpositiontemplates[{$position|safetext}]">
 							<option value="">{gt text="Default template"}</option>
 							{html_options values=$blocktemplates output=$blocktemplates selected=$pageconfiguration.blockpositions.$position}
@@ -150,8 +150,8 @@
 							<legend>{$block.module|safetext}</legend>
 							{/if}
 							<div class="form-group">
-								<label class="col-lg-3 control-label" for="theme_blocktypetemplate_{$block.module|safetext}_{$block.bkey|safetext}" title="{$block.text_type_long|safetext}">{$block.text_type|safetext}</label>
-								<div class="col-lg-9">
+								<label class="col-sm-3 control-label" for="theme_blocktypetemplate_{$block.module|safetext}_{$block.bkey|safetext}" title="{$block.text_type_long|safetext}">{$block.text_type|safetext}</label>
+								<div class="col-sm-9">
 								{assign var=bkey value=$block.bkey}
 									<select class="form-control" id="theme_blocktypetemplate_{$block.module|safetext}_{$block.bkey|safetext}" name="blocktypetemplates[{$block.bkey|safetext}]">
 										<option value="">{gt text="Default template"}</option>
@@ -172,7 +172,7 @@
 
                 {foreach from=$blocks item='block'}
 					<div class="form-group">
-						<label class="col-lg-3 control-label" for="theme_blockinstancetemplate_{$block.bid|safetext}" title="{$block.description|safetext}">
+						<label class="col-sm-3 control-label" for="theme_blockinstancetemplate_{$block.bid|safetext}" title="{$block.description|safetext}">
 							{if $block.title neq ''}
 							{$block.title|safetext}
 							{else}
@@ -180,7 +180,7 @@
 							{/if}
 							<span class="sub">({$block.bid})</span>
 						</label>
-						<div class="col-lg-9">
+						<div class="col-sm-9">
 							<select class="form-control" id="theme_blockinstancetemplate_{$block.bid|safetext}" name="blockinstancetemplates[{$block.bid|safetext}]">
 								<option value="">{gt text="Default template"}</option>
 								{html_options values=$blocktemplates output=$blocktemplates selected=$pageconfiguration.blockinstances[$block.bid]}
@@ -192,7 +192,7 @@
         </div>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text="Save"}">{gt text="Save"}</button>
                 <a class="btn btn-danger" href="{route name='zikulathememodule_admin_pageconfigurations' themename=$themename}" title="{gt text="Cancel"}">{gt text="Cancel"}</a>
             </div>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/modifypageconfigurationassignment.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/modifypageconfigurationassignment.tpl
@@ -15,8 +15,8 @@
 
         <fieldset>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagemodule">{gt text="Module"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagemodule">{gt text="Module"}</label>
+                <div class="col-sm-9">
                 <select class="form-control" id="theme_pagemodule" name="pagemodule">
                     <option value="">&nbsp;</option>
                     {foreach from=$pagetypes key='pagevalue' item='pagetext'}
@@ -27,40 +27,40 @@
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagetype">{gt text="Function type"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagetype">{gt text="Function type"}</label>
+                <div class="col-sm-9">
                 <input id="theme_pagetype" type="text" class="form-control" name="pagetype" size="30" value="{$pagetype|safetext}" />
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagefunc">{gt text="Function name"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagefunc">{gt text="Function name"}</label>
+                <div class="col-sm-9">
                 <input id="theme_pagefunc" type="text" class="form-control" name="pagefunc" size="30" value="{$pagefunc|safetext}" />
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagecustomargs">{gt text="Function arguments"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagecustomargs">{gt text="Function arguments"}</label>
+                <div class="col-sm-9">
                 <input id="theme_pagecustomargs" type="text" class="form-control" name="pagecustomargs" size="30" value="{$pagecustomargs|safetext}" />
                 <em class="help-block sub">{gt text="Notice: This is a list of arguments found in the page URL, separated by '/'."}</em>
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_filename">{gt text="Configuration file"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_filename">{gt text="Configuration file"}</label>
+                <div class="col-sm-9">
                 <select class="form-control" id="theme_filename" name="filename">
                     {html_options values=$existingconfigs output=$existingconfigs selected=$filename}
                 </select>
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_important">{gt text="Important"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_important">{gt text="Important"}</label>
+                <div class="col-sm-9">
                 <input id="theme_important" type="checkbox" name="pageimportant" value="1"{if $pageimportant|default:0} checked="checked"{/if} />
                 <em class="help-block sub">{gt text="Any match with this assignment will be consider over the following others."}</em>
             </div>
             <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                     <button class="btn btn-success" title="{gt text="Save"}">{gt text="Save"}</button>
                     <a class="btn btn-danger" href="{route name='zikulathememodule_admin_pageconfigurations' themename=$themename}" title="{gt text="Cancel"}">{gt text="Cancel"}</a>
                 </div>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/pageconfigurations.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/pageconfigurations.tpl
@@ -60,8 +60,8 @@
         <input type="hidden" name="themename" value="{$themename|safetext}" />
         <fieldset>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagemodule">{gt text="Module"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagemodule">{gt text="Module"}</label>
+                <div class="col-sm-9">
                 <select class="form-control" id="theme_pagemodule" name="pagemodule">
                     <option value="">&nbsp;</option>
                     {foreach from=$pagetypes key='pagevalue' item='pagetext'}
@@ -72,40 +72,40 @@
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagetype">{gt text="Function type"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagetype">{gt text="Function type"}</label>
+                <div class="col-sm-9">
                 <input id="theme_pagetype" type="text" class="form-control" name="pagetype" size="30" />
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagefunc">{gt text="Function name"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagefunc">{gt text="Function name"}</label>
+                <div class="col-sm-9">
                 <input id="theme_pagefunc" type="text" class="form-control" name="pagefunc" size="30" />
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_pagecustomargs">{gt text="Function arguments"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_pagecustomargs">{gt text="Function arguments"}</label>
+                <div class="col-sm-9">
                 <input id="theme_pagecustomargs" type="text" class="form-control" name="pagecustomargs" size="30" />
                 <em class="help-block sub">{gt text="Notice: This is a list of arguments found in the page URL, separated by '/'."}</em>
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_filename">{gt text="Configuration file"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_filename">{gt text="Configuration file"}</label>
+                <div class="col-sm-9">
                 <select class="form-control" id="theme_filename" name="filename">
                     {html_options values=$existingconfigs output=$existingconfigs}
                 </select>
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_important">{gt text="Important"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_important">{gt text="Important"}</label>
+                <div class="col-sm-9">
                 <input id="theme_important" type="checkbox" name="pageimportant" value="1" />
                 <em class="help-block sub">{gt text="Any match with this assignment will be consider over the following others."}</em>
             </div>
             <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                     <button class="btn btn-success" title="{gt text="Save"}">{gt text="Save"}</button>
                     <a class="btn btn-danger" href="{route name='zikulathememodule_admin_view'}" title="{gt text="Cancel"}">{gt text="Cancel"}</a>
                 </div>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/setasdefault.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/setasdefault.tpl
@@ -13,10 +13,10 @@
         <input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
         <input type="hidden" name="confirmation" value="1" />
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="themeswitcher_theme_change">
+            <label class="col-sm-3 control-label" for="themeswitcher_theme_change">
                 {gt text="Override users' theme settings"}
             </label>
-            <div class="col-lg-9">
+            <div class="col-sm-9">
                 <input id="themeswitcher_theme_change" name="resetuserselected" type="checkbox" value="1" />
                 {if $theme_change}
                     <em class="help-block">{gt text='Users are allowed to change their own theme.'}</em>
@@ -26,7 +26,7 @@
             </div>
         </div>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Accept'}">
                     {gt text="Accept"}
                 </button>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/variables.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/variables.tpl
@@ -59,20 +59,20 @@
                 {/if}
             </legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_newvariablename">{gt text="Name"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_newvariablename">{gt text="Name"}</label>
+                <div class="col-sm-9">
                     <input id="theme_newvariablename" type="text" class="form-control" name="newvariablename" size="30" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="theme_newvariablevalue">{gt text="Value"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="theme_newvariablevalue">{gt text="Value"}</label>
+                <div class="col-sm-9">
                     <input id="theme_newvariablevalue" type="text" class="form-control" name="newvariablevalue" size="30" />
                 </div>
             </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text="Save"}">{gt text="Save"}</button>
                 <a class="btn btn-danger" href="{route name='zikulathememodule_admin_pageconfigurations' themename=$themename}" title="{gt text="Cancel"}">{gt text="Cancel"}</a>
             </div>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/view.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Admin/view.tpl
@@ -1,6 +1,6 @@
 {pageaddvar name='javascript' value='system/Zikula/Module/ThemeModule/Resources/public/js/ZikulaThemeModule.Admin.View.js'}
-{gt text="Extension database" assign=extdbtitle}
-{assign value="<strong><a href=\"https://github.com/zikula-modules\">`$extdbtitle`</a></strong>" var=extdblink}
+{gt text="Extension database" assign='extdbtitle'}
+{assign value="<strong><a href=\"https://github.com/zikula-modules\">`$extdbtitle`</a></strong>" var='extdblink'}
 
 {adminheader}
 <h3>
@@ -10,7 +10,7 @@
 
 <p class="alert alert-info">{gt text='Themes control the visual presentation of a site. Zikula ships with a small selection of themes, but many more are available from the %s.' tag1=$extdblink}</p>
 
-{pagerabc posvar="startlet" forwardvars='' printempty=true route='zikulathememodule_admin_view'}
+{pagerabc posvar='startlet' forwardvars='' printempty=true route='zikulathememodule_admin_view'}
 
 <table class="table table-bordered table-striped">
     <thead>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Block/render_modify.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Block/render_modify.tpl
@@ -6,20 +6,20 @@
 </div>
 </div>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="rmodule">{gt text="Module" domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="rmodule">{gt text="Module" domain='zikula'}</label>
+    <div class="col-sm-9">
     {html_select_modules id='rmodule' name='rmodule' capability='user' selected=$module|default:''}
 </div>
 </div>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="rtemplate">{gt text="Template file" domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="rtemplate">{gt text="Template file" domain='zikula'}</label>
+    <div class="col-sm-9">
     <input id="rtemplate" value="{$template|default:''|safetext}" maxlength="100" size="40" name="rtemplate" type="text" />
 </div>
 </div>
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="rparameters">{gt text="Parameters" domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="rparameters">{gt text="Parameters" domain='zikula'}</label>
+    <div class="col-sm-9">
     <input id="rtemplate" value="{$parameters|default:''|safetext}" maxlength="300" size="40" name="rparameters" type="text" />
     <span class='help-block sub'>{gt text="Format: parameter1=value1;parameter2=value2..." domain='zikula'}</span>
 </div>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Block/themeswitcher.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Block/themeswitcher.tpl
@@ -1,9 +1,9 @@
 {if $format eq 1}
-{pageaddvar name="javascript" value="system/Zikula/Module/ThemeModule/Resources/public/js/themeswitcher.js"}
+{pageaddvar name='javascript' value='system/Zikula/Module/ThemeModule/Resources/public/js/themeswitcher.js'}
 <img src="{$currentthemepic}" id="preview" alt="{$currenttheme.displayname}" title="{$currenttheme.description|default:$currenttheme.displayname}" />
 <form id="themeform" action="" method="get" enctype="application/x-www-form-urlencoded">
     <div>
-        {foreach from=$themes item=theme}
+        {foreach from=$themes item='theme'}
         {/foreach}
         <select id="newtheme" name="newtheme">
             {foreach from=$themes item=theme}
@@ -15,7 +15,7 @@
 </form>
 {else}
 <ul>
-    {foreach from=$themes item=theme}
+    {foreach from=$themes item='theme'}
     <li><a href="?newtheme={$theme.name}">{$theme.displayname}</a></li>
     {/foreach}
 </ul>

--- a/src/system/Zikula/Module/ThemeModule/Resources/views/Block/themeswitcher_modify.tpl
+++ b/src/system/Zikula/Module/ThemeModule/Resources/views/Block/themeswitcher_modify.tpl
@@ -1,6 +1,6 @@
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="themeswitcher_format">{gt text="Output format" domain='zikula'}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="themeswitcher_format">{gt text="Output format" domain='zikula'}</label>
+    <div class="col-sm-9">
         <select id="themeswitcher_format" class="form-control" name="format">
             <option value="1"{if $format eq 1} selected="selected"{/if}>{gt text="Dropdown list with preview images" domain='zikula'}</option>
             <option value="2"{if $format eq 2} selected="selected"{/if}>{gt text="Simple list" domain='zikula'}</option>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/approveregistration.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/approveregistration.tpl
@@ -22,7 +22,7 @@
         <input type="hidden" id="users_restoreview" name="restoreview" value="{$restoreview}" />
         <input type="hidden" id="users_confirmed" name="confirmed" value="true" />
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
             {strip}
             {if !$reginfo.isverified && $force}
             {gt text='Skip Verification' assign='actionTitle'}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/config.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/config.tpl
@@ -53,8 +53,8 @@
             <legend>{gt text="General settings"}</legend>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ANONYMOUS_DISPLAY_NAME'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Name displayed for anonymous user'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Name displayed for anonymous user'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safehtml}" size="20" maxlength="20" />
                     <em class="help-block sub">{gt text='Anonymous users are visitors to your site who have not logged in.'}</em>
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
@@ -62,8 +62,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ITEMS_PER_PAGE'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Number of items displayed per page'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Number of items displayed per page'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" size="3" value="{$configData->getFieldData($fieldName)|safetext}" />
                     <em class="help-block sub">{gt text="When lists are displayed (for example, lists of users, lists of registrations) this option controls how many items are displayed at one time."}</em>
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
@@ -71,16 +71,16 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_AVATAR_IMAGE_PATH'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Path to user's avatar images"}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Path to user's avatar images"}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
                 </div>
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_GRAVATARS_ENABLED'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Allow globally recognized avatars'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Allow globally recognized avatars'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text="Yes"}</label>
@@ -92,8 +92,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_GRAVATAR_IMAGE'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Default gravatar image'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Default gravatar image'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
                 </div>
@@ -104,8 +104,8 @@
             <legend>{gt text="Account page settings"}</legend>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ACCOUNT_DISPLAY_GRAPHICS'|const}
-                <label class="col-lg-3 control-label">{gt text="Display graphics on user's account page"}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text="Display graphics on user's account page"}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)}checked="checked" {/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text="Yes"}</label>
@@ -117,32 +117,32 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ACCOUNT_PAGE_IMAGE_PATH'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Path to account page images'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Path to account page images'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
                 </div>
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ACCOUNT_ITEMS_PER_PAGE'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Number of links per page'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Number of links per page'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" size="3" value="{$configData->getFieldData($fieldName)|safetext}" />
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
                 </div>
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_ACCOUNT_ITEMS_PER_ROW'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Number of links per row'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Number of links per row'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" size="3" value="{$configData->getFieldData($fieldName)|safetext}" />
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
                 </div>
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_MANAGE_EMAIL_ADDRESS'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Users module handles e-mail address maintenance'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Users module handles e-mail address maintenance'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text="Yes"}</label>
@@ -158,8 +158,8 @@
             <legend>{gt text="User credential settings"}</legend>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_METHOD'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Credential required for user log-in'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Credential required for user log-in'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_username" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::LOGIN_METHOD_UNAME'|const}" {if ($configData->getFieldData($fieldName) < constant('Zikula\Module\UsersModule\Constant::LOGIN_METHOD_EMAIL')) || ($configData->getFieldData($fieldName) > constant('Zikula\Module\UsersModule\Constant::LOGIN_METHOD_ANY'))}checked="checked" {/if}/>
                         <label for="{$configData->getFieldId($fieldName)}_username">{gt text="User name"}</label>
@@ -175,8 +175,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REQUIRE_UNIQUE_EMAIL'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='New e-mail addresses must be unique'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='New e-mail addresses must be unique'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text="Yes"}</label>
@@ -190,8 +190,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_PASSWORD_MINIMUM_LENGTH'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Minimum length for user passwords"}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Minimum length for user passwords"}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safehtml}" size="2" maxlength="2" />
                     <em class="help-block sub">{gt text="This affects both passwords created during registration, as well as passwords modified by users or administrators."} {gt text="Enter an integer greater than zero."}</em>
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
@@ -199,8 +199,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_HASH_METHOD'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Password hashing method"}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Password hashing method"}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <select class="form-control" id="{$configData->getFieldId($fieldName)}" name="{$fieldName}">
                         <option value="sha1" {if $configData->getFieldData($fieldName) == 'sha1'} selected="selected"{/if}>SHA1</option>
                         <option value="sha256" {if $configData->getFieldData($fieldName) == 'sha256'} selected="selected"{/if}>SHA256</option>
@@ -211,8 +211,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_PASSWORD_STRENGTH_METER_ENABLED'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Show password strength meter"}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Show password strength meter"}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)}checked="checked" {/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text="Yes"}</label>
@@ -224,8 +224,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_EXPIRE_DAYS_CHANGE_EMAIL'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="E-mail address verifications expire in"}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="E-mail address verifications expire in"}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div class="input-group">
                         <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|default:0}" maxlength="3" />
                         <span class="input-group-addon">{gt text="days"}</span>
@@ -237,8 +237,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_EXPIRE_DAYS_CHANGE_PASSWORD'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Password reset requests expire in'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Password reset requests expire in'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div class="input-group">                    
                         <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|default:0}" maxlength="3" />
                         <span class="input-group-addon">{gt text='days'}</span>
@@ -254,9 +254,9 @@
             <legend>{gt text="Registration settings"}</legend>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ENABLED'|const}
-                <label class="col-lg-3 control-label">{gt text="Allow new user account registrations"}<span class="required"></span></label>
+                <label class="col-sm-3 control-label">{gt text="Allow new user account registrations"}<span class="required"></span></label>
                 {assign var='registrationEnabledFieldName' value=$fieldName}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text='Yes'}</label>
@@ -268,16 +268,16 @@
             </div>
             <div class="form-group" data-switch="{$registrationEnabledFieldName}" data-switch-value="0">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_DISABLED_REASON'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Statement displayed if registration disabled"}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="Statement displayed if registration disabled"}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <textarea class="form-control" id="{$configData->getFieldId($fieldName)}" name="{$fieldName}" cols="45" rows="10">{$configData->getFieldData($fieldName)|safehtml}</textarea>
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
                 </div>
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ADMIN_NOTIFICATION_EMAIL'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="E-mail address to notify of registrations"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text="E-mail address to notify of registrations"}</label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}" type="email" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                     <em class="help-block sub">{gt text='A notification is sent to this e-mail address for each registration. Leave blank for no notifications.'}</em>
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
@@ -285,8 +285,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_PASSWORD_REMINDER_ENABLED'|const}
-                <label class="col-lg-3 control-label">{gt text='Password reminder is enabled'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Password reminder is enabled'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1"{if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text='Yes'}</label>
@@ -298,8 +298,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_PASSWORD_REMINDER_MANDATORY'|const}
-                <label class="col-lg-3 control-label">{gt text='Password reminder is mandatory'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Password reminder is mandatory'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1"{if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text='Yes'}</label>
@@ -311,8 +311,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_REQUIRED'|const}
-                <label class="col-lg-3 control-label">{gt text='User registration is moderated'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='User registration is moderated'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div id="{$configData->getFieldId($fieldName)}">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1"{if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text='Yes'}</label>
@@ -324,8 +324,8 @@
             </div>
             {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_VERIFICATION_MODE'|const}
             <div class="form-group" id="{$configData->getFieldId($fieldName)}">
-                <label class="col-lg-3 control-label">{gt text="Verify e-mail address during registration"}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text="Verify e-mail address during registration"}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div>
                         <input id="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::VERIFY_USERPWD'|const}" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::VERIFY_USERPWD'|const}" {if ($configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::VERIFY_USERPWD')) || $configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::VERIFY_SYSTEMPWD')} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::VERIFY_USERPWD'|const}">{gt text='Yes. User chooses password, then activates account via e-mail'}</label>
@@ -339,8 +339,8 @@
             </div>
             {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_AUTO_LOGIN'|const}
             <div class="form-group" id="{$configData->getFieldId($fieldName)}_wrap">
-                <label class="col-lg-3 control-label">{gt text='Log in new registrations automatically?'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Log in new registrations automatically?'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div class="z-formlist">
                         <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1"{if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_yes">{gt text='Newly registered users are logged in automatically.'}</label>
@@ -356,8 +356,8 @@
             </div>
             {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_APPROVAL_SEQUENCE'|const}
             <div class="form-group" id="{$configData->getFieldId($fieldName)}_wrap">
-                <label class="col-lg-3 control-label">{gt text='Order that approval and verification occur'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Order that approval and verification occur'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div class="z-formlist">
                         <input id="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const}" type="radio" name="{$fieldName}" value="{'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const}"{if $configData->getFieldData($fieldName) == constant('Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE')} checked="checked"{/if} />
                         <label for="{$configData->getFieldId($fieldName)}_{'Zikula\Module\UsersModule\Constant::APPROVAL_BEFORE'|const}">{gt text="Registration applications must be approved before users verify their e-mail address."}</label>
@@ -375,8 +375,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_EXPIRE_DAYS_REGISTRATION'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Registrations pending verification expire in'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Registrations pending verification expire in'}<span class="required"></span></label>
+                <div class="col-sm-9">
                     <div class="input-group">
                         <input id="{$configData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" type="text" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|default:0}" maxlength="3" />      
                         <span class="input-group-addon">{gt text='days'}</span>
@@ -390,8 +390,8 @@
 
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_QUESTION'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Spam protection question'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Spam protection question'}</label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}" class="form-control" tpye="text" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safehtml}" size="50" maxlength="255" />
                     <em class="help-block sub">{gt text="You can set a question to be answered at registration time, to protect the site against spam automated registrations by bots and scripts."}</em>
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
@@ -399,8 +399,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ANTISPAM_ANSWER'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Spam protection answer'}<span id="{$configData->getFieldId($fieldName)}_mandatory" class="required hide"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Spam protection answer'}<span id="{$configData->getFieldId($fieldName)}_mandatory" class="required hide"></span></label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safehtml}" size="50" maxlength="255" />
                     <em class="help-block sub">{gt text="Registering users will have to provide this response when answering the spam protection question. It is required if a spam protection question is provided."}</em>
                     {if isset($errorFields.$fieldName)}<p class="help-block alert alert-danger">{$errorFields.$fieldName}</p>{/if}
@@ -408,8 +408,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ILLEGAL_UNAMES'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Reserved user names'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Reserved user names'}</label>
+                <div class="col-sm-9">
                     <input id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} type="text" class="form-control" name="{$fieldName}" value="{$configData->getFieldData($fieldName)|safetext}" size="50" maxlength="255" />
                     <em class="help-block sub">
                         {gt text='Separate each user name with a comma.'}<br />
@@ -420,8 +420,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ILLEGAL_AGENTS'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Banned user agents'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Banned user agents'}</label>
+                <div class="col-sm-9">
                     <textarea class="form-control" id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} name="{$fieldName}" cols="45" rows="2">{$configData->getFieldData($fieldName)|safehtml}</textarea>
                     <em class="help-block sub">
                         {gt text='Separate each user agent string with a comma.'}<br />
@@ -432,8 +432,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_REGISTRATION_ILLEGAL_DOMAINS'|const}
-                <label class="col-lg-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Banned e-mail address domains'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="{$configData->getFieldId($fieldName)}">{gt text='Banned e-mail address domains'}</label>
+                <div class="col-sm-9">
                     <textarea class="form-control" id="{$configData->getFieldId($fieldName)}"{if isset($errorFields.$fieldName)} class="form-error"{/if} name="{$fieldName}" cols="45" rows="2">{$configData->getFieldData($fieldName)|safehtml}</textarea>
                     <em class="help-block sub">
                         {gt text='Separate each domain with a comma.'}<br />
@@ -448,8 +448,8 @@
             <legend>{gt text="User log-in settings"}</legend>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_WCAG_COMPLIANT'|const}
-                <label class="col-lg-3 control-label">{gt text='WCAG-compliant log-in and log-out'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='WCAG-compliant log-in and log-out'}<span class="required"></span></label>
+                <div class="col-sm-9">
                 <div id="{$configData->getFieldId($fieldName)}">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)}checked="checked" {/if}/>
                     <label for="{$configData->getFieldId($fieldName)}_yes">{gt text='Yes'}</label>
@@ -462,8 +462,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_DISPLAY_INACTIVE_STATUS'|const}
-                <label class="col-lg-3 control-label">{gt text='Failed login displays inactive status'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Failed login displays inactive status'}<span class="required"></span></label>
+                <div class="col-sm-9">
                 <div class="z-formlist">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                     <label for="{$configData->getFieldId($fieldName)}_yes">{gt text='Yes. The log-in error message will indicate that the user account is inactive.'}</label>
@@ -477,8 +477,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_DISPLAY_VERIFY_STATUS'|const}
-                <label class="col-lg-3 control-label">{gt text='Failed login displays verification status'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Failed login displays verification status'}<span class="required"></span></label>
+                <div class="col-sm-9">
                 <div class="z-formlist">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                     <label for="{$configData->getFieldId($fieldName)}_yes">{gt text='Yes. The log-in error message will indicate that the registration is pending verification.'}</label>
@@ -492,8 +492,8 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='Zikula\Module\UsersModule\Constant::MODVAR_LOGIN_DISPLAY_APPROVAL_STATUS'|const}
-                <label class="col-lg-3 control-label">{gt text='Failed login displays approval status'}<span class="required"></span></label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text='Failed login displays approval status'}<span class="required"></span></label>
+                <div class="col-sm-9">
                 <div class="z-formlist">
                     <input id="{$configData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $configData->getFieldData($fieldName)} checked="checked"{/if} />
                     <label for="{$configData->getFieldId($fieldName)}_yes">{gt text='Yes. The log-in error message will indicate that the registration is pending approval.'}</label>
@@ -508,7 +508,7 @@
         </fieldset>
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Save'}">
                     {gt text="Save"}
                 </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/deleteusers.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/deleteusers.tpl
@@ -15,8 +15,8 @@
     <fieldset>
         <input type="hidden" name="userid[{$key}]" value="{$user.uid|safetext}" />
         <div class="form-group">
-            <label class="col-lg-3 control-label">{gt text='User name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label">{gt text='User name'}</label>
+            <div class="col-sm-9">
                 <div class="form-control-static">
                     <strong>{$user.uname|safetext}</strong>
                 </div>
@@ -30,7 +30,7 @@
     </fieldset>
     {/foreach}
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             {gt text='Delete user account' plural='Delete user accounts' count=$users|@count assign='buttonText'}
             <button class="btn btn-success" title="{$buttonText}">
                 {$buttonText}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/denyregistration.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/denyregistration.tpl
@@ -18,8 +18,8 @@
         <fieldset>
             <legend>{gt text='Applicant notification'}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_usernotify">{gt text="Notify the applicant via e-mail?"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_usernotify">{gt text="Notify the applicant via e-mail?"}</label>
+                <div class="col-sm-9">
                 <div id="users_usernotify">
                     <input id="users_usernotifyyes" type="radio" name="usernotify" value="1" />
                     <label for="users_usernotifyyes">{gt text="Yes"}</label>
@@ -29,15 +29,15 @@
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_reason">{gt text="Reason"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_reason">{gt text="Reason"}</label>
+                <div class="col-sm-9">
                 <textarea id="users_reason" class="form-control" name="reason" cols="50" rows="6"></textarea>
                 <div class="help-block">{gt text='Note: The reason is sent in the user notification e-mail. All formatting, including extra spaces and blank lines are ignored.'}</div>
             </div>
         </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-danger" id='confirm' type='submit' title="{gt text='Delete registration'}">
                     {gt text='Delete registration'}
                 </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/export.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/export.tpl
@@ -11,33 +11,33 @@
         <fieldset>
             <legend>Export Options</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_export_titles">{gt text="Export Title Row"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_export_titles">{gt text="Export Title Row"}</label>
+                <div class="col-sm-9">
                     <input id="users_export_titles" type="checkbox" name="exportTitles" value="1" checked="checked" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_export_email">{gt text="Export Email Address"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_export_email">{gt text="Export Email Address"}</label>
+                <div class="col-sm-9">
                     <input id="users_export_email" type="checkbox" name="exportEmail" value="1" checked="checked" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_export_regdate">{gt text="Export Registration Date"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_export_regdate">{gt text="Export Registration Date"}</label>
+                <div class="col-sm-9">
                     <input id="users_export_regdate" type="checkbox" name="exportRegDate" value="1" checked="checked" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_export_lastlogin">{gt text="Export Last Login Date"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_export_lastlogin">{gt text="Export Last Login Date"}</label>
+                <div class="col-sm-9">
                     <input id="users_export_lastlogin" type="checkbox" name="exportLastLogin" value="1" checked="checked" />
                 </div>
             </div>
             {if isset($groups) && $groups == '1'}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_export_groups">{gt text="Export Group Membership"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_export_groups">{gt text="Export Group Membership"}</label>
+                <div class="col-sm-9">
                     <input id="users_export_groups" type="checkbox" name="exportGroups" value="1"/>
                 </div>
             </div>
@@ -46,14 +46,14 @@
         <fieldset>
             <legend>{gt text="CSV Export File"}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_export">{gt text="CSV filename"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_export">{gt text="CSV filename"}</label>
+                <div class="col-sm-9">
                     <input id="users_export" type="text" class="form-control" name="exportFile" size="30" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_export_delimiter">{gt text="CSV delimiter"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_export_delimiter">{gt text="CSV delimiter"}</label>
+                <div class="col-sm-9">
                     <select class="form-control" id="users_export_delimiter" name="delimiter">
                         <option value="1">{gt text="Comma"} (,)</option>
                         <option value="2">{gt text="Semicolon"} (;)</option>
@@ -64,7 +64,7 @@
             </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 {button class="btn btn-success" __alt='Export' __title='Export' __text='Export'}
                 <a class="btn btn-danger" href="{route name='zikulausersmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/import.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/import.tpl
@@ -17,15 +17,15 @@
         <fieldset>
             <legend>{gt text="Select the CSV file"}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_import">{gt text="CSV file (Max. %s)" tag1=$post_max_size}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_import">{gt text="CSV file (Max. %s)" tag1=$post_max_size}</label>
+                <div class="col-sm-9">
                 <input id="users_import" type="file" name="importFile" size="30" />
                 <em class="help-block sub">{gt text='The file must be utf8 encoded.'}</em>
             </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_import_delimiter">{gt text="CSV delimiter"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_import_delimiter">{gt text="CSV delimiter"}</label>
+                <div class="col-sm-9">
                 <select class="form-control" id="users_import_delimiter" name="delimiter">
                     <option value="1">Comma (,)</option>
                     <option value="2">Semicolon (;)</option>
@@ -35,7 +35,7 @@
         </div>
         </fieldset>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 {button class="btn btn-success" __alt='Import' __title='Import' __text='Import'}
                 <a class="btn btn-danger" href="{route name='zikulausersmodule_admin_view'}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/includeregistration.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/includeregistration.tpl
@@ -1,16 +1,16 @@
 <fieldset>
     <legend>{gt text='Account Information'}</legend>
     <div class="form-group">
-        <label class="col-lg-3 control-label">{gt text='User name:'}</label>
-        <div class="col-lg-9">
+        <label class="col-sm-3 control-label">{gt text='User name:'}</label>
+        <div class="col-sm-9">
             <div class="form-control-static">
                 {$reginfo.uname}
             </div>
         </div>
     </div>
     <div class="form-group">
-        <label class="col-lg-3 control-label">{gt text='E-mail address:'}</label>
-        <div class="col-lg-9">
+        <label class="col-sm-3 control-label">{gt text='E-mail address:'}</label>
+        <div class="col-sm-9">
             <div class="form-control-static">
                 {if !empty($reginfo.email)}
                 <a href="mailto:{$reginfo.email|urlencode}">{$reginfo.email|safetext}</a>
@@ -41,8 +41,8 @@
 <fieldset>
     <legend>{gt text='Registration Status'}</legend>
     <div class="form-group">
-        <label class="col-lg-3 control-label">{gt text='Expires:'}</label>
-        <div class="col-lg-9">
+        <label class="col-sm-3 control-label">{gt text='Expires:'}</label>
+        <div class="col-sm-9">
             <div class="alert alert-info">
                 {gt text='Because a password is not set for this registration, the e-mail verification process cannot be skipped. It must be completed so that the user can establish a password before the user account is created.'}
             </div>
@@ -60,13 +60,13 @@
 <fieldset>
     <legend>{gt text='Registration Status'}</legend>
     <div class="form-group">
-        <div class="col-lg-9">
+        <div class="col-sm-9">
             <span>{if $reginfo.isverified}{gt text='Never, registration is verified'}{elseif empty($reginfo.verificationsent)}{gt text='Expiration date will be set when the verification e-mail is sent'}{elseif !isset($reginfo.validuntil) || empty($reginfo.validuntil)}{gt text='Never'}{else}{$reginfo.validuntil}{/if}</span>
         </div>
     </div>
     <div class="form-group">
-        <label class="col-lg-3 control-label">{gt text='E-mail verification:'}</label>
-        <div class="col-lg-9">
+        <label class="col-sm-3 control-label">{gt text='E-mail verification:'}</label>
+        <div class="col-sm-9">
             <div class="form-control-static">
                 {if !isset($reginfo.isverified) || empty($reginfo.isverified) || !$reginfo.isverified}
                 {if !isset($reginfo.verificationsent) || empty($reginfo.verificationsent)}
@@ -84,8 +84,8 @@
         </div>
     </div>
     <div class="form-group">
-        <label class="col-lg-3 control-label">{gt text='Administrator approval:'}</label>
-        <div class="col-lg-9">
+        <label class="col-sm-3 control-label">{gt text='Administrator approval:'}</label>
+        <div class="col-sm-9">
             <div class="form-control-static">
                 {if !isset($reginfo.isapproved) || empty($reginfo.isapproved) || !$reginfo.isapproved}
                 <span class="fa fa-times fa-fw fa-red"></span>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/mailusers.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/mailusers.tpl
@@ -51,26 +51,26 @@
                 <legend>{gt text='Compose message'}</legend>
                 <p class="alert alert-info">{gt text="Notice: This e-mail message will be sent to your address and to all other recipients you select. Your address will be the entered as the main recipient, and all your selected recipients will be included in the blind carbon copies ('Bcc') list. You can specify the number of 'Bcc' recipients to be added to each e-mail message. If the number of your selected recipients exceeds the number you enter here, then repeat messages will be sent until everyone in your selection has been mailed (you will receive a copy of each message). The allowed batch size may be set by your hosting provider."}</p>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="users_from">{gt text="Sender's name"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="users_from">{gt text="Sender's name"}</label>
+                    <div class="col-sm-9">
                         <input id="users_from" class="form-control" name="sendmail[from]" type="text" size="40" value="{$modvars.ZConfig.sitename}" />
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="users_rpemail">{gt text="Address to which replies should be sent"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="users_rpemail">{gt text="Address to which replies should be sent"}</label>
+                    <div class="col-sm-9">
                         <input id="users_rpemail" class="form-control" name="sendmail[rpemail]" type="text" size="40" value="{$modvars.ZConfig.adminmail}" />
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="users_subject">{gt text="Subject"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="users_subject">{gt text="Subject"}</label>
+                    <div class="col-sm-9">
                         <input id="users_subject" class="form-control" name="sendmail[subject]" type="text" size="40" />
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="users_format">{gt text='Format'}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="users_format">{gt text='Format'}</label>
+                    <div class="col-sm-9">
                         <select id="users_format" class="form-control" name="sendmail[format]" size="1" >
                             <option value="text"{if !isset($modvars.Mailer.html) || !$modvars.Mailer.html} selected="selected"{/if}>{gt text='Text'}</option>
                             <option value="html"{if isset($modvars.Mailer.html) && $modvars.Mailer.html} selected="selected"{/if}>{gt text='HTML'}</option>
@@ -78,14 +78,14 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="users_message">{gt text="Message"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="users_message">{gt text="Message"}</label>
+                    <div class="col-sm-9">
                         <textarea id="users_message" class="form-control" name="sendmail[message]" cols="50" rows="10"></textarea>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="batchsize">{gt text="Send e-mail messages in batches"}</label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="batchsize">{gt text="Send e-mail messages in batches"}</label>
+                    <div class="col-sm-9">
                         <span>
                             <input name="sendmail[batchsize]" type="text" id="batchsize" class="form-control" value="100" size="5" />
                             <em>{gt text="messages per batch"}</em>
@@ -97,7 +97,7 @@
             {notifydisplayhooks eventname='users.ui_hooks.user.form_edit' id=null}
 
             <div class="form-group">
-                <div class="col-lg-offset-3 col-lg-9">
+                <div class="col-sm-offset-3 col-sm-9">
                     <button class="btn btn-success" type='submit' title="{gt text='Send e-mail to selected recipients'}">
                         {gt text="Send e-mail to selected recipients"}
                     </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/modify.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/modify.tpl
@@ -55,9 +55,9 @@
         <input id="{$formData->getFieldId($fieldName)}" type="hidden" name="{$fieldName}" value="{$formData->getFieldData($fieldName)|safetext}" />
         <div class="form-group">
             {assign var='fieldName' value='uname'}
-            <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='User name'}<span class="required"></span></label>
+            <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='User name'}<span class="required"></span></label>
             {assign var='fieldName' value='uname'}
-            <div class="col-lg-9">
+            <div class="col-sm-9">
                 <input id="{$formData->getFieldId($fieldName)}"  class=" to-lower-case form-control{if isset($errorFields.$fieldName)}form-error{/if}" type="text" name="{$fieldName}" size="30" maxlength="25" value="{$formData->getFieldData($fieldName)|safetext}" required="required"/>
                 <em class="help-block sub">{gt text='User names can contain letters, numbers, underscores, periods, or dashes.'}</em>
                 <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
@@ -65,27 +65,27 @@
         </div>
         <div class="form-group">
             {assign var='fieldName' value='email'}
-            <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='E-mail address'}<span class="required"></span></label>
+            <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='E-mail address'}<span class="required"></span></label>
             {assign var='fieldName' value='email'}
-            <div class="col-lg-9">
+            <div class="col-sm-9">
                 <input id="{$formData->getFieldId($fieldName)}" class="form-control to-lower-case{if isset($errorFields.$fieldName)} form-error{/if}" type="email" name="{$fieldName}" size="30" maxlength="60" value="{$formData->getFieldData($fieldName)|safetext}" data-match="#users_modify_emailagain" data-match-error-message="{gt text='The value entered does not match the e-mail address entered in the e-mail address field.'}" required="required"/>
                 <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
             </div>
         </div>
         <div class="form-group">
             {assign var='fieldName' value='emailagain'}
-            <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat e-mail address for verification'}<span class="required"></span></label>
+            <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat e-mail address for verification'}<span class="required"></span></label>
             {assign var='fieldName' value='emailagain'}
-            <div class="col-lg-9">
+            <div class="col-sm-9">
                 <input id="{$formData->getFieldId($fieldName)}" class="form-control to-lower-case{if isset($errorFields.$fieldName)} form-error{/if}" type="email" name="{$fieldName}" size="30" maxlength="60" value="{$formData->getFieldData($fieldName)|safetext}" required="required"/>
                 <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
             </div>
         </div>
         <div class="form-group">
             {assign var='fieldName' value='activated'}
-            <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='User status'}</label>
+            <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='User status'}</label>
             {assign var='fieldName' value='activated'}
-            <div class="col-lg-9">
+            <div class="col-sm-9">
                 {if $editingSelf}
                 <input type="hidden" name="{$fieldName}" value="{$formData->getFieldData($fieldName)}" />
                 {/if}
@@ -98,11 +98,11 @@
         </div>
         <div class="form-group">
             {assign var='fieldName' value='theme'}
-            <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">
+            <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">
                 {gt text='Theme'}
             </label>
             {assign var='fieldName' value='theme'}
-            <div class="col-lg-9">
+            <div class="col-sm-9">
                 <select id="{$formData->getFieldId($fieldName)}" class="form-control" name="{$fieldName}">
                     <option value="">{gt text="Site's default theme"}</option>
                     {html_select_themes selected=$formData->getFieldData($fieldName) state=ThemeUtil::STATE_ACTIVE filter=ThemeUtil::FILTER_USER}
@@ -133,7 +133,7 @@
         </p>
 
         <div id="{$formData->getFieldId($fieldName)}_wrap" class="form-group">
-            <label class="col-lg-3 control-label">
+            <label class="col-sm-3 control-label">
                 {if $usersAuth}
                 {gt text="Change the user's password?"}
                 {else}
@@ -143,7 +143,7 @@
 
 
             {assign var='fieldName' value='setpass'}
-            <div id="{$formData->getFieldId($fieldName)}_wrap" class="col-lg-9">
+            <div id="{$formData->getFieldId($fieldName)}_wrap" class="col-sm-9">
                 <div id="{$formData->getFieldId($fieldName)}">
                     <input id="{$formData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1"{if $formData->getFieldData($fieldName)} checked="checked"{/if} />
                     <label for="{$formData->getFieldId($fieldName)}_yes">{gt text="Yes"}</label>
@@ -156,7 +156,7 @@
         <div id="{$formData->getFieldId('pass')}_wrap">
             {assign var='fieldName' value='pass'}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">
                     {if $usersAuth}
                     {gt text='New password'}
                     {else}
@@ -164,7 +164,7 @@
                     {/if}
                     <span class="required"></span>
                 </label>
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" type="password" name="{$fieldName}" size="30" maxlength="20" data-match="#users_modify_passagain" data-match-error-message="The value entered does not match the password entered in the password field." data-min="{$modvars.ZikulaUsersModule.minpass}" data-min-error-message="{gt text='Passwords must be at least %s characters in length.' tag1=$modvars.ZikulaUsersModule.minpass}"/>
                     <em class="sub help-block">{gt text='Notice: The minimum length for user passwords is %s characters.' tag1=$modvars.ZikulaUsersModule.minpass}</em>
                     <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">
@@ -175,9 +175,9 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='passagain'}
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat password for verification'}<span class="required"></span></label>
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat password for verification'}<span class="required"></span></label>
                 {assign var='fieldName' value='passagain'}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" type="password" name="{$fieldName}" size="30" maxlength="20" />
                     <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">
                         {if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}
@@ -233,7 +233,7 @@
     {notifydisplayhooks eventname='users.ui_hooks.user.form_edit' id=$formData->getFieldData('uid')}
 
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <div id="{$formData->getFormId()|cat:'_ajax_indicator'}" class="btn btn-warning hide"><i class="fa fa-spinner fa-spin"></i>&nbsp;{gt text="Checking"}</div>
             <button id="{$formData->getFormId()|cat:'_submit'}" class="btn btn-success" type="submit" title="{gt text='Save'}">
                 {gt text='Save'}
@@ -249,7 +249,7 @@
 </h3>
 
 <div class="form-group">
-    <div class="col-lg-offset-3 col-lg-9">
+    <div class="col-sm-offset-3 col-sm-9">
         {if !$editingSelf}
         <a class="btn btn-danger" href="{route name='zikulausersmodule_admin_deleteusers' userid=$formData->getFieldData('uid')}">{gt text='Delete'}</a>
         {/if}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/modifyregistration.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/modifyregistration.tpl
@@ -25,9 +25,9 @@
             <legend>{gt text='Account information'}</legend>
             <div class="form-group">
                 {assign var='fieldName' value='uname'}
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='User name'}<span class="required"></span></label>
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='User name'}<span class="required"></span></label>
                 {assign var='fieldName' value='uname'}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)}form-error{/if}" type="text" name="{$fieldName}" size="30" maxlength="25" value="{$formData->getFieldData($fieldName)|safetext}" />
                     <em class="help-block">{gt text='User names can contain letters, numbers, underscores, periods, or dashes.'}</em>
                     <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
@@ -35,27 +35,27 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='email'}
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='E-mail address'}<span class="required"></span></label>
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='E-mail address'}<span class="required"></span></label>
                 {assign var='fieldName' value='email'}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" type="email" name="{$fieldName}" size="30" maxlength="60" value="{$formData->getFieldData($fieldName)|safetext}" />
                     <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
                 </div>
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='emailagain'}
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat e-mail address for verification'}<span class="required"></span></label>
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat e-mail address for verification'}<span class="required"></span></label>
                 {assign var='fieldName' value='emailagain'}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)}form-error{/if}" type="email" name="{$fieldName}" size="30" maxlength="60" value="{$formData->getFieldData($fieldName)|safetext}" />
                     <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
                 </div>
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='theme'}
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Theme'}</label>
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Theme'}</label>
                 {assign var='fieldName' value='theme'}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <select id="{$formData->getFieldId($fieldName)}" class="form-control" name="{$fieldName}">
                         <option value="">{gt text="Site's default theme"}</option>
                         {html_select_themes selected=$formData->getFieldData($fieldName) state=ThemeUtil::STATE_ACTIVE filter=ThemeUtil::FILTER_USER}
@@ -73,7 +73,7 @@
         {notifydisplayhooks eventname='users.ui_hooks.user.form_edit' id=$formData->getFieldData('uid')}
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                     {button id=$formData->getFormId()|cat:'_submitnewuser' type='submit' class='btn btn-success' set='icons/extrasmall' __alt='Save' __title='Save' __text='Save'}
                     <a class="btn btn-default" href="{if $restoreview == 'view'}{route name='zikulausersmodule_admin_viewregistrations' restoreview=true}{else}{route name='zikulausersmodule_admin_displayregistration' uid=$formData->getFieldData('uid')}{/if}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/newuser.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/newuser.tpl
@@ -5,7 +5,7 @@
         {pageaddvar name='javascript' value='system/Zikula/Module/UsersModule/Resources/public/js/Zikula.Users.PassMeter.js'}
         {pageaddvarblock}
             <script type="text/javascript">
-                ( function($) {
+                (function($) {
                     $(document).ready(function() {
                         ZikulaUsersPassMeter.init('{{$formData->getFieldId('pass')}}', '{{$formData->getFormId()}}_passmeter',{
                             username: '{{$formData->getFieldId('uname')}}',
@@ -43,9 +43,9 @@
             <legend>{gt text='Account information'}</legend>
             <div class="form-group">
                 {assign var='fieldName' value='uname'}
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='User name'}<span class="required"></span></label>
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='User name'}<span class="required"></span></label>
                 {assign var='fieldName' value='uname'}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" type="text" name="{$fieldName}" size="30" maxlength="25" value="{$formData->getFieldData($fieldName)|safetext}" />
                     <em class="help-block sub">{gt text='User names can contain letters, numbers, underscores, periods, or dashes.'}</em>
                     <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
@@ -53,27 +53,27 @@
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='email'}
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='E-mail address'}<span class="required"></span></label>
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='E-mail address'}<span class="required"></span></label>
                 {assign var='fieldName' value='email'}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" type="email" name="{$fieldName}" size="30" maxlength="60" value="{$formData->getFieldData($fieldName)|safetext}" />
                     <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
                 </div>
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='emailagain'}
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat e-mail address for verification'}<span class="required"></span></label>
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat e-mail address for verification'}<span class="required"></span></label>
                 {assign var='fieldName' value='emailagain'}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" type="email" name="{$fieldName}" size="30" maxlength="60" value="{$formData->getFieldData($fieldName)|safetext}" />
                     <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
                 </div>
             </div>
             <div class="form-group">
                 {assign var='fieldName' value='theme'}
-                <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Theme'}</label>
+                <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Theme'}</label>
                 {assign var='fieldName' value='theme'}
-                <div class="col-lg-9">
+                <div class="col-sm-9">
                     <select id="{$formData->getFieldId($fieldName)}" class="form-control" name="{$fieldName}">
                         <option value="">{gt text="Site's default theme"}</option>
                         {html_select_themes selected=$formData->getFieldData($fieldName) state=ThemeUtil::STATE_ACTIVE filter=ThemeUtil::FILTER_USER}
@@ -86,8 +86,8 @@
             <legend>{gt text='Log-in information'}</legend>
             {assign var='fieldName' value='setpass'}
             <div id="{$formData->getFieldId($fieldName)}_wrap" class="form-group">
-                <label class="col-lg-3 control-label">{gt text="Set the user's password now?"}</label>
-                <div id="{$formData->getFieldId($fieldName)}" class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text="Set the user's password now?"}</label>
+                <div id="{$formData->getFieldId($fieldName)}" class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1"{if $formData->getFieldData($fieldName)} checked="checked"{/if} />
                     <label for="{$formData->getFieldId($fieldName)}_yes">{gt text="Yes"}</label>
                     <input id="{$formData->getFieldId($fieldName)}_no" type="radio" name="{$fieldName}" value="0"{if !$formData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -106,8 +106,8 @@
             <div data-switch="setpass" data-switch-value="1">
                 {assign var='fieldName' value='pass'}
                 <div class="form-group">
-                    <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Password'}<span class="required"></span></label>
-                    <div class="col-lg-9">
+                    <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Password'}<span class="required"></span></label>
+                    <div class="col-sm-9">
                         <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" type="password" name="{$fieldName}" size="30" maxlength="20" />
                         <em class="sub help-block">{gt text='Notice: The minimum length for user passwords is %s characters.' tag1=$modvars.ZikulaUsersModule.minpass}</em>
                         <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
@@ -117,17 +117,17 @@
                 </div>
                 <div class="form-group">
                     {assign var='fieldName' value='passagain'}
-                    <label class="col-lg-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat password for verification'}<span class="required"></span></label>
+                    <label class="col-sm-3 control-label" for="{$formData->getFieldId($fieldName)}">{gt text='Repeat password for verification'}<span class="required"></span></label>
                     {assign var='fieldName' value='passagain'}
-                    <div class="col-lg-9">
+                    <div class="col-sm-9">
                         <input id="{$formData->getFieldId($fieldName)}" class="form-control{if isset($errorFields.$fieldName)} form-error{/if}" type="password" name="{$fieldName}" size="30" maxlength="20" />
                         <p id="{$formData->getFieldId($fieldName)}_error" class="help-block alert alert-danger{if !isset($errorFields.$fieldName)} hide{/if}">{if isset($errorFields.$fieldName)}{$errorFields.$fieldName}{/if}</p>
                     </div>
                 </div>
                 {assign var='fieldName' value='sendpass'}
                 <div id="{$formData->getFieldId($fieldName)}_container" class="form-group">
-                    <label class="col-lg-3 control-label">{gt text="Send password via e-mail?"}</label>
-                    <div id="{$formData->getFieldId($fieldName)}" class="col-lg-9">
+                    <label class="col-sm-3 control-label">{gt text="Send password via e-mail?"}</label>
+                    <div id="{$formData->getFieldId($fieldName)}" class="col-sm-9">
                         <input id="{$formData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1" {if $formData->getFieldData($fieldName)} checked="checked"{/if} />
                         <label for="{$formData->getFieldId($fieldName)}_yes">{gt text="Yes"}</label>
                         <input id="{$formData->getFieldId($fieldName)}_no" type="radio" name="{$fieldName}" value="0" {if !$formData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -139,8 +139,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text="Send welcome message to user?"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text="Send welcome message to user?"}</label>
+                <div class="col-sm-9">
                     <input id="usernotification_yes" type="radio" name="usernotification" value="1" />
                     <label for="usernotification_yes">{gt text="Yes"}</label>
                     <input id="usernotification_no" type="radio" name="usernotification" value="0" checked="checked" />
@@ -148,8 +148,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text="Send info message to adminstrators?"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text="Send info message to adminstrators?"}</label>
+                <div class="col-sm-9">
                     <input id="adminnotification_yes" type="radio" name="adminnotification" value="1" />
                     <label for="adminnotification_yes">{gt text="Yes"}</label>
                     <input id="adminnotification_no" type="radio" name="adminnotification" value="0" checked="checked" />
@@ -158,8 +158,8 @@
             </div>
             <div id="{$formData->getFormId()}_password_is_set_wrap" class="form-group">
                 {assign var='fieldName' value='usermustverify'}
-                <label class="col-lg-3 control-label">{gt text="Verify user's e-mail address?"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label">{gt text="Verify user's e-mail address?"}</label>
+                <div class="col-sm-9">
                     <input id="{$formData->getFieldId($fieldName)}_yes" type="radio" name="{$fieldName}" value="1"{if $formData->getFieldData($fieldName)} checked="checked"{/if} />
                     <label for="{$formData->getFieldId($fieldName)}_yes">{gt text="Yes (recommended)"}</label>
                     <input id="{$formData->getFieldId($fieldName)}_no" type="radio" name="{$fieldName}" value="0"{if !$formData->getFieldData($fieldName)} checked="checked"{/if} />
@@ -178,7 +178,7 @@
         {notifydisplayhooks eventname='users.ui_hooks.user.form_edit' id=null}
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 {button id=$formData->getFormId()|cat:'_submitnewuser' type='submit' class='btn btn-success' __alt='Submit new user' __title='Submit new user' __text='Submit new user'}
                 <a class="btn btn-danger" href="{route name='zikulausersmodule_admin_view'}">{gt text='Cancel'}</a>
             </div>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/search.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/search.tpl
@@ -21,20 +21,20 @@
         <fieldset>
             <legend>{gt text="Find users"}</legend>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_uname">{gt text="User name"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_uname">{gt text="User name"}</label>
+                <div class="col-sm-9">
                     <input id="users_uname" class="form-control" type="text" name="uname" size="40" maxlength="40" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_email">{gt text="E-mail address"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_email">{gt text="E-mail address"}</label>
+                <div class="col-sm-9">
                     <input id="users_email" class="form-control" type="text" name="email" size="40" maxlength="255" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_ugroup">{gt text="Group membership"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_ugroup">{gt text="Group membership"}</label>
+                <div class="col-sm-9">
                     <select id="users_ugroup" class="form-control" name="ugroup">
                         <option value="0" selected="selected">{gt text="Any group"}</option>
                         {section name=group loop=$groups}
@@ -44,14 +44,14 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_regdateafter">{gt text="Registration date after (yyyy-mm-dd)"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_regdateafter">{gt text="Registration date after (yyyy-mm-dd)"}</label>
+                <div class="col-sm-9">
                     <input id="users_regdateafter" class="form-control" type="text" name="regdateafter" size="40" maxlength="10" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_regdatebefore">{gt text="Registration date before (yyyy-mm-dd)"}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_regdatebefore">{gt text="Registration date before (yyyy-mm-dd)"}</label>
+                <div class="col-sm-9">
                     <input id="users_regdatebefore" class="form-control" type="text" name="regdatebefore" size="40" maxlength="10" />
                 </div>
             </div>
@@ -68,7 +68,7 @@
         {/foreach}
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text="Search"}">
                     {gt text='Search'}
                 </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/search_results.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/search_results.tpl
@@ -21,12 +21,12 @@
                     {if $modvars.ZConfig.profilemodule}
                     <th>{gt text="Internal name"}</th>
                     {/if}
-                    <th>{gt text="E-mail address"}</th>
+                    <th>{gt text="Email address"}</th>
                     <th class="text-right">{gt text="Actions"}</th>
                 </tr>
             </thead>
             <tbody>
-                {section name=item loop=$items}
+                {section name='item' loop=$items}
                 <tr>
                     {if $deleteUsers}
                     <td>{if ($items[item].uid != 1) && ($items[item].uid != 2)}<input type="checkbox" class="user-checkboxes" name="userid[]" value="{$items[item].uid}" />{/if}</td>
@@ -58,7 +58,7 @@
         {/if}
 
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
             {if $deleteUsers}
                 {button type='submit' class="btn btn-warning"  __alt="Delete selected users" __title="Delete selected users" __text="Delete selected users"}
             {/if}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/toggleforcedpasswordchange.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/toggleforcedpasswordchange.tpl
@@ -24,7 +24,7 @@
         <input type="hidden" name="userid" value="{$user_obj.uid|safetext}" />
         <input type="hidden" name="user_must_change_password" value="{if $user_must_change_password}0{else}1{/if}" />
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 {if $user_must_change_password}
                     <button class="btn btn-danger" title="{gt text='Yes, cancel the change of password'}">
                         {gt text='Yes, cancel the change of password'}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Admin/verifyregistration.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Admin/verifyregistration.tpl
@@ -14,7 +14,7 @@
         <input type="hidden" id="users_restoreview" name="restoreview" value="{$restoreview}" />
         <input type="hidden" id="users_confirmed" name="confirmed" value="true" />
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
             {strip}
             {gt assign='titleIfSent' text='Resend verification code'}
             {gt assign='titleIfNotSent' text='Send verification code'}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/Authentication/LoginFormFields/Default/Default.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/Authentication/LoginFormFields/Default/Default.tpl
@@ -23,7 +23,7 @@
 {/if}
 
 <div class="form-group">
-    <label class="col-lg-3 control-label required" for="users_login_login_id">{strip}
+    <label class="col-sm-3 control-label required" for="users_login_login_id">{strip}
         {if $authentication_method eq 'email'}
             {gt text='Email address'}
         {elseif $authentication_method eq 'uname'}
@@ -32,7 +32,7 @@
             {gt text='User name or e-mail address'}
         {/if}
     {/strip}</label>
-    <div class="col-lg-9">
+    <div class="col-sm-9">
         <div class="input-group">
             {if $authentication_method eq 'email'}
                 <i class="fa fa-fw fa-envelope input-group-addon"></i>
@@ -45,8 +45,8 @@
 </div>
 
 <div class="form-group">
-    <label class="col-lg-3 control-label required" for="users_login_pass">{if isset($change_password) && $change_password}{gt text='Current password'}{else}{gt text='Password'}{/if}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label required" for="users_login_pass">{if isset($change_password) && $change_password}{gt text='Current password'}{else}{gt text='Password'}{/if}</label>
+    <div class="col-sm-9">
         <div class="input-group">
             <i class="fa fa-fw fa-asterisk input-group-addon"></i>
             <input id="users_login_pass" class="form-control" type="password" name="authentication_info[pass]" size="25" maxlength="60" required="required" />
@@ -57,8 +57,8 @@
 
 {if isset($change_password) && $change_password}
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="users_newpass">{gt text="New password"}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="users_newpass">{gt text="New password"}</label>
+    <div class="col-sm-9">
         <input type="password" class="form-control" id="users_login_newpass" name="authentication_info[new_pass]" size="20" maxlength="20" value="" />
     </div>
 </div>
@@ -68,15 +68,15 @@
 {/if}
 
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="users_login_confirm_new_pass">{gt text="New password (repeat for verification)"}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="users_login_confirm_new_pass">{gt text="New password (repeat for verification)"}</label>
+    <div class="col-sm-9">
         <input id="users_login_confirm_new_pass" class="form-control"  type="password" name="authentication_info[confirm_new_pass]" size="20" maxlength="20" />
     </div>
 </div>
 
 <div class="form-group">
-    <label class="col-lg-3 control-label" for="users_login_pass_reminder">{gt text="New password reminder"}</label>
-    <div class="col-lg-9">
+    <label class="col-sm-3 control-label" for="users_login_pass_reminder">{gt text="New password reminder"}</label>
+    <div class="col-sm-9">
         <input type="text" class="form-control" id="users_login_pass_reminder" name="authentication_info[pass_reminder]" value="" size="25" maxlength="128" />
         <div class="sub help-block">{gt text="Enter a word or a phrase that will remind you of your password."}</div>
         <div class="help-block alert alert-warning">{gt text="Notice: Do not use a word or phrase that will allow others to guess your password! Do not include your password or any part of your password here!"}</div>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/changeemail.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/changeemail.tpl
@@ -1,4 +1,4 @@
-{gt text='E-mail address manager' assign='templatetitle'}
+{gt text='Email address manager' assign='templatetitle'}
 
 {include file='User/menu.tpl'}
 <p class="alert alert-info">
@@ -7,23 +7,23 @@
 </p>
 <form id="changeemail" class="form-horizontal" role="form" action="{route name='zikulausersmodule_user_updateemail'}" method="post">
     <fieldset>
-        <legend>{gt text="Update e-mail address"}</legend>
+        <legend>{gt text="Update email address"}</legend>
         <input type="hidden" id="changeemailcsrftoken" name="csrftoken" value="{insert name='csrftoken'}" />
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="users_newemail">{gt text="New e-mail address"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="users_newemail">{gt text="New e-mail address"}</label>
+            <div class="col-sm-9">
                 <input id="users_newemail" class="form-control" type="text" name="newemail" value="" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="users_newemailagain">{gt text="New e-mail address again (for verification)"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="users_newemailagain">{gt text="New e-mail address again (for verification)"}</label>
+            <div class="col-sm-9">
                 <input id="users_newemailagain" class="form-control" type="text" name="newemailagain" value="" />
             </div>
         </div>
     </fieldset>
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text="Save"}">
                 {gt text='Save'}
             </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/changelang.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/changelang.tpl
@@ -6,8 +6,8 @@
     <fieldset>
         <legend>{gt text="Change language"}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="user_changelang">{gt text="New language"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="user_changelang">{gt text="New language"}</label>
+            <div class="col-sm-9">
                 <select id="user_changelang" name="setsessionlanguage" class="form-control">
                     {foreach key='code' item='language' from=$languages}
                     {if $code eq $usrlang}
@@ -21,7 +21,7 @@
         </div>
     </fieldset>
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             <button class="btn btn-success" title="{gt text="Save"}">
                 {gt text="Save"}
             </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/changepassword.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/changepassword.tpl
@@ -5,7 +5,7 @@
         {pageaddvar name='javascript' value='system/Zikula/Module/UsersModule/Resources/public/js/Zikula.Users.PassMeter.js'}
         {pageaddvarblock}
             <script type="text/javascript">
-                ( function($) {
+                (function($) {
                     $(document).ready(function() {
                         ZikulaUsersPassMeter.init('newpassword', 'users_user_changepassword_passmeter',{
                             username: 'usernamehidden',
@@ -38,8 +38,8 @@
         <input type="hidden" id="changepassword_csrftoken" name="csrftoken" value="{insert name='csrftoken'}" />
     <input type="hidden" id="usernamehidden" name="usernamehidden" value="{if $login}{$user_obj.uname}{else}{user}{/if}" />
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="oldpassword">{gt text="Current password"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="oldpassword">{gt text="Current password"}</label>
+            <div class="col-sm-9">
                 <input type="password" id="oldpassword" name="oldpassword" class="form-control{if isset($password_errors.oldpass) && !empty($password_errors.oldpass)} form-error{/if}" value="" />
                 {if isset($password_errors.oldpass) && !empty($password_errors.oldpass)}
                 <div class="help-block alert alert-danger">
@@ -51,8 +51,8 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="newpassword">{gt text="New password"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="newpassword">{gt text="New password"}</label>
+            <div class="col-sm-9">
                 <input name="newpassword" id="newpassword" type="password" class="form-control{if isset($password_errors.reginfo_pass) && !empty($password_errors.reginfo_pass)} form-error{/if}" value="" />
                 {if isset($password_errors.reginfo_pass) && !empty($password_errors.reginfo_pass)}
                 <div class="help-block alert alert-danger">
@@ -74,8 +74,8 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="newpasswordconfirm">{gt text="New password (repeat for verification)"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="newpasswordconfirm">{gt text="New password (repeat for verification)"}</label>
+            <div class="col-sm-9">
                 <input type="password" id="newpasswordconfirm" name="newpasswordconfirm" class="form-control {if isset($password_errors.passagain) && !empty($password_errors.passagain)} form-error{/if}" value="" />
                 {if isset($password_errors.passagain) && !empty($password_errors.passagain)}
                 <div class="help-block alert alert-danger">
@@ -87,8 +87,8 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="passreminder">{gt text="New password reminder"}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="passreminder">{gt text="New password reminder"}</label>
+            <div class="col-sm-9">
                 <input type="text" id="passreminder" name="passreminder" value="" class="form-control {if isset($password_errors.passreminder) && !empty($password_errors.passreminder)} form-error{/if}" size="25" maxlength="128" />
                 {if isset($password_errors.passreminder) && !empty($password_errors.passreminder)}
                 <div class="help-block alert alert-danger">
@@ -103,7 +103,7 @@
         </div>
     </fieldset>
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             {if $login}
             <button class='btn btn-success' title="{gt text='Save and continue logging in'}">
                 {gt text='Save and continue logging in'}

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/login.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/login.tpl
@@ -40,7 +40,7 @@
             </div>
             {if ($modvars.ZConfig.seclevel|lower != 'high')}
             <div class="form-group">
-                <div class="col-lg-offset-3 col-lg-9">
+                <div class="col-sm-offset-3 col-sm-9">
                     <input id="users_login_rememberme" type="checkbox" name="rememberme" value="1" />
                     <label for="users_login_rememberme">{gt text='Keep me logged in on this computer'}</label>
                 </div>
@@ -74,7 +74,7 @@
         {/if}
 
         <div>
-            <button class="btn btn-success col-lg-offset-3" title="{gt text='Log in'}">
+            <button class="btn btn-success col-sm-offset-3" title="{gt text='Log in'}">
                 <i class="fa fa-arrow-right"></i>
                 {gt text='Log in'}
             </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/lostpassword.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/lostpassword.tpl
@@ -7,25 +7,25 @@
         <input type="hidden" id="lostpasswordcsrftoken" name="csrftoken" value="{insert name='csrftoken'}" />
         <fieldset>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_uname">{gt text='User name'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_uname">{gt text='User name'}</label>
+                <div class="col-sm-9">
                     <input id="users_uname" type="text" class="form-control" name="uname" size="25" maxlength="25" value="{$uname|safetext}" />
                 </div>
             </div>
             {if ($modvars.ZikulaUsersModule.reg_uniemail|default:1 == 1)}
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='or'}</label>
+                <label class="col-sm-3 control-label">{gt text='or'}</label>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_email">{gt text='E-mail address'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_email">{gt text='E-mail address'}</label>
+                <div class="col-sm-9">
                     <input id="users_email" type="email" class="form-control" name="email" size="40" maxlength="60" value="{$email|safetext}" />
                 </div>
             </div>
             {/if}
         </fieldset>
         <div class="form-group">
-             <div class="col-lg-offset-3 col-lg-9">
+             <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Submit'}">
                     {gt text='Submit'}
                 </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/lostpasswordcode.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/lostpasswordcode.tpl
@@ -10,18 +10,18 @@
         <input type="hidden" id="users_lostpassword_setpass" name="setpass" value="0" />
         <fieldset>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_uname">{gt text='User name'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_uname">{gt text='User name'}</label>
+                <div class="col-sm-9">
                     <input id="users_uname" type="text" class="form-control" name="uname" size="25" maxlength="25" value="{$uname}" />
                 </div>
             </div>
             {if ($modvars.ZikulaUsersModule.reg_uniemail|default:true)}
             <div class="form-group">
-                <label class="col-lg-3 control-label">{gt text='or'}</label>
+                <label class="col-sm-3 control-label">{gt text='or'}</label>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_email">{gt text='E-mail address'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_email">{gt text='E-mail address'}</label>
+                <div class="col-sm-9">
                     <input id="users_email" type="email" class="form-control" name="email" size="40" maxlength="60" value="{$email}" />
                 </div>
             </div>
@@ -29,14 +29,14 @@
         </fieldset>
         <fieldset>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_code">{gt text='Confirmation code'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_code">{gt text='Confirmation code'}</label>
+                <div class="col-sm-9">
                     <input id="users_code" type="text" class="form-control" name="code" size="5" value="{$code}" required="required" />
                 </div>
             </div>
         </fieldset>
         <div class="form-group">
-             <div class="col-lg-offset-3 col-lg-9">
+             <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" title="{gt text='Submit'}">
                     {gt text='Submit'}
                 </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/lostuname.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/lostuname.tpl
@@ -8,14 +8,14 @@
     <fieldset>
         <input type="hidden" id="lostunamecsrftoken" name="csrftoken" value="{insert name='csrftoken'}" />
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="users_email">{gt text='E-mail address'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="users_email">{gt text='E-mail address'}</label>
+            <div class="col-sm-9">
                 <input id="users_email" type="email" class="form-control" name="email" size="40" maxlength="60" value="{$email|safetext}" required="required" />
             </div>
         </div>
     </fieldset>
     <div class="form-group">
-        <div class="col-lg-offset-3 col-lg-9">
+        <div class="col-sm-offset-3 col-sm-9">
             {button class="btn btn-success" __alt='Submit' __title='Submit' __text='Submit'}
         </div>
     </div>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/passwordreminder.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/passwordreminder.tpl
@@ -6,19 +6,19 @@
     <fieldset>
         <legend>{gt text='Reminder'}</legend>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="users_uname">{gt text='User name'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="users_uname">{gt text='User name'}</label>
+            <div class="col-sm-9">
                 <div class="form-control-static" id="users_uname">{$uname}</div>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-lg-3 control-label" for="users_passreminder">{gt text='Password reminder'}</label>
-            <div class="col-lg-9">
+            <label class="col-sm-3 control-label" for="users_passreminder">{gt text='Password reminder'}</label>
+            <div class="col-sm-9">
                 <div class="form-control-static" id="users_passreminder">{$passreminder}</div>
             </div>
         </div>
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <p class="alert alert-success">{gt text="I remember my password now."}</p>
                 <a class="btn btn-success" href="{route name='zikulausersmodule_user_login'}"><i class="fa fa-arrow-right"></i> {gt text="Go to log-in screen"}</a>
             </div>
@@ -47,26 +47,26 @@
             <legend>{gt text='Reset your password'}</legend>
             {if !empty($passreminder)}<p class="alert alert-info">{gt text='If you still do not remember your password, you can create a new one here.'}</p>{/if}
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_newpass">{gt text='Password'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_newpass">{gt text='Password'}</label>
+                <div class="col-sm-9">
                     <input class="form-control" id="users_newpass" type="password" name="newpass" maxlength="60" value="" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_newpassagain">{gt text='Password (repeat for verification)'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_newpassagain">{gt text='Password (repeat for verification)'}</label>
+                <div class="col-sm-9">
                     <input class="form-control" id="users_newpassagain" type="password" name="newpassagain" maxlength="60" value="" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_newpassreminder">{gt text='Password reminder'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_newpassreminder">{gt text='Password reminder'}</label>
+                <div class="col-sm-9">
                     <input class="form-control" id="users_newpassreminder" type="text" name="newpassreminder" maxlength="128" value="{$newpassreminder}" />
                     <em class="help-block">{gt text="Enter a word or a phrase that will remind you of your password."}</em>
                     <div class="alert alert-info">{gt text="Notice: Do not use a word or phrase that will allow others to guess your password! Do not include your password or any part of your password here!"}</div>
                 </div>
             </div>
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button class="btn btn-success" type="submit" name="Save">{gt text="Save"}</button>
                 <a class="btn btn-danger" href="{route name='zikulausersmodule_user_index'}" title="{gt text="Cancel"}">{gt text="Cancel"}</a>
             </div>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/registration_method.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/registration_method.tpl
@@ -43,7 +43,7 @@
         </fieldset>
 
         <div class="form-group">
-            <button class="btn btn-success col-lg-offset-3" title="{gt text='Continue registration'}">
+            <button class="btn btn-success col-sm-offset-3" title="{gt text='Continue registration'}">
                 <i class="fa fa-arrow-right"></i>
                 {gt text='Continue registration'}
             </button>

--- a/src/system/Zikula/Module/UsersModule/Resources/views/User/verifyregistration.tpl
+++ b/src/system/Zikula/Module/UsersModule/Resources/views/User/verifyregistration.tpl
@@ -5,7 +5,7 @@
         {pageaddvar name='javascript' value='system/Zikula/Module/UsersModule/Resources/public/js/Zikula.Users.PassMeter.js'}
         {pageaddvarblock}
             <script type="text/javascript">
-                ( function($) {
+                (function($) {
                     $(document).ready(function() {
                         ZikulaUsersPassMeter.init('users_newpass', 'users_verifyregistration_passmeter',{
                             username: 'users_uname',
@@ -39,14 +39,14 @@
             <legend>{gt text='Verification code'}</legend>
             <p class="alert alert-info">{gt text="Please enter your user name and the verification code you received."}</p>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_uname">{gt text='User name'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_uname">{gt text='User name'}</label>
+                <div class="col-sm-9">
                     <input id="users_uname" type="text" class="form-control" name="uname" size="25" maxlength="25" value="{$verify_uname}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_verifycode">{gt text='Verification code'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_verifycode">{gt text='Verification code'}</label>
+                <div class="col-sm-9">
                 <input id="users_verifycode" type="text" class="form-control" name="verifycode" size="5" maxlength="6" value="{$verifycode}" />
                 </div>
             </div>
@@ -56,8 +56,8 @@
             <legend>{gt text='Create a password'}</legend>
             <p class="alert alert-info">{gt text='You must establish a password for your account before the verification process is complete.'}</p>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_newpass">{gt text='Password'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_newpass">{gt text='Password'}</label>
+                <div class="col-sm-9">
                     <input id="users_newpass" type="password" class="form-control" name="newpass" size="25" maxlength="60" value="" />
                 </div>
                 {if $modvars.ZikulaUsersModule.use_password_strength_meter == 1}
@@ -66,14 +66,14 @@
                 {/if}
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_newpassagain">{gt text='Password (repeat for verification)'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_newpassagain">{gt text='Password (repeat for verification)'}</label>
+                <div class="col-sm-9">
                     <input id="users_newpassagain" type="password" class="form-control" name="newpassagain" size="25" maxlength="60" value="" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label" for="users_newpassreminder">{gt text='Password reminder'}</label>
-                <div class="col-lg-9">
+                <label class="col-sm-3 control-label" for="users_newpassreminder">{gt text='Password reminder'}</label>
+                <div class="col-sm-9">
                     <input id="users_newpassreminder" type="text" class="form-control" name="newpassreminder" size="25" maxlength="128" value="{$newpassreminder}" />
                     <div class="sub help-block">{gt text="Enter a word or a phrase that will remind you of your password."}</div>
                     <div class="help-block alert alert-info">{gt text="Notice: Do not use a word or phrase that will allow others to guess your password! Do not include your password or any part of your password here!"}</div>
@@ -82,7 +82,7 @@
         </fieldset>
         {/if}
         <div class="form-group">
-            <div class="col-lg-offset-3 col-lg-9">
+            <div class="col-sm-offset-3 col-sm-9">
                 {button class="btn btn-success" __alt='Submit' __title='Submit' __text='Submit'}
                 <a class="btn btn-default" href="{homepage|safetext}" title="{gt text='Cancel'}">{gt text='Cancel'}</a>
             </div>


### PR DESCRIPTION
All forms were using incorrect Bootstrap classes, which caused the various breakpoints to mis-align elements. This commit standardizes all forms throughout the Zikula core with consistency.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no

Example of incorrect form:

![forms](https://cloud.githubusercontent.com/assets/274862/6978773/3ad1b57c-d9a7-11e4-84ec-4c45c6c18521.png)

With this fix, all form labels are placed to the left of the form, starting at the break-point of 768px. Any device width under 768px places form labels above its field.