### PR TITLE
Fix 2444

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/CacheClearer.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/CacheClearer.php
@@ -49,6 +49,9 @@ class CacheClearer
         }
         
         $this->cacheTypes = array(
+            "symfony.annotations" => array(
+                "$cacheFolder/annotations"
+            ),
             "symfony.routing.generator" => array(
                 "$cacheFolder{$cachePrefix}UrlGenerator.php",
                 "$cacheFolder{$cachePrefix}UrlGenerator.php.meta",
@@ -72,8 +75,15 @@ class CacheClearer
     {
         foreach ($this->cacheTypes as $cacheType => $files) {
             if (substr($cacheType, 0, strlen($type)) === $type) {
-                // This silently ignores non existing files.
-                $this->fs->remove($files);
+                foreach ($files as $file) {
+                    if (is_dir($file)) {
+                        // Do not delete the folder itself, but all files in it.
+                        // Otherwise Symfony somehow can't create the folder anymore.
+                        $file = new \FilesystemIterator($file);
+                    }
+                    // This silently ignores non existing files.
+                    $this->fs->remove($file);
+                }
             }
         }
     }

--- a/src/system/ZikulaRoutesModule/Resources/views/Route/reload.tpl
+++ b/src/system/ZikulaRoutesModule/Resources/views/Route/reload.tpl
@@ -9,10 +9,9 @@
 
     {insert name="getstatusmsg"}
     <p class="alert alert-warning">{gt text='Do you really want to reload routes? Note: Custom routes won\'t be removed.'}</p>
-    <form class="form-horizontal" action="{modurl modname='ZikulaRoutesModule' type='route' func='reload' lct='admin'}" method="post" role="form">
+    <form class="form-horizontal" action="{modurl modname='ZikulaRoutesModule' type='route' func='reload' lct='admin' stage=1}" method="post" role="form">
         <div>
             <input type="hidden" name="csrftoken" value="{insert name='csrftoken'}" />
-            <input type="hidden" id="confirmation" name="confirmation" value="1" />
             <fieldset>
                 <legend>{gt text='Confirmation prompt'}</legend>
                 <div class="form-group">

--- a/src/system/ZikulaRoutesModule/Util/ControllerUtil.php
+++ b/src/system/ZikulaRoutesModule/Util/ControllerUtil.php
@@ -90,11 +90,12 @@ class ControllerUtil extends BaseControllerUtil
         if ($module === null) {
             throw new NotFoundHttpException();
         }
+        /** @var \Zikula\RoutesModule\Entity\Repository\Route $routeRepository */
+        $hadRoutes = $routeRepository->removeAllOfModule($module);
+
         /** @var \Zikula\RoutesModule\Routing\RouteFinder $routeFinder */
         $routeFinder = $this->get('zikularoutesmodule.routing_finder');
         $routeCollection = $routeFinder->find($module);
-        /** @var \Zikula\RoutesModule\Entity\Repository\Route $routeRepository */
-        $hadRoutes = $routeRepository->removeAllOfModule($module);
         if ($routeCollection->count() > 0) {
             $routeRepository->addRouteCollection($module, $routeCollection);
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | ---
| Fixed tickets     | #2444
| Refs tickets      | ---
| License           | MIT
| Doc PR            | ---
| Changelog updated | no

Please test @shefik. Because this changes the route of the reload routes action, you have to manually clear your cache and edit the database after checking out this branch. Find the `zikularoutesmodule_route_reload` route in the `zikula_routes_route` table and set `route_path` to `/%zikularoutesmodule.routing.route.plural%/reload/{stage}/{module}` and `route_defaults` to `a:3:{s:5:"stage";i:0;s:6:"module";N;s:11:"_controller";s:60:"Zikula\RoutesModule\Controller\RouteController::reloadAction";}`. Then test again.