### PR TITLE
disable 'advanced' handling of RouteNotFoundException

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/ExceptionListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/ExceptionListener.php
@@ -124,22 +124,22 @@ class ExceptionListener implements EventSubscriberInterface
     {
         $message = $event->getException()->getMessage();
         $event->getRequest()->getSession()->getFlashBag()->add('error', $message);
-        if ($userLoggedIn && \SecurityUtil::checkPermission('ZikulaRoutesModule::', '::', ACCESS_ADMIN)) {
-            $originalRouteCollection = $this->router->getOriginalRouteCollection()->all();
-            if (!array_key_exists('zikularoutesmodule_route_reload', $originalRouteCollection)) {
-                // reload routes for the Routes module first
-                $this->routesControllerUtil->reloadRoutesByModule('ZikulaRoutesModule');
-                $this->cacheClearer->clear("symfony.routing");
-            }
-            $url = $this->router->generate('zikularoutesmodule_route_reload', array('lct' => 'admin'), RouterInterface::ABSOLUTE_URL);
-            $frontController = \System::getVar('entrypoint', 'index.php');
-            if (strpos($url, "$frontController/") !== false) {
-                $url = str_ireplace("$frontController/", "", $url);
-            }
-            $event->getRequest()->getSession()->getFlashBag()->add('error', __('You might try re-loading the routes for the extension in question.'));
-            $event->setResponse(new RedirectResponse($url));
-            $event->stopPropagation();
-        }
+//        if ($userLoggedIn && \SecurityUtil::checkPermission('ZikulaRoutesModule::', '::', ACCESS_ADMIN)) {
+//            $originalRouteCollection = $this->router->getOriginalRouteCollection()->all();
+//            if (!array_key_exists('zikularoutesmodule_route_reload', $originalRouteCollection)) {
+//                // reload routes for the Routes module first
+//                $this->routesControllerUtil->reloadRoutesByModule('ZikulaRoutesModule');
+//                $this->cacheClearer->clear("symfony.routing");
+//            }
+//            $url = $this->router->generate('zikularoutesmodule_route_reload', array('lct' => 'admin'), RouterInterface::ABSOLUTE_URL);
+//            $frontController = \System::getVar('entrypoint', 'index.php');
+//            if (strpos($url, "$frontController/") !== false) {
+//                $url = str_ireplace("$frontController/", "", $url);
+//            }
+//            $event->getRequest()->getSession()->getFlashBag()->add('error', __('You might try re-loading the routes for the extension in question.'));
+//            $event->setResponse(new RedirectResponse($url));
+//            $event->stopPropagation();
+//        }
     }
 
     /**

--- a/src/lib/Zikula/Bundle/CoreBundle/EventListener/ExceptionListener.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/EventListener/ExceptionListener.php
@@ -124,8 +124,13 @@ class ExceptionListener implements EventSubscriberInterface
     {
         $message = $event->getException()->getMessage();
         $event->getRequest()->getSession()->getFlashBag()->add('error', $message);
-//        if ($userLoggedIn && \SecurityUtil::checkPermission('ZikulaRoutesModule::', '::', ACCESS_ADMIN)) {
-//            $originalRouteCollection = $this->router->getOriginalRouteCollection()->all();
+        if ($userLoggedIn && \SecurityUtil::checkPermission('ZikulaRoutesModule::', '::', ACCESS_ADMIN)) {
+            $originalRouteCollection = $this->router->getOriginalRouteCollection()->all();
+            if (array_key_exists('zikularoutesmodule_route_reload', $originalRouteCollection)) {
+                $url = $this->router->generate('zikularoutesmodule_route_reload', array('lct' => 'admin'), RouterInterface::ABSOLUTE_URL);
+                $link = "<a href='$url'>". __('re-loading the routes') . "</a>";
+                $event->getRequest()->getSession()->getFlashBag()->add('error', __f('You might try %s for the extension in question.', $link));
+            }
 //            if (!array_key_exists('zikularoutesmodule_route_reload', $originalRouteCollection)) {
 //                // reload routes for the Routes module first
 //                $this->routesControllerUtil->reloadRoutesByModule('ZikulaRoutesModule');
@@ -139,7 +144,7 @@ class ExceptionListener implements EventSubscriberInterface
 //            $event->getRequest()->getSession()->getFlashBag()->add('error', __('You might try re-loading the routes for the extension in question.'));
 //            $event->setResponse(new RedirectResponse($url));
 //            $event->stopPropagation();
-//        }
+        }
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | -
| Refs tickets      | #2470
| License           | MIT
| Doc PR            | -
| Changelog updated | no

disable (at least temporarily) 'advanced' handling of RouteNotFoundException. The redirects have caused issues before and can cause endless redirects. There are specific issues when `adminpanelmenu` is in use because it expects routes to be available. This PR reduces handling to be the same error message for admin and normal users.

refs #2470 (probably)

@cmfcmf @Guite and any others - please share your concerns. I would like to merge this into 1.4.0