### PR TITLE
Change getPluralOffset to return numbers and not boolean values

### DIFF
--- a/src/javascript/helpers/Zikula.js
+++ b/src/javascript/helpers/Zikula.js
@@ -868,6 +868,13 @@ Zikula.Gettext = Class.create(/** @lends Zikula.Gettext.prototype */{
             eq = this.defaults.pluralForms;
             eval(eq);
         }
+        
+        if(plural === false){
+            plural = 0;
+        }else{
+            plural = 1;
+        }
+        
         if (plural >= nplurals) {
             plural = nplurals - 1;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| 1.4 PR        | -
| Refs tickets  | -
| License       | LGPLv3+
| Doc PR        | -

- [ ] check 1.4

With this change the function getPluralOffset will return numbers and not boolean values. This change is required because the function getPluralMessage uses this value as offset to access array keys.