### PR TITLE
Do not include the config files twice - will override the ZConfig global

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/HttpKernel/ZikulaKernel.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/HttpKernel/ZikulaKernel.php
@@ -49,19 +49,20 @@ abstract class ZikulaKernel extends Kernel
     private $autoloader;
 
     /**
-     * Flag determines if container is dumped or not
-     *
-     * @param $flag
+     * @deprecated - Remove when inclusion of files inside the constructor is removed!
+     * @var bool
      */
-    public function setDump($flag)
-    {
-        $this->dump = $flag;
-    }
+    private static $included = false;
 
     public function __construct($env, $debug)
     {
         parent::__construct($env, $debug);
 
+        if (self::$included) {
+            return;
+        }
+        self::$included = true;
+        
         // this is all to be deprecated (todo drak)
         $paths = array(
             $this->rootDir .'/../config/config.php',
@@ -74,6 +75,16 @@ abstract class ZikulaKernel extends Kernel
                 include $path;
             }
         }
+    }
+
+    /**
+     * Flag determines if container is dumped or not
+     *
+     * @param $flag
+     */
+    public function setDump($flag)
+    {
+        $this->dump = $flag;
     }
 
     public function boot()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Doc PR            | ---
| Changelog updated | no

@rallek @eespan This patch might solve the news upload directory problem, because it always set `datadir` to `null` instead of `userdata`.