### PR TITLE
Adding Proper Support for Fonts

### DIFF
--- a/src/lib/legacy/Zikula/Core.php
+++ b/src/lib/legacy/Zikula/Core.php
@@ -573,6 +573,7 @@ class Zikula_Core
             PageUtil::registerVar('title');
             PageUtil::setVar('title', System::getVar('defaultpagetitle'));
             PageUtil::registerVar('keywords', true);
+            PageUtil::registerVar('font', true);
             PageUtil::registerVar('stylesheet', true);
             PageUtil::registerVar('javascript', true);
             PageUtil::registerVar('jsgettext', true);

--- a/src/lib/util/PageUtil.php
+++ b/src/lib/util/PageUtil.php
@@ -40,6 +40,7 @@
  * <li>body</li>
  * <li>header</li>
  * <li>footer</li>
+ * <li>font</li>
  * </ul>
  *
  * In addition, if your system is operating in legacy compatibility mode, then
@@ -63,6 +64,7 @@ class PageUtil
      * <li>body</li>
      * <li>header</li>
      * <li>footer</li>
+     * <li>font</li>
      * </ul>
      *
      * In addition, if your system is operating in legacy compatibility mode, then


### PR DESCRIPTION
Adding support for page var "font", and correcting error, where @import was not supporting remote URLs.

Example use in a template:

`{pageaddvar name='font' value='//fonts.googleapis.com/css?family=Oswald:300,400,700'}`

Any remote font URL can be used. It does not need to be a Google font. All fonts will be loaded before other stylesheets, since it is required for fonts to always load first for proper styling.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no