### PR TITLE
fix route translation

### DIFF
--- a/src/app/config/config.yml
+++ b/src/app/config/config.yml
@@ -4,7 +4,7 @@ imports:
 
 framework:
     #esi:             ~
-    translator:      { fallbacks: %locale% }
+    translator:      { fallbacks: en }
     secret:          %secret%
     router:
         resource: "%kernel.root_dir%/config/routing.yml"

--- a/src/lib/Zikula/Bundle/CoreBundle/Bundle/MetaData.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/Bundle/MetaData.php
@@ -124,10 +124,10 @@ class MetaData
         return $this->__(/** @Ignore */$this->displayName);
     }
 
-    public function getUrl()
+    public function getUrl($translated = true)
     {
         $this->confirmTranslator();
-        return $this->__(/** @Ignore */$this->url);
+        return $translated ? $this->__(/** @Ignore */$this->url) : $this->url;
     }
 
     public function getOldNames()

--- a/src/lib/i18n/ZLanguage.php
+++ b/src/lib/i18n/ZLanguage.php
@@ -163,7 +163,7 @@ class ZLanguage
         ModUtil::setupMultilingual();
         $this->setLocale($this->languageCode);
         $request->setLocale($this->languageCode);
-        $request->setDefaultLocale($this->languageCode);
+        $request->setDefaultLocale('en');
         $this->bindCoreDomain();
         $this->processErrors();
     }

--- a/src/system/SettingsModule/Controller/AdminController.php
+++ b/src/system/SettingsModule/Controller/AdminController.php
@@ -29,9 +29,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use ZLanguage;
 use Zikula\Bundle\CoreBundle\YamlDumper;
 
-/**
- * @Route("/admin")
- */
 class AdminController extends \Zikula_AbstractController
 {
     /**
@@ -46,7 +43,7 @@ class AdminController extends \Zikula_AbstractController
     }
 
     /**
-     * @Route("")
+     * @Route("/admin")
      *
      * entry point for the module
      *
@@ -59,7 +56,7 @@ class AdminController extends \Zikula_AbstractController
     }
 
     /**
-     * @Route("/config")
+     * @Route("/admin/config")
      * @Method("GET")
      *
      * display the main site settings form
@@ -106,7 +103,7 @@ class AdminController extends \Zikula_AbstractController
     }
 
     /**
-     * @Route("/config")
+     * @Route("/admin/config")
      * @Method("POST")
      *
      * update main site settings
@@ -203,7 +200,7 @@ class AdminController extends \Zikula_AbstractController
     }
 
     /**
-     * @Route("/ml", options={"i18n"=false})
+     * @Route("/settings/admin/multilingual", options={"i18n"=false, "zkNoBundlePrefix"=true})
      * @Method("GET")
      *
      * i18n = false so route can be found when changing languages
@@ -228,7 +225,7 @@ class AdminController extends \Zikula_AbstractController
     }
 
     /**
-     * @Route("/ml")
+     * @Route("/settings/admin/multilingual", options={"i18n"=false, "zkNoBundlePrefix"=true})
      * @Method("POST")
      *
      * update ML settings
@@ -275,6 +272,8 @@ class AdminController extends \Zikula_AbstractController
             SessionUtil::delVar('language');
         }
 
+        /** @var \JMS\I18nRoutingBundle\Router\I18nRouter $router */
+        $router = $this->get('router');
         // Write the vars
         foreach ($settings as $formname => $varname) {
             $newvalue = $request->request->get($formname, null);
@@ -287,21 +286,19 @@ class AdminController extends \Zikula_AbstractController
         $yamlManager = new YamlDumper($this->get('kernel')->getRootDir() .'/config');
         $yamlManager->setParameter('locale', $locale);
 
-        // Reload multilingual routing settings.
-        ModUtil::apiFunc('ZikulaRoutesModule', 'admin', 'reloadMultilingualRoutingSettings');
-
-        // clear all cache and compile directories
-        ModUtil::apiFunc('ZikulaSettingsModule', 'admin', 'clearallcompiledcaches');
+        ModUtil::apiFunc('ZikulaRoutesModule', 'admin', 'reloadMultilingualRoutingSettings'); // resets config/dynamic/generated.yml
+        $url = $router->generate('zikulasettingsmodule_admin_multilingual', array(), RouterInterface::ABSOLUTE_URL);
 
         // all done successfully
-        $request->getSession()->getFlashBag()->add('status', $this->__('Done! Saved localisation settings.'));
-        $url = $this->get('router')->generate('zikulasettingsmodule_admin_multilingual', array(), RouterInterface::ABSOLUTE_URL);
+        /** @var \Symfony\Component\Translation\TranslatorInterface $translator */
+        $translator = $this->get('translator');
+        $request->getSession()->getFlashBag()->add('status', $translator->trans('Done! Saved localisation settings.', [], 'zikula', $locale));
 
         return new RedirectResponse($url);
     }
 
     /**
-     * @Route("/phpinfo")
+     * @Route("/admin/phpinfo")
      *
      * Displays the content of {@link phpinfo()}.
      *


### PR DESCRIPTION
Remove all multilingual and prefix options from controller methods responsible to change the locale. Set default locale to 'en' where possible. Ensure module metadata 'ur' is translated properly for each locale's route. fixes #2642.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | n/a
| Fixed tickets     | #2642
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | not req.