### PR TITLE
Adding support for getting the parent class of a bundle

### DIFF
--- a/src/lib/Zikula/Core/AbstractBundle.php
+++ b/src/lib/Zikula/Core/AbstractBundle.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\Yaml\Yaml;
 
 abstract class AbstractBundle extends Bundle
 {
@@ -17,6 +18,15 @@ abstract class AbstractBundle extends Bundle
     protected $booted = false;
 
     private $basePath;
+
+    public function getParent()
+    {  
+        if (is_readable($file = $this->getConfigPath().'/bundle.yml')) {
+            $bundleConfig = Yaml::parse(file_get_contents($file));
+            
+            return $bundleConfig[strtolower($this->name)]['parent'];
+        }
+    }
 
     public function isBooted()
     {


### PR DESCRIPTION
Based on the Symfony docs referenced here:

http://symfony.com/doc/current/cookbook/bundles/inheritance.html

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | https://github.com/zikula/core/issues/2448
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no