### PR TITLE
Adding conditional statement for addCollapseableBehavior in Blocks

### DIFF
--- a/src/system/BlocksModule/Listener/CollapseableBlockListener.php
+++ b/src/system/BlocksModule/Listener/CollapseableBlockListener.php
@@ -16,6 +16,7 @@ namespace Zikula\BlocksModule\Listener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use System;
 use Zikula\ThemeModule\Engine\Asset;
 use Zikula\ThemeModule\Engine\AssetBag;
 use Zikula\ExtensionsModule\Api\VariableApi;
@@ -42,6 +43,9 @@ class CollapseableBlockListener implements EventSubscriberInterface
      */
     public function addCollapseableBehavior(GetResponseEvent $event)
     {
+        if ((System::isInstalling()) || (System::isUpgrading())) {
+            return;
+        }
         if (!$event->isMasterRequest()) {
             return;
         }


### PR DESCRIPTION
Adding conditional statement for addCollapseableBehavior in Blocks, so database query is not executed during Zikula core install/upgrade.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | https://github.com/zikula/core/issues/2764
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | no