### PR TITLE
Add nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "vakata/jstree": "3.0.*",
         "afarkas/html5shiv": "3.7.*",
         "composer/installers": "1.0.*",
+        "nikic/php-parser" : "0.9.4",
 
         "zikula/legal-module": "dev-master",
         "zikula/profile-module": "dev-master"


### PR DESCRIPTION
Add "nikic/php-parser" : "0.9.4" to avoid previous version to be installed by composer.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | no
| Fixed tickets     | #2430 
| Refs tickets      | #2430 
| License           | MIT
| Doc PR            | 
| Changelog updated | no
