### PR TITLE
Hooks from version fix

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -14,6 +14,7 @@ CHANGELOG - ZIKULA 1.4.x
  - Features:
     - New advanced block filtering based on a combination of any query parameter or request attributes.
  - Core-2.0 Features:
+    - Implement new definition spec for Hook capabilities.
     - Implement new BlockApi and all corresponding methods.
         - BlockControllerInterface
         - AbstractBlockController

--- a/src/docs/Core-2.0/Hooks/HookContainer.md
+++ b/src/docs/Core-2.0/Hooks/HookContainer.md
@@ -1,0 +1,51 @@
+HookContainer
+=============
+
+Extensions that wish to utilize Hooks must define a HookContainer class that extends 
+`\Zikula\Component\HookDispatcher\AbstractContainer`. The class must implement one method `setupHookBundles()` which
+instantiates and registers hook bundles.
+
+````php
+    protected function setupHookBundles()
+    {
+        $bundle = new SubscriberBundle('ZikulaSpecModule', 'subscriber.user.ui_hooks.view.content', 'ui_hooks', $this->__('Foo'));
+        $bundle->addEvent('foo_view', 'zikula_spec_module.ui_hooks.foo_view');
+        $this->registerHookSubscriberBundle($bundle);
+    }
+```
+
+See `src/docs/en/dev/Hooks` for more information on Hooks.
+
+
+Installation of Hooks
+---------------------
+
+In the extension's `install` method, the extension must obtain an instance of its own hook container and register 
+the bundles:
+
+```php
+    $hookContainer = $this->hookApi->getHookContainerInstance($this->bundle->getMetaData());
+    \HookUtil::registerSubscriberBundles($hookContainer->getHookSubscriberBundles());
+```
+
+In the `uninstall` method, the extension must do the same (except use `unregister...`):
+
+```php
+    $hookContainer = $this->hookApi->getHookContainerInstance($this->bundle->getMetaData());
+    \HookUtil::unregisterSubscriberBundles($hookContainer->getHookSubscriberBundles());
+```
+
+All the extensions hooks can be stored in the same container and simply defined as either Provider or Subscriber bundles.
+If you wish, you may separate the definition bundles by defining different classes in the composer file. If the
+HookContainers are separate for each type, then you must specify the type in the instantiation:
+
+```php
+    $subscriberHookContainer = $this->hookApi->getHookContainerInstance($this->bundle->getMetaData(), HookApi::SUBSCRIBER_TYPE);
+    \HookUtil::registerSubscriberBundles($subscriberHookContainer->getHookSubscriberBundles());
+
+    $providerHookContainer = $this->hookApi->getHookContainerInstance($this->bundle->getMetaData(), HookApi::PROVIDER_TYPE);
+    \HookUtil::registerProviderBundles($providerHookContainer->getHookProviderBundles());
+```
+
+Please note that install/remove is not 100% finalized for the Core-2.0.0 spec. It is possible that this may eventually
+simply be removed altogether and the core will handle installation and removal of an extension's hooks.

--- a/src/docs/Core-2.0/Hooks/definitions.md
+++ b/src/docs/Core-2.0/Hooks/definitions.md
@@ -1,0 +1,26 @@
+Hook Definitions
+================
+
+In order for hooks to function, the `composer.json` file must define the extension's HookContainer class in the 
+`capabilities` array like so:
+
+```json
+    "extra": {
+        "zikula": {
+            "capabilities": {
+                "hook_subscriber": {"class": "Zikula\\BlocksModule\\Container\\HookContainer"}
+                "hook_provider": {"class": "Zikula\\BlocksModule\\Container\\HookContainer"}
+            }
+        }
+    }
+```
+
+Note that this replaces the 1.4.x convention of identifying the capabilities with
+`"hook_subscriber": {'enabled": true}`.
+
+Only define the key(s) that the module implements (e.g. `"hook_subscriber"` or `"hook_provider"` or both).
+
+It is technically possible to define two different definition classes (one for subscriber and one for provider hooks).
+If this is done, you must specify the hook type when instantiating the class from the Api (See HookContainer).
+
+See `src/docs/en/dev/Hooks` for more information on Hooks.

--- a/src/lib/Zikula/Bundle/CoreBundle/Bundle/MetaData.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/Bundle/MetaData.php
@@ -5,7 +5,7 @@ namespace Zikula\Bundle\CoreBundle\Bundle;
 use Symfony\Component\HttpKernel\Exception\PreconditionRequiredHttpException;
 use Zikula\Common\Translator\TranslatorTrait;
 
-class MetaData
+class MetaData implements \ArrayAccess
 {
     use TranslatorTrait;
 
@@ -259,5 +259,28 @@ class MetaData
             'corecompatibility' => $this->getCoreCompatibility(),
             'core_max' => '' // core_min is set from corecompatibility
         );
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->$offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        $method = "get" . ucwords($offset);
+        return $this->$method();
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        // not allowed
+        throw new \Exception('Setting values by array access is not allowed.');
+    }
+
+    public function offsetUnset($offset)
+    {
+        // not allowed
+        throw new \Exception('Unsetting values by array access is not allowed.');
     }
 }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxInstallController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxInstallController.php
@@ -236,6 +236,7 @@ class AjaxInstallController extends AbstractController
     {
         $installer = new \Zikula\BlocksModule\BlocksModuleInstaller();
         $installer->setBundle($this->container->get('kernel')->getModule('ZikulaBlocksModule'));
+        $installer->setContainer($this->container);
         // create the default blocks.
         $installer->defaultdata();
 

--- a/src/system/BlocksModule/BlocksModuleInstaller.php
+++ b/src/system/BlocksModule/BlocksModuleInstaller.php
@@ -16,7 +16,7 @@ namespace Zikula\BlocksModule;
 use Zikula\BlocksModule\Entity\BlockEntity;
 use Zikula\BlocksModule\Entity\BlockPlacementEntity;
 use Zikula\BlocksModule\Entity\BlockPositionEntity;
-use Zikula\BlocksModule\Helper\HookHelper;
+use Zikula\BlocksModule\Container\HookContainer;
 use Zikula\BlocksModule\Helper\InstallerHelper;
 use Zikula\Core\AbstractExtensionInstaller;
 use ZLanguage;
@@ -52,8 +52,8 @@ class BlocksModuleInstaller extends AbstractExtensionInstaller
         // Set a default value for a module variable
         $this->setVar('collapseable', false);
 
-        $hookHelper = new HookHelper($this->getTranslator());
-        HookUtil::registerSubscriberBundles($hookHelper->getHookSubscriberBundles());
+        $hookContainer = $this->hookApi->getHookContainerInstance($this->bundle->getMetaData());
+        HookUtil::registerSubscriberBundles($hookContainer->getHookSubscriberBundles());
 
         // Initialisation successful
         return true;
@@ -71,8 +71,8 @@ class BlocksModuleInstaller extends AbstractExtensionInstaller
         // Upgrade dependent on old version number
         switch ($oldversion) {
             case '3.8.1':
-                $hookHelper = new HookHelper($this->getTranslator());
-                HookUtil::registerSubscriberBundles($hookHelper->getHookSubscriberBundles());
+                $HookContainer = new HookContainer($this->getTranslator());
+                HookUtil::registerSubscriberBundles($HookContainer->getHookSubscriberBundles());
             case '3.8.2':
             case '3.9.0':
                 $blocks = $this->entityManager->getRepository('ZikulaBlocksModule:BlockEntity')->findAll();

--- a/src/system/BlocksModule/Container/HookContainer.php
+++ b/src/system/BlocksModule/Container/HookContainer.php
@@ -11,12 +11,12 @@
  * information regarding copyright and licensing.
  */
 
-namespace Zikula\BlocksModule\Helper;
+namespace Zikula\BlocksModule\Container;
 
-use Zikula\Component\HookDispatcher\AbstractContainer as HookContainer;
+use Zikula\Component\HookDispatcher\AbstractContainer;
 use Zikula\Component\HookDispatcher\SubscriberBundle;
 
-class HookHelper extends HookContainer
+class HookContainer extends AbstractContainer
 {
     protected function setupHookBundles()
     {

--- a/src/system/BlocksModule/composer.json
+++ b/src/system/BlocksModule/composer.json
@@ -28,7 +28,7 @@
             "oldnames": [],
             "capabilities": {
                 "admin": {"route": "zikulablocksmodule_admin_view"},
-                "hook_subscriber": {"enabled": true}
+                "hook_subscriber": {"class": "Zikula\\BlocksModule\\Container\\HookContainer"}
             },
             "securityschema": {
                 "ZikulaBlocksModule::": "Block key:Block title:Block ID",

--- a/src/system/ExtensionsModule/Api/AdminApi.php
+++ b/src/system/ExtensionsModule/Api/AdminApi.php
@@ -380,6 +380,10 @@ class AdminApi extends \Zikula_AbstractApi
         ModUtil::dbInfoLoad($modinfo['name'], $osdir);
 
         $version = ExtensionsUtil::getVersionMeta($modinfo['name'], $modpath, $module);
+        if ($version instanceof MetaData) {
+            // Core-2.0 Spec module
+            $version = $this->get('zikula_extensions_module.api.hook')->getHookContainerInstance($version);
+        }
 
         // Module deletion function. Only execute if the module is initialised.
         if ($modinfo['state'] != ModUtil::STATE_UNINITIALISED) {

--- a/src/system/ExtensionsModule/Api/HookApi.php
+++ b/src/system/ExtensionsModule/Api/HookApi.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright 2015 Zikula Foundation
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Zikula
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+namespace Zikula\ExtensionsModule\Api;
+
+use Symfony\Component\Translation\TranslatorInterface;
+use Zikula\Bundle\CoreBundle\Bundle\MetaData;
+
+class HookApi
+{
+    /**
+     * Provider capability key.
+     */
+    const PROVIDER_TYPE = 'hook_provider';
+
+    /**
+     * Subscriber capability key.
+     */
+    const SUBSCRIBER_TYPE = 'hook_subscriber';
+
+    /**
+     * Allow to provide to self.
+     */
+    const SELF_TYPE = 'subscribe_own';
+    /**
+     * @var \Zikula\Common\Translator\Translator
+     */
+    private $translator;
+
+    /**
+     * HookApi constructor.
+     * @param $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * Factory class to create instance of HookContainer class defined in MetaData::capabilities.
+     * @param MetaData $metaData
+     * @param null $requestedHookType
+     * @return null|\Zikula\Component\HookDispatcher\AbstractContainer
+     */
+    public function getHookContainerInstance(MetaData $metaData, $requestedHookType = null)
+    {
+        foreach ([self::SUBSCRIBER_TYPE, self::PROVIDER_TYPE] as $type) {
+            if (isset($metaData->getCapabilities()[$type]['class'])
+                && (!isset($requestedHookType) || $type == $requestedHookType)) {
+                $hookContainerClassName = $metaData->getCapabilities()[$type]['class'];
+                $reflection = new \ReflectionClass($hookContainerClassName);
+                if ($reflection->isSubclassOf('Zikula\Component\HookDispatcher\AbstractContainer')) {
+
+                    return new $hookContainerClassName($this->translator);
+                }
+            }
+        }
+
+        return null;
+    }
+
+
+}

--- a/src/system/ExtensionsModule/Controller/AdminController.php
+++ b/src/system/ExtensionsModule/Controller/AdminController.php
@@ -38,6 +38,7 @@ use Symfony\Component\Routing\RouterInterface;
 use HookUtil;
 use vierbergenlars\SemVer\expression;
 use vierbergenlars\SemVer\version;
+use Zikula\Bundle\CoreBundle\Bundle\MetaData;
 
 /**
  * No need for a route prefix, as there isn't a user controller.
@@ -1595,6 +1596,10 @@ class AdminController extends \Zikula_AbstractController
         // create an instance of the module's version
         // we will use it to get the bundles
         $moduleVersionObj = ExtensionsUtil::getVersionMeta($moduleName);
+        if ($moduleVersionObj instanceof MetaData) {
+            // Core-2.0 Spec module
+            $moduleVersionObj = $this->get('zikula_extensions_module.api.hook')->getHookContainerInstance($moduleVersionObj);
+        }
 
         // find out the capabilities of the module
         $isProvider = (HookUtil::isProviderCapable($moduleName)) ? true : false;
@@ -1663,6 +1668,10 @@ class AdminController extends \Zikula_AbstractController
 
                 // create an instance of the subscriber's version
                 $hooksubscriberVersionObj = ExtensionsUtil::getVersionMeta($hooksubscribers[$i]['name']);
+                if ($hooksubscriberVersionObj instanceof MetaData) {
+                    // Core-2.0 Spec module
+                    $hooksubscriberVersionObj = $this->get('zikula_extensions_module.api.hook')->getHookContainerInstance($hooksubscriberVersionObj);
+                }
 
                 // get the areas of the subscriber
                 $hooksubscriberAreas = HookUtil::getSubscriberAreasByOwner($hooksubscribers[$i]['name']);
@@ -1719,6 +1728,10 @@ class AdminController extends \Zikula_AbstractController
 
                     // create an instance of the provider's version
                     $sbaProviderModuleVersionObj = ExtensionsUtil::getVersionMeta($sbaProviderModule);
+                    if ($sbaProviderModuleVersionObj instanceof MetaData) {
+                        // Core-2.0 Spec module
+                        $sbaProviderModuleVersionObj = $this->get('zikula_extensions_module.api.hook')->getHookContainerInstance($sbaProviderModuleVersionObj);
+                    }
 
                     // get the bundle title
                     $currentSortingTitles[$areaname] = $this->view->__(/** @Ignore */$sbaProviderModuleVersionObj->getHookProviderBundle($areaname)->getTitle());
@@ -1748,6 +1761,10 @@ class AdminController extends \Zikula_AbstractController
 
                 // create an instance of the provider's version
                 $hookproviderVersionObj = ExtensionsUtil::getVersionMeta($hookproviders[$i]['name']);
+                if ($hookproviderVersionObj instanceof MetaData) {
+                    // Core-2.0 Spec module
+                    $hookproviderVersionObj = $this->get('zikula_extensions_module.api.hook')->getHookContainerInstance($hookproviderVersionObj);
+                }
 
                 // get the areas of the provider
                 $hookproviderAreas = HookUtil::getProviderAreasByOwner($hookproviders[$i]['name']);

--- a/src/system/ExtensionsModule/Resources/config/services.xml
+++ b/src/system/ExtensionsModule/Resources/config/services.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="zikula_extensions_module.api.variable.class">Zikula\ExtensionsModule\Api\VariableApi</parameter>
         <parameter key="zikula_extensions_module.api.extension.class">Zikula\ExtensionsModule\Api\ExtensionApi</parameter>
+        <parameter key="zikula_extensions_module.api.hook.class">Zikula\ExtensionsModule\Api\HookApi</parameter>
         <parameter key="zikula_extensions_module.extension_var_repository.class">Zikula\ExtensionsModule\Entity\Repository\ExtensionVarRepository</parameter>
         <parameter key="zikula_extensions_module.extension_repository.class">Zikula\ExtensionsModule\Entity\Repository\ExtensionRepository</parameter>
     </parameters>
@@ -30,6 +31,10 @@
         <service id="zikula_extensions_module.api.extension" class="%zikula_extensions_module.api.extension.class%">
             <argument type="service" id="zikula_extensions_module.extension_repository"/>
             <argument type="service" id="kernel"/>
+        </service>
+
+        <service id="zikula_extensions_module.api.hook" class="%zikula_extensions_module.api.hook.class%" lazy="true">
+            <argument id="translator" type="service"/>
         </service>
     </services>
 

--- a/src/system/ExtensionsModule/Tests/Api/Fixtures/HookContainer.php
+++ b/src/system/ExtensionsModule/Tests/Api/Fixtures/HookContainer.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright Zikula Foundation 2015 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+namespace Zikula\ExtensionsModule\Tests\Api\Fixtures;
+
+use Zikula\Component\HookDispatcher\AbstractContainer;
+use Zikula\Component\HookDispatcher\SubscriberBundle;
+
+class HookContainer extends AbstractContainer
+{
+    protected function setupHookBundles()
+    {
+        $bundle = new SubscriberBundle('ZikulaBlocksModule', 'foo.area', 'ui_hooks', $this->__('Translatable title'));
+        $bundle->addEvent('form_edit', 'foo.event.name');
+        $this->registerHookSubscriberBundle($bundle);
+    }
+}

--- a/src/system/ExtensionsModule/Tests/Api/HookApiTest.php
+++ b/src/system/ExtensionsModule/Tests/Api/HookApiTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright 2015 Zikula Foundation
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Zikula
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+namespace Zikula\ExtensionsModule\Tests\Api;
+
+use Zikula\Bundle\CoreBundle\Bundle\MetaData;
+use Zikula\ExtensionsModule\Api\HookApi;
+
+class HookApiTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HookApi
+     */
+    private $api;
+
+    public function setUp()
+    {
+        $translator = $this
+            ->getMockBuilder('\Zikula\Common\Translator\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $translator
+            ->method('__')
+            ->willReturnArgument(0);
+        $this->api = new HookApi($translator);
+    }
+
+    public function testGetHookContainerInstance()
+    {
+        $meta = new MetaData($this->getJson());
+        $hookContainerInstance = $this->api->getHookContainerInstance($meta);
+        $this->assertInstanceOf('\Zikula\Component\HookDispatcher\AbstractContainer', $hookContainerInstance);
+        $subscriberBundle = $hookContainerInstance->getHookSubscriberBundle('foo.area');
+
+        $this->assertInstanceOf('\Zikula\Component\HookDispatcher\SubscriberBundle', $subscriberBundle);
+        $this->assertEquals('Translatable title', $subscriberBundle->getTitle());
+        $this->assertEquals('ui_hooks', $subscriberBundle->getCategory());
+        $this->assertEquals('foo.area', $subscriberBundle->getArea());
+
+        $subscriberHookContainerInstance = $this->api->getHookContainerInstance($meta, HookApi::SUBSCRIBER_TYPE);
+        $this->assertEquals($hookContainerInstance, $subscriberHookContainerInstance);
+
+        $this->assertEmpty($hookContainerInstance->getHookProviderBundles());
+
+        $hookEvents = $subscriberBundle->getEvents();
+        $this->assertCount(1, $hookEvents);
+        $this->assertEquals('foo.event.name', $hookEvents['form_edit']);
+    }
+
+    private function getJson()
+    {
+        $jsonArray = [
+            "name" =>  "zikula/specmodule-module",
+            "version" =>  "2.0.0-beta",
+            "description" =>  "A module depicting the Core-2.0.0 Extension specification.",
+            "type" =>  "zikula-module",
+            "license" =>  "MIT",
+            "authors" =>  [
+                "name" =>  "Zikula Team",
+                "homepage" =>  "http => //zikula.org/"
+            ],
+            "autoload" =>  [
+                "psr-4" =>  [ "Zikula\\SpecModule\\" =>  "" ]
+            ],
+            "require" =>  [
+                "php" =>  ">=5.4.1"
+            ],
+            "extra" =>  [
+                "zikula" =>  [
+                    "core-compatibility" =>  ">=1.4.1",
+                    "class" =>  "Zikula\\SpecModule\\ZikulaSpecModule",
+                    "displayname" =>  "SpecModule",
+                    "url" =>  "spec",
+                    "oldnames" =>  [],
+                    "capabilities" =>  [
+                        "hook_subscriber" =>  ["class" =>  "Zikula\\ExtensionsModule\\Tests\\Api\\Fixtures\\HookContainer"]
+                    ],
+                    "securityschema" =>  [
+                        "ZikulaSpecModule::" => "::"
+                    ],
+                    "base-path" => "",
+                    "root-path" => "",
+                    "short-name" => "SpecModule",
+                    "extensionType" => "system"
+                ]
+            ]
+        ];
+
+        return json_decode(json_encode($jsonArray), true);
+    }
+}

--- a/src/system/ExtensionsModule/Util.php
+++ b/src/system/ExtensionsModule/Util.php
@@ -38,7 +38,7 @@ class Util
      *                                          if the version class isn't of the correct type or
      *                                          if the lib directory cannot be found for v1.3 style modules 
      *
-     * @return Zikula_AbstractVersion|array
+     * @return Zikula_AbstractVersion|\Zikula\Bundle\CoreBundle\Bundle\MetaData|array
      */
     public static function getVersionMeta($moduleName, $rootdir = 'modules', $module = null)
     {
@@ -60,7 +60,7 @@ class Util
             }
         } elseif ($module instanceof AbstractModule) {
             // Core-2.0 spec
-            $modversion = $module->getMetaData()->getFilteredVersionInfoArray();
+            $modversion = $module->getMetaData();
         } elseif (!is_dir("$rootdir/$moduleName")) {
             $modversion = array(
                     'name' => $moduleName,


### PR DESCRIPTION
Define a Hook definition Spec for Core-2.0 modules. See [the spec](https://github.com/zikula/core/blob/HooksFromVersionFix/src/docs/Core-2.0/Hooks/definitions.md)

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | #2682, #2687 
| Refs tickets      | -
| License           | MIT
| Doc PR            | included
| Changelog updated | yes

 - implements ArrayAccess in MetaData to improve ease of access.
 - modifies how AbstractExtensionInstaller implements dependencies to use ContainerAware
 - creates a HookApi complete with docs and tests.
 - fixes BlocksModule\Helper\HookHelper to rename it to HookContainer