### PR TITLE
Add _locale to lang decode

### DIFF
--- a/src/lib/util/System.php
+++ b/src/lib/util/System.php
@@ -729,7 +729,12 @@ class System
             $modname = strtolower($parameters['_zkModule']);
             $type = strtolower($parameters['_zkType']);
             $func = strtolower($parameters['_zkFunc']);
-            $lang = strtolower($parameters['_locale']);
+            
+            if (isset($parameters['_locale'])) {
+	            $lang = strtolower($parameters['_locale']);
+	            $request->query->set('lang', $lang);            
+	            self::queryStringSetVar('lang', $lang);            
+            }
             
             $request->attributes->set('_zkModule', $modname);
             $request->attributes->set('_zkType', $type);
@@ -737,11 +742,10 @@ class System
             $request->query->set('module', $modname);
             $request->query->set('type', $type);
             $request->query->set('func', $func);
-            $request->query->set('lang', $lang);
+
             self::queryStringSetVar('module', $modname);
             self::queryStringSetVar('type', $type);
             self::queryStringSetVar('func', $func);
-            self::queryStringSetVar('lang', $lang);
             
             return;
 

--- a/src/lib/util/System.php
+++ b/src/lib/util/System.php
@@ -729,17 +729,20 @@ class System
             $modname = strtolower($parameters['_zkModule']);
             $type = strtolower($parameters['_zkType']);
             $func = strtolower($parameters['_zkFunc']);
-
+            $lang = strtolower($parameters['_locale']);
+            
             $request->attributes->set('_zkModule', $modname);
             $request->attributes->set('_zkType', $type);
             $request->attributes->set('_zkFunc', $func);
             $request->query->set('module', $modname);
             $request->query->set('type', $type);
             $request->query->set('func', $func);
+            $request->query->set('lang', $lang);
             self::queryStringSetVar('module', $modname);
             self::queryStringSetVar('type', $type);
             self::queryStringSetVar('func', $func);
-
+            self::queryStringSetVar('lang', $lang);
+            
             return;
 
         } catch (ResourceNotFoundException $e) {


### PR DESCRIPTION
This is decoding _locale of new style url's to lang variable still used in Zlanguage.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | n/a
| Fixed tickets     | #2459 
| Refs tickets      | #2459 
| License           | MIT
| Doc PR            | n/a
| Changelog updated | no

 