### PR TITLE
Fix problem with new adminMenu category display

### DIFF
--- a/src/lib/Zikula/Bundle/HookBundle/Controller/HookController.php
+++ b/src/lib/Zikula/Bundle/HookBundle/Controller/HookController.php
@@ -270,6 +270,10 @@ class HookController extends Controller
             $templateParameters['hookproviders'] = [];
         }
         $templateParameters['hookDispatcher'] = $this->get('hook_dispatcher');
+        $request = $this->get('request_stack')->getCurrentRequest();
+        $request->attributes->set('_zkModule', $moduleName);
+        $request->attributes->set('_zkType', 'admin');
+        $request->attributes->set('_zkFunc', 'Hooks');
 
         return $templateParameters;
     }

--- a/src/lib/Zikula/Bundle/HookBundle/Resources/views/Hook/edit.html.twig
+++ b/src/lib/Zikula/Bundle/HookBundle/Resources/views/Hook/edit.html.twig
@@ -6,7 +6,7 @@
     {% set showBothPanels = true %}
 {% endif %}
 
-{{ render(controller('ZikulaAdminModule:Admin:adminheader')) }}
+{{ adminHeader() }}
 <h3>
     <span class="fa fa-paperclip"></span>
     {{ __('Hooks') }}
@@ -53,7 +53,7 @@
     {% endif %}
 {% endif %}
 
-{{ render(controller('ZikulaAdminModule:Admin:adminfooter')) }}
+{{ adminFooter() }}
 {% if isSubscriber %}
     {#{pageaddvarblock}#}{# @TODO #}
     <script type="text/javascript">

--- a/src/system/AdminModule/AdminModuleInstaller.php
+++ b/src/system/AdminModule/AdminModuleInstaller.php
@@ -73,6 +73,16 @@ class AdminModuleInstaller extends \Zikula_AbstractInstaller
         // Upgrade dependent on old version number
         switch ($oldversion) {
             case '1.9.1':
+                // ensure there is a proper sortorder for modulecategories
+                // has the sort order already been set?
+                $categories = $this->entityManager->getRepository('ZikulaAdminModule:AdminCategoryEntity')->findBy(['sortorder' => 0]);
+                if (count($categories) > 1) {
+                    // sort categories by id
+                    $dql = "UPDATE Zikula\\AdminModule\\Entity\\AdminCategoryEntity ac SET ac.sortorder = ac.cid - 1";
+                    $query = $this->entityManager->createQuery($dql);
+                    $query->execute();
+                }
+            case '1.9.2':
             // future upgrade routines
         }
 
@@ -103,19 +113,38 @@ class AdminModuleInstaller extends \Zikula_AbstractInstaller
      */
     public function defaultdata()
     {
-        $records = array(
-                    array('name'     => $this->__('System'),
-                          'description' => $this->__('Core modules at the heart of operation of the site.')),
-                    array('name'     => $this->__('Layout'),
-                          'description' => $this->__("Layout modules for controlling the site's look and feel.")),
-                    array('name'     => $this->__('Users'),
-                          'description' => $this->__('Modules for controlling user membership, access rights and profiles.')),
-                    array('name'     => $this->__('Content'),
-                          'description' => $this->__('Modules for providing content to your users.')),
-                    array('name'     => $this->__('Uncategorised'),
-                          'description' => $this->__('Newly-installed or uncategorized modules.')),
-                    array('name'     => $this->__('Security'),
-                          'description' => $this->__('Modules for managing the site\'s security.')));
+        $records = [
+            [
+                'name' => $this->__('System'),
+                'description' => $this->__('Core modules at the heart of operation of the site.'),
+                'sortorder' => 0
+            ],
+            [
+                'name' => $this->__('Layout'),
+                'description' => $this->__("Layout modules for controlling the site's look and feel."),
+                'sortorder' => 1
+            ],
+            [
+                'name' => $this->__('Users'),
+                'description' => $this->__('Modules for controlling user membership, access rights and profiles.'),
+                'sortorder' => 2
+            ],
+            [
+                'name' => $this->__('Content'),
+                'description' => $this->__('Modules for providing content to your users.'),
+                'sortorder' => 3
+            ],
+            [
+                'name' => $this->__('Uncategorised'),
+                'description' => $this->__('Newly-installed or uncategorized modules.'),
+                'sortorder' => 4
+            ],
+            [
+                'name' => $this->__('Security'),
+                'description' => $this->__('Modules for managing the site\'s security.'),
+                'sortorder' => 5
+            ]
+        ];
 
         foreach ($records as $record) {
             $item = new AdminCategoryEntity();

--- a/src/system/AdminModule/AdminModuleVersion.php
+++ b/src/system/AdminModule/AdminModuleVersion.php
@@ -29,7 +29,7 @@ class AdminModuleVersion extends \Zikula_AbstractVersion
         $meta['displayname']    = $this->__('Administration panel');
         $meta['description']    = $this->__('Backend administration interface.');
         $meta['url']            = $this->__('adminpanel');
-        $meta['version']        = '1.9.1';
+        $meta['version']        = '1.9.2';
         $meta['core_min']       = '1.4.0';
         $meta['securityschema'] = array('ZikulaAdminModule::' => 'Admin Category name::Admin Category ID');
 

--- a/src/system/AdminModule/Entity/AdminCategoryEntity.php
+++ b/src/system/AdminModule/Entity/AdminCategoryEntity.php
@@ -21,7 +21,7 @@ use Zikula\Core\Doctrine\EntityAccess;
  *
  * We use annotations to define the entity mappings to database (see http://www.doctrine-project.org/docs/orm/2.1/en/reference/basic-mapping.html).
  *
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="Zikula\AdminModule\Entity\Repository\AdminCategoryRepository")
  * @ORM\Table(name="admin_category")
  */
 class AdminCategoryEntity extends EntityAccess

--- a/src/system/AdminModule/Entity/Repository/AdminCategoryRepository.php
+++ b/src/system/AdminModule/Entity/Repository/AdminCategoryRepository.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright Zikula Foundation 2016 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license GNU/LGPLv3 (or at your option, any later version).
+ * @package Zikula_Form
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+namespace Zikula\AdminModule\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class AdminCategoryRepository extends EntityRepository
+{
+    public function getIndexedCollection($indexBy)
+    {
+        $collection = $this->getEntityManager()->createQueryBuilder()
+            ->select('ac')
+            ->from($this->_entityName, 'ac', 'ac.' . $indexBy)
+            ->getQuery()
+            ->getResult();
+
+        return $collection;
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | yes
| Fixed tickets     | #2797
| Refs tickets      | -
| License           | MIT
| Doc PR            | -
| Changelog updated | not needed

 - sortorder now set on installation. Lack of this prevented correct sorting in new adminMenu.
 - improve performance of adminMenu
 - add empty categories to adminMenu display
 - made adminMenu work in Hook controller

fixes #2797