### PR TITLE
formatForOS() corrupts path beginning with "../"

### DIFF
--- a/src/lib/util/DataUtil.php
+++ b/src/lib/util/DataUtil.php
@@ -380,9 +380,13 @@ class DataUtil
             if ($current == '.') {
                 // current path element is a dot, so we don't do anything
             } elseif ($current == '..') {
-                // current path element is .., so we remove the last path in case of relative paths
-                if (!$absolutepathused) {
+                // current path element is .., so we remove the last path
+                if (count($clean_array) > 0) {
                     array_pop($clean_array);
+                } else {
+                    if (!$absolutepathused) {
+                        array_push($clean_array, $current);
+                    }
                 }
             } else {
                 // current path element is valid, so we add it to the path


### PR DESCRIPTION
A relative path beginning with "../" results in an array_pop() on an empty array (stack underflow). In a relative path a leading ".." should be left in place. A leading ".." should be removed only in an absolue path.