### PR TITLE
Updated noconflict for resolving prototype/jQuery/Bootstrap issues

### DIFF
--- a/src/javascript/jquery/noconflict.js
+++ b/src/javascript/jquery/noconflict.js
@@ -1,4 +1,23 @@
 jQuery.noConflict();
+/*
+ Fix provided by http://softec.lu/site/DevelopersCorner/BootstrapPrototypeConflict
+ */
+if ((typeof Prototype !== "undefined") && (Prototype.BrowserFeatures.ElementExtensions)) {
+    var disablePrototypeJS = function (method, pluginsToDisable) {
+            var handler = function (event) {
+                event.target[method] = undefined;
+                setTimeout(function () {
+                    delete event.target[method];
+                }, 0);
+            };
+            pluginsToDisable.each(function (plugin) {
+                jQuery(window).on(method + '.bs.' + plugin, handler);
+            });
+        },
+        pluginsToDisable = ['collapse', 'dropdown', 'modal', 'tooltip', 'popover', 'tab'];
+    disablePrototypeJS('show', pluginsToDisable);
+    disablePrototypeJS('hide', pluginsToDisable);
+}
 // setup ajax for jQuery
 (function($) {
     var defaultOptions = {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2238 for 1.3.x
| Refs tickets  | https://github.com/zikula/core/pull/2242
| License       | MIT
| Doc PR        | -

See https://github.com/zikula/core/commit/ef34c5bb6037cfb4079a9e930770dab1786f4f48 where this was also applied in 1.4.x to solve for instance Bootstrap Tabs disappearing when also using Prototype. For users using Bootstrap (themes) in 1.3.x this solves issues when using prototype and jquery/bootstrap together.