### PR TITLE
Modifying the cache ID for the theme templates

### DIFF
--- a/src/lib/legacy/Zikula/View/Theme.php
+++ b/src/lib/legacy/Zikula/View/Theme.php
@@ -335,6 +335,8 @@ class Zikula_View_Theme extends Zikula_View
         $event = new \Zikula\Core\Event\GenericEvent($this, array(), $maincontent);
         $maincontent = $this->eventManager->dispatch('theme.prefetch', $event)->getData();
 
+        $this->cache_id = md5($this->cache_id.'|'.$maincontent);
+
         // Assign the main content area to the template engine
         $this->assign('maincontent', $maincontent);
 


### PR DESCRIPTION
Modifying the cache ID for the theme templates, to allow both render cache and theme cache to be enabled simultaneously.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no