### PR TITLE
Add current language detection to route plugin

### DIFF
--- a/src/lib/legacy/viewplugins/function.route.php
+++ b/src/lib/legacy/viewplugins/function.route.php
@@ -43,6 +43,7 @@ function smarty_function_route($params, Zikula_View $view)
     unset($params['name']);
     $absolute = isset($params['absolute']) ? $params['absolute'] : false;
     unset($params['absolute']);
+    $params['_locale'] = isset($params['_locale']) ? $params['_locale'] : $view->language;
 
     /** @var $router \JMS\I18nRoutingBundle\Router\I18nRouter */
     $router = $view->getContainer()->get('router');


### PR DESCRIPTION
 Set _locale if not present to current language ($view->language)

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | #2472 
| Refs tickets      | #2472 
| License           | MIT
| Doc PR            |
| Changelog updated | no
