### PR TITLE
Icons fixed and bs_hamburger.tpl added

### DIFF
--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Menutree/bootstrap.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Menutree/bootstrap.tpl
@@ -3,8 +3,8 @@
         <div class="menutree collapse navbar-collapse" id="menutree-navbar-collapse-{$blockinfo.bid}">
             {menutree data=$menutree_content id='menu'|cat:$blockinfo.bid class='nav navbar-nav' ext=true bootstrap=true extopt='first,last,single,dropdown,childless,dropdown-menu'}
             {if $menutree_editlinks}
-            <ul class="menutree_horizontal_controls">
-                <li><a class="fa fa-add" href="{route name='zikulablocksmodule_admin_modify' bid=$blockinfo.bid addurl=1}#menutree_tabs" title="{gt text='Add the current URL as new link in this block'}"></a></li>
+            <ul class="nav navbar-nav navbar-right">
+                <li><a class="fa fa-plus" href="{route name='zikulablocksmodule_admin_modify' bid=$blockinfo.bid addurl=1}#menutree_tabs" title="{gt text='Add the current URL as new link in this block'}"></a></li>
                 <li><a class="fa fa-pencil" href="{route name='zikulablocksmodule_admin_modify' bid=$blockinfo.bid fromblock=1}" title="{gt text='Edit this block'}"></a></li>
             </ul>
             {/if}

--- a/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Menutree/bs_hamburger.tpl
+++ b/src/system/Zikula/Module/BlocksModule/Resources/views/Block/Menutree/bs_hamburger.tpl
@@ -1,0 +1,22 @@
+<nav class="navbar navbar-default" role="navigation">
+    <div class="container">
+    <div class="container">
+	    <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#menutree-{$blockinfo.bid}">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="{homepage}">{$modvars.ZConfig.sitename}</a>
+        </div>
+        <div class="menutree collapse navbar-collapse" id="menutree-{$blockinfo.bid}">
+            {menutree data=$menutree_content id='menu'|cat:$blockinfo.bid class='nav navbar-nav' ext=true bootstrap=true extopt='first,last,single,dropdown,childless,dropdown-menu'}
+            {if $menutree_editlinks}
+            <ul class="nav navbar-nav navbar-right">
+                <li><a class="fa fa-plus" href="{route name='zikulablocksmodule_admin_modify' bid=$blockinfo.bid addurl=1}#menutree_tabs" title="{gt text='Add the current URL as new link in this block'}"></a></li>
+                <li><a class="fa fa-pencil" href="{route name='zikulablocksmodule_admin_modify' bid=$blockinfo.bid fromblock=1}" title="{gt text='Edit this block'}"></a></li>
+            </ul>
+            {/if}
+        </div>
+    </div>
+</nav>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | [no]

Just some optimizations
Fixed the add icon and optimized the location of the icons to the right.
Added a second boostrap template (bs_hamburger.tpl) including hamburger symbol
@Kaik This is instead of #2475 