### PR TITLE
[1.3] Load correct theme in case Mobile theme is enabled and Mobile detect is enabled

### DIFF
--- a/src/lib/util/UserUtil.php
+++ b/src/lib/util/UserUtil.php
@@ -1906,6 +1906,8 @@ class UserUtil
             $detect = new Mobile_Detect();
             if ($detect->isMobile()) {
                 $pagetheme = 'Mobile';
+`            } else {
+                $pagetheme = FormUtil::getPassedValue('theme', null, 'GETPOST');
             }
         } else {
              $pagetheme = FormUtil::getPassedValue('theme', null, 'GETPOST');

--- a/src/lib/util/UserUtil.php
+++ b/src/lib/util/UserUtil.php
@@ -1906,7 +1906,7 @@ class UserUtil
             $detect = new Mobile_Detect();
             if ($detect->isMobile()) {
                 $pagetheme = 'Mobile';
-`            } else {
+`           } else {
                 $pagetheme = FormUtil::getPassedValue('theme', null, 'GETPOST');
             }
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| 1.4 PR        | -
| Refs tickets  | -
| License       | MIT
| Doc PR        | -

This PR is related to Zikula 1.3 branch only, and corrects a bug in default theme loading in case Mobile theme is enabled and Mobile detect is also enabled, but client is not mobile.
In particular, if described conditions occurs, then "Printer" and "RSS" themes, passed in URL, will not load.