### PR TITLE
[WIP] Make thumbnailing a transformation, so that other transformations can be applied after thumbnailing

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -5,6 +5,8 @@ CHANGELOG - ZIKULA 1.4.x
 
  - BC Breaks:
      - Removed `Zikula\Core\Api\AbstractApi` that was introduced only in 1.4.0 (#2494)
+     - If you use the Imagine System plugin and add custom transformations with a priority greater than 50,
+       these are now applied *after* the thumbnail is generated. (#2594)
  - Deprecated:
      - Twig function `pageAddVar()` deprecated. Use `pageAddAsset()` or `pageSetVar()` instead.
  - Fixes:

--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -23,6 +23,8 @@ CHANGELOG - ZIKULA 1.4.x
     - Core-2.0 Module Specification finalized and enabled (#2500, #2560)
     - Combined and customized bootstrap/font-awesome css using Less.
     - Improved multilingual UI in general settings (#2547)
+    - [Imagine Plugin] Possibility to add transformations which are applied after the thumbnail 
+        is generated. (#2594)
  
 
 * 1.4.0 (2015-07-20)

--- a/src/plugins/Imagine/README.md
+++ b/src/plugins/Imagine/README.md
@@ -177,7 +177,7 @@ It's recommended to use grouping methods.
 
 ### Custom image transformations
 
-It is possibly to apply custom image transformations before the thumbnail is created. 
+It is possible to apply custom image transformations before the thumbnail is created. 
 This can be archived by adding transformations to the preset (see Presets section) 
 or applying transformation inline:
 

--- a/src/plugins/Imagine/README.md
+++ b/src/plugins/Imagine/README.md
@@ -177,9 +177,9 @@ It's recommended to use grouping methods.
 
 ### Custom image transformations
 
-It is possible to apply for thumbnails custom image transformations, supported by Imagine library.
-This can be archived by adding transformation to preset (see Presets section) or applying
-transformation inline:
+It is possibly to apply custom image transformations before the thumbnail is created. 
+This can be archived by adding transformations to the preset (see Presets section) 
+or applying transformation inline:
 
 ```
     $manager = $this->getContainer()->get('systemplugin.imagine.manager');
@@ -191,6 +191,21 @@ transformation inline:
         ->setPreset('my_preset');
     $thumb = $manager->getThumb('path/to/image.png');
 ```
+
+By adding transformations with a priority greater than 50, you can also apply 
+custom transformations after the thumbnail generation:
+
+```
+    $manager = $this->getContainer()->get('systemplugin.imagine.manager');
+    $transformation = new Imagine\Filter\Transformation();
+    $transformation->add(new Imagine\Filter\Basic\FlipHorizontally(), 60);
+
+    $manager->setModule('Foo')
+        ->setTransformation($transformation)
+        ->setPreset('my_preset');
+    $thumb = $manager->getThumb('path/to/image.png');
+```
+
 
 ### Imagine engines
 

--- a/src/plugins/Imagine/lib/Imagine/Manager.php
+++ b/src/plugins/Imagine/lib/Imagine/Manager.php
@@ -430,10 +430,13 @@ class SystemPlugin_Imagine_Manager extends Zikula_Controller_AbstractPlugin
 		
         $size = new \Imagine\Image\Box($preset['width'], $preset['height']);
 
+        // Clone the transformation here, because we don't want the thumbnail transformations to bubble up.
+        $transformation = clone $this->getTransformation();
+        $transformation->add(new \Imagine\Filter\Basic\Thumbnail($size, $mode), 50);
+
         try {
-            $this->getTransformation()
+            $transformation
                 ->apply($this->getImagine()->open($image->getRealPath()))
-                ->thumbnail($size, $mode)
                 ->save($image->getThumbRealPath(), $options);
         } catch (Exception $exception) {
             throw $exception;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | yes, in edge cases
| Deprecations?     | no
| Tests pass?       | ---
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Doc PR            | ---
| Changelog updated | yes

This makes it possible to use the Imagine plugin to create thumbnails and apply further transformations after creating the thumbnail. Currently, all custom transformations are applied before creating the thumbnail. With this PR, it is possible to add transformations which are applied after creating the thumbnail. I.e. watermark the image's thumbnail.

This is a minor BC break for modules using Imagine transformations with a priority greater than 50. I am not aware of any modules doing so. If there are such modules, the fix is as trivial as changing the priorities of the custom transformations.