### PR TITLE
Generate vendor lists from composer.lock file.

### DIFF
--- a/build.php
+++ b/build.php
@@ -14,6 +14,93 @@ use Symfony\Component\Filesystem\Filesystem;
 
 require 'src/vendor/autoload.php';
 
+class GenerateVendorDocCommand extends Symfony\Component\Console\Command\Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('build:generate_vendor_doc')
+            ->setDescription('Generates a file containing all the vendors and the installed version.')
+            ->addOption('write-to', null, InputOption::VALUE_REQUIRED, 'Where to dump the generated file.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Reading composer vendors.');
+        $packages = json_decode(file_get_contents('composer.lock'), true);
+        $packages = $packages['packages'];
+
+        $output->writeln('Generating output');
+
+        $typeOrder = array(
+            'zikula-module' => 'Zikula Modules',
+            'zikula-theme' => 'Zikula Themes',
+            'zikula-plugin' => 'Zikula Plugins',
+            'symfony-bundle' => 'Symfony Bundles',
+            'component' => 'Web Components',
+            'library' => 'Other PHP libraries',
+            'composer-installer' => 'Composer Installers'
+        );
+        $types = array_keys($typeOrder);
+        usort($packages, function ($a, $b) use ($types) {
+            return array_search($a['type'], $types) - array_search($b['type'], $types);
+        });
+
+        $content = '';
+        $currentType = '';
+        $authors = array();
+        foreach ($packages as $package) {
+            if ($currentType != $package['type']) {
+                if ($currentType != '') {
+                    $content .= "\n";
+                }
+                $content .= $typeOrder[$package['type']] . "\n";
+                $content .= str_repeat('-', strlen($typeOrder[$package['type']])) . "\n";
+                $currentType = $package['type'];
+            }
+            $content .= "- **" . $package['name'] . "** `" . $package['version'] . "`";
+            if (isset($package['license'])) {
+                $content .= ", License: `" . implode(', ', $package['license']) . "`\n";
+            } else {
+                $content .= "\n";
+            }
+            if (isset($package['description'])) {
+                $content .= "  *" . $package['description'] . "*\n";
+            }
+            if (isset($package['authors'])) {
+                $authors = array_merge($authors, $package['authors']);
+            }
+        }
+
+        $content .= "\n\n";
+        $content .= "These are the main authors of all of the projects supporting Zikula\n";
+        $content .= "-------------------------------------------------------------------\n";
+
+        $tmp = array();
+        foreach ($authors as $k => $author) {
+            if (in_array($author['name'], $tmp)) {
+                unset($authors[$k]);
+                continue;
+            }
+            $tmp[] = $author['name'];
+        }
+        foreach ($authors as $author) {
+            $content .= "- **" . $author['name'] . "**";
+            if (isset($author['homepage'])) {
+                $content .= " " . $author['homepage'];
+            }
+            if (isset($author['email'])) {
+                $content .= " *" . $author['email'] . "*";
+            }
+            $content .= "\n";
+        }
+        
+        $output->writeln('Dumping vendors to ' . $input->getOption('write-to'));
+
+        file_put_contents($input->getOption('write-to'), $content);
+    }
+}
+
 class PurgeVendorsCommand extends \Symfony\Component\Console\Command\Command
 {
     protected function configure()
@@ -251,4 +338,5 @@ $application = new Application();
 $application->add(new BuildPackageCommand());
 $application->add(new PurgeVendorsCommand());
 $application->add(new FixAutoloaderCommand());
+$application->add(new GenerateVendorDocCommand());
 $application->run();

--- a/build.xml
+++ b/build.xml
@@ -106,6 +106,7 @@
         <move file="${workspace}/source/composer.json" tofile="${packagepath}/docs/en/dev/composer.json" overwrite="true"/>
         <move file="${workspace}/source/composer.lock" tofile="${packagepath}/docs/en/dev/composer.lock" overwrite="true"/>
 
+        <exec command="${workspace}/source/build.php build:generate_vendor_doc --write-to '${packagepath}/docs/en/Composer_Vendors.md'" checkreturn="true" passthru="true"/>
         <exec command="${workspace}/source/build.php build:purge_vendors --vendor-dir ${packagepath}/vendor" checkreturn="true" passthru="true"/>
         <exec command="${workspace}/source/build.php build:fix_autoloader --vendor-dir ${packagepath}/vendor" checkreturn="true" passthru="true"/>
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | ---
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Doc PR            | ---
| Changelog updated | no

//cc @craigh 

Example output:

Zikula Modules
--------------
- **zikula/profile-module** `dev-master`, License: `LGPL-3.0+`
  *Extends Zikula's user management.*
- **zikula/legal-module** `dev-master`, License: `LGPL-3.0+`
  *Change me description Module*

Symfony Bundles
---------------
- **stof/doctrine-extensions-bundle** `v1.1.0`, License: `MIT`
  *Integration of the gedmo/doctrine-extensions with Symfony2*
- **zikula/bootstrap-bundle** `dev-master`, License: `MIT`
  *Zikula Bootstrap bundle*
- **sensio/framework-extra-bundle** `v3.0.7`, License: `MIT`
  *This bundle provides a way to configure your controllers with annotations*
- **doctrine/doctrine-bundle** `v1.3.0`, License: `MIT`
  *Symfony DoctrineBundle*
- **doctrine/doctrine-cache-bundle** `v1.0.1`, License: `MIT`
  *Symfony2 Bundle for Doctrine Cache*
- **elao/web-profiler-extra-bundle** `v2.3.0`, License: `MIT`
  *Add routing, container, assetic & twig information inside the profiler*
- **friendsofsymfony/jsrouting-bundle** `1.5.4`, License: `MIT`
  *A pretty nice way to expose your Symfony2 routing to client applications.*
- **jms/i18n-routing-bundle** `dev-master`, License: `Apache2`
  *This bundle allows you to create i18n routes.*
- **jms/translation-bundle** `1.1.0`, License: `Apache2`
  *Puts the Symfony2 Translation Component on steroids*
- **symfony/monolog-bundle** `v2.7.1`, License: `MIT`
  *Symfony MonologBundle*
- **symfony/swiftmailer-bundle** `v2.3.8`, License: `MIT`
  *Symfony SwiftmailerBundle*
- **symfony/assetic-bundle** `v2.6.1`, License: `MIT`
  *Integrates Assetic into Symfony2*
- **zikula/fontawesome-bundle** `dev-master`, License: `MIT`
  *FontAwesome Bundle for Zikula*
- **zikula/generator-bundle** `dev-master`, License: `MIT`
  *This module generates code for you*
- **zikula/jquery-ui-bundle** `dev-master`, License: `MIT`
  *Zikula jQuery UI bundle*
- **sensio/distribution-bundle** `v3.0.20`, License: `MIT`
  *Base bundle for Symfony Distributions*
- **zikula/jquery-minicolors-bundle** `dev-master`, License: `MIT`
  *jQuery MiniColors Bundle for Zikula*
- **zikula/jquery-bundle** `dev-master`, License: `MIT`
  *Zikula jQuery bundle*

Web Components
--------------
- **bootstrap-plus/bootstrap-jqueryui** `dev-master`, License: `MIT`
  *A jqueryui version for bootstrap3.*
- **bootstrap-plus/bootstrap-media-lightbox** `dev-master`, License: `MIT`
  *A lightweight and borderless media lightbox extension for bootstrap3. It supports single images, image galleries, videos and iframes.*
- **afarkas/html5shiv** `3.7.2`, License: `MIT, GPL-2.0`
  *Defacto way to enable use of HTML5 sectioning elements in legacy Internet Explorer.*
- **components/bootstrap** `3.3.4`, License: `MIT`
  *The most popular front-end framework for developing responsive, mobile first projects on the web.*
- **bassjobsen/bootstrap-3-typeahead** `v3.1.1`, License: `Apache-2.0`
  *Bootstrap 3 Typeahead*
- **components/jquery** `2.1.3`, License: `MIT`
  *jQuery JavaScript Library*
- **components/jqueryui** `1.11.4`, License: `MIT`
  *jQuery UI is a curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library. Whether you're building highly interactive web applications or you just need to add a date picker to a form control, jQuery UI is the perfect choice.*
- **vakata/jstree** `3.0.9`, License: `MIT`
  *jsTree is jquery plugin, that provides interactive trees.*
- **abeautifulsite/jquery-minicolors** `dev-master`, License: `MIT`
  *jQuery MiniColors Plugin*
- **components/font-awesome** `4.3.0`, License: `MIT, OFL-1.1`
  *The iconic font designed for use with Twitter Bootstrap.*

Other PHP libraries
-------------------
- **sensiolabs/security-checker** `v2.0.1`, License: `MIT`
  *A security checker for your composer.lock*
- **swiftmailer/swiftmailer** `v5.4.0`, License: `MIT`
  *Swiftmailer, free feature-rich PHP mailer*
- **zikula/filesystem** `dev-master`, License: `MIT`
  *Zikula FileSystem Component*
- **ramsey/array_column** `1.1.3`, License: `MIT`
  *Provides functionality for array_column() to projects using PHP earlier than version 5.5.*
- **zikula/wizard** `dev-master`, License: `MIT`
  *Wizard for multi-stage interaction including Symfony Forms*
- **willdurand/jsonp-callback-validator** `v1.1.0`, License: `MIT`
  *JSONP callback validator.*
- **twig/twig** `v1.18.0`, License: `BSD-3-Clause`
  *Twig, the flexible, fast, and secure template language for PHP*
- **twig/extensions** `v1.2.0`, License: `MIT`
  *Common additional features for Twig that do not directly belong in core*
- **symfony/symfony** `v2.6.6`, License: `MIT`
  *The Symfony PHP framework*
- **kriswallsmith/assetic** `v1.2.1`, License: `MIT`
  *Asset Management for PHP*
- **doctrine/inflector** `v1.0.1`, License: `MIT`
  *Common String Manipulations with regard to casing and singular/plural rules.*
- **doctrine/dbal** `v2.5.1`, License: `MIT`
  *Database Abstraction Layer*
- **doctrine/lexer** `v1.0.1`, License: `MIT`
  *Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.*
- **doctrine/orm** `v2.4.7`, License: `MIT`
  *Object-Relational-Mapper for PHP*
- **drak/doctrine1** `dev-master`, License: `LGPL`
  *PHP5 Database ORM*
- **doctrine/common** `v2.5.0`, License: `MIT`
  *Common Library for Doctrine projects*
- **doctrine/collections** `v1.2`, License: `MIT`
  *Collections Abstraction library*
- **beberlei/DoctrineExtensions** `v0.3.0`
- **behat/transliterator** `v1.0.1`, License: `Artistic-1.0`
  *String transliterator*
- **doctrine/annotations** `v1.2.3`, License: `MIT`
  *Docblock Annotations Parser*
- **doctrine/cache** `v1.4.0`, License: `MIT`
  *Caching library offering an object-oriented API for many cache backends*
- **psr/log** `1.0.0`, License: `MIT`
  *Common interface for logging libraries*
- **drak/smarty** `dev-master`
  *Smarty repository for Zikula Core*
- **michelf/php-markdown** `1.4.1`, License: `BSD-3-Clause`
  *PHP Markdown*
- **monolog/monolog** `1.13.1`, License: `MIT`
  *Sends your logs to files, sockets, inboxes, databases and various web services*
- **nikic/php-parser** `v0.9.1`, License: `BSD`
  *A PHP parser written in PHP*
- **phpids/phpids** `dev-master`, License: `LGPL-3.0+`
  *PHPIDS (PHP-Intrusion Detection System) is a simple to use, well structured, fast and state-of-the-art security layer for your PHP based web application*
- **ezyang/htmlpurifier** `dev-master`, License: `LGPL`
  *Standards compliant HTML filter written in PHP*
- **matthiasnoback/symfony-service-definition-validator** `v1.2.2`, License: `MIT`
  *Library for validating service definitions created with the Symfony Dependency Injection Component*
- **gedmo/doctrine-extensions** `v2.3.12`, License: `MIT`
  *Doctrine2 behavioral extensions*
- **matthiasnoback/symfony-console-form** `dev-master`, License: `MIT`
  *Use Symfony forms for Console command input*
- **imagine/imagine** `0.6.2`, License: `MIT`
  *Image processing for PHP 5.3*
- **jdorn/sql-formatter** `v1.2.17`, License: `MIT`
  *a PHP SQL highlighting library*

Composer Installers
-------------------
- **robloach/component-installer** `0.0.12`, License: `MIT`
  *Allows installation of Components via Composer.*
- **composer/installers** `v1.0.21`, License: `MIT`
  *A multi-framework Composer library installer*


These are the main authors of all of the projects supporting Zikula
-------------------------------------------------------------------
- **Zikula Development Team** http://zikula.org
- **Your name** http://example.com/ *example@example.com*
- **Christophe Coevoet** *stof@notk.org*
- **Zikula** http://zikula.org
- **Fabien Potencier** *fabien@symfony.com*
- **Symfony Community** http://symfony.com/contributors
- **Benjamin Eberlei** *kontakt@beberlei.de*
- **Doctrine Project** http://www.doctrine-project.org/
- **Fabio B. Silva** *fabio.bat.silva@gmail.com*
- **Guilherme Blanco** *guilhermeblanco@hotmail.com*
- **Elao Team** http://www.elao.com
- **Contributors** http://github.com/Elao/WebProfilerExtraBundle/contributors
- **FriendsOfSymfony Community** https://github.com/friendsofsymfony/FOSJsRoutingBundle/contributors
- **William Durand** *william.durand1@gmail.com*
- **Johannes M. Schmitt** *schmittjoh@gmail.com*
- **Johannes Schmitt** https://github.com/schmittjoh *schmittjoh@gmail.com*
- **Kris Wallsmith** http://kriswallsmith.net/ *kris.wallsmith@gmail.com*
- **Zikula Community** http://zikula.org/
- **Jacob Thornton** *jacobthornton@gmail.com*
- **Mark Otto** *markdotto@gmail.com*
- **Bass Jobsen** *bass@w3masters.nl*
- **John Resig** *jeresig@gmail.com*
- **jQuery UI Team** http://jqueryui.com/about
- **Joern Zaefferer** http://bassistance.de *joern.zaefferer@gmail.com*
- **Scott Gonzalez** http://scottgonzalez.com *scott.gonzalez@gmail.com*
- **Kris Borchers** http://krisborchers.com *kris.borchers@gmail.com*
- **Mike Sherov** http://mike.sherov.com *mike.sherov@gmail.com*
- **TJ VanToll** http://tjvantoll.com *tj.vantoll@gmail.com*
- **Corey Frang** http://gnarf.net *gnarf37@gmail.com*
- **Felix Nagel** http://www.felixnagel.com *info@felixnagel.com*
- **Ivan Bozhanov** *jstree@jstree.com*
- **Chris Corbyn**
- **Karma Dordrak** http://zikula.org *drak@zikula.org*
- **Kyle Giovannetti** *kylegio@gmail.com*
- **Ben Ramsey** http://benramsey.com
- **Craig Heydenburg** *craig@zikula.org*
- **Armin Ronacher** *armin.ronacher@active-4.com*
- **Twig Team** http://twig.sensiolabs.org/contributors
- **Roman Borschel** *roman@code-factory.org*
- **Jonathan Wage** *jonwage@gmail.com*
- **Konsta Vesterinen** *kvesteri@cc.hut.fi*
- **PHP-FIG** http://www.php-fig.org/
- **Michel Fortin** http://michelf.ca/ *michel.fortin@michelf.ca*
- **John Gruber** http://daringfireball.net/
- **Jordi Boggiano** http://seld.be *j.boggiano@seld.be*
- **Nikita Popov**
- **Lars Strojny** *lars@strojny.net*
- **Edward Z. Yang** http://ezyang.com *admin@htmlpurifier.org*
- **Matthias Noback** http://php-and-symfony.matthiasnoback.nl *matthiasnoback@gmail.com*
- **David Buchmann** *david@liip.ch*
- **Gediminas Morkevicius** *gediminas.morkevicius@gmail.com*
- **Gustavo Falco** *comfortablynumb84@gmail.com*
- **Bulat Shakirzyanov** http://avalanche123.com *mallluhuct@gmail.com*
- **Jeremy Dorn** http://jeremydorn.com/ *jeremy@jeremydorn.com*
- **Rob Loach** http://robloach.net *robloach@gmail.com*
- **Kyle Robinson Young** https://github.com/shama *kyle@dontkry.com*
