### PR TITLE
Reverting previous commit, to restore functionality to properly regenerate modules

### DIFF
--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxInstallController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxInstallController.php
@@ -169,7 +169,7 @@ class AjaxInstallController extends AbstractController
     {
         // regenerate modules list
         $modApi = new ExtensionsAdminApi($this->container, new ZikulaExtensionsModule());
-        $modApi->regenerate(array('filemodules' => $modApi->getfilemodules(array('system'))));
+        $modApi->regenerate(array('filemodules' => $modApi->getfilemodules()));
 
         // set each of the core modules to active
         reset($this->systemModules);


### PR DESCRIPTION
Reverting previous commit, to restore functionality to properly regenerate modules during core installation.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | https://github.com/zikula/core/issues/2665
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no