### PR TITLE
Added vagrant support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@
 /src/vendor/
 /src/web/*
 /src/ztemp/
+
+/.vagrant

--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -49,14 +49,15 @@ CHANGELOG - ZIKULA 1.4.x
     - Add CsrfTokenHandler service (`\Zikula\Core\Token\CsrfTokenHandler`)
     - Add 'info' type flash messages.
     - Add CLI Symfony Styleguide to CLI install and upgrade (#2667)
+    - Add Vagrant support (#2814)
  - Core-2.0 Features:
     - Add AdminInterfaceController and Twig tags - AdminModule
         - Refactored functions header, footer, breadcrumbs
-        - menu - replace old categorymenu action - supports both categries and modules mode as well as panel and tabs templates. 
-        - add updatecheck, securityanalyzer, developernotices instead of notices 
+        - menu - replace old categorymenu action - supports both categries and modules mode as well as panel and tabs templates.
+        - add updatecheck, securityanalyzer, developernotices instead of notices
     - Add ExtensionsInterfaceController and Twig tags - ExtensionsModule
         - Refactor functions header, links
-        - Introduce footer, breadcrumbs and help - not fully functional 
+        - Introduce footer, breadcrumbs and help - not fully functional
     - Add `currentUser` global variable to twig templates.
     - Add (move) `Zikula\CategoriesModule\Entity\AbstractCategoryAssignment` and related documentation.
         - Replaces `Zikula\Core\Doctrine\Entity\AbstractEntityCategory` (aliased for BC).
@@ -112,7 +113,7 @@ CHANGELOG - ZIKULA 1.4.x
     - Add vierbergenlars/php-semver vendor lib for version comparison (#2560)
     - Combined and customized bootstrap/font-awesome css using Less.
     - Improved multilingual UI in general settings (#2547)
-    - [Imagine Plugin] Possibility to add transformations which are applied after the thumbnail 
+    - [Imagine Plugin] Possibility to add transformations which are applied after the thumbnail
         is generated. (#2594)
     - Add umask support
  - Core-2.0 Features:
@@ -193,7 +194,7 @@ CHANGELOG - ZIKULA 1.4.x
       - Switched to Symfony error handling.
       - Switched to HttpKernel request cycle.
       - [FORWARD COMPAT] Added forward compatibility layer with Symfony2 HttpFoundation
-    
+
         - `$request->isGet/Post()` should be replaced with `$request->isMethod('GET/POST')`.
         - The GET request is available from `$request->query->get()` and POST from
           `$request->request->get()`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Zikula Core - Application Framework
   2. [Requirements](#requirements)
   3. [Before installing](#beforeinstalling)
   4. [Installing](#installing)
-  5. [Contributing](#contributing)
+  5. [Vagrant installation](#vagrant)
+  6. [Contributing](#contributing)
 
 <a name="introduction"></a>
 Introduction
@@ -62,6 +63,16 @@ Once all of the pre-install steps are complete, choose an installation method:
   1) CLI install: `cd` to zikula root and run `php app/console zikula:install:start`
   2) HTTP install: Run `http://yoursiteurl/install` and follow any on-screen prompts.
 
+<a name="vagrant"></a>
+Vagrant installation
+--------------------
+You can use vagrant to easily setup a complete Zikula development environment.
+All you need to do is install [Vagrant](https://vagrantup.com) and
+[VirtualBox](https://www.virtualbox.org/). Then run `vagrant up` inside the
+cloned repository and wait for the machine to boot (first time booting might
+take several minutes). Then head over to `localhost:8080` and install Zikula.
+Database user, password and table are all set to `zikula`. PHPMyAdmin is
+accessible from `localhost:8081`.
 
 <a name="contributing"></a>
 Contributing
@@ -73,8 +84,8 @@ Contributions can be made to Zikula in a number of ways
   2. Assisting other users at the [user community site](http://zikula.org/forum/)
   3. Creating themes for Zikula.
   4. Authoring additional modules for Zikula. Please see our [developer documentation](https://github.com/zikula/core/tree/1.4/src/docs/en/dev)
-  5. Contributing bug fixes and patches to the Core. 
-  
+  5. Contributing bug fixes and patches to the Core.
+
 Pull requests are welcome, please see https://github.com/zikula/core/wiki/Contributing.
 
 All pull requests must follow [this template](https://github.com/zikula/core/wiki/Contributing#pull-request-template)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.network :forwarded_port, guest: 80, host: 8080
+  config.vm.network :forwarded_port, guest: 81, host: 8081
+
+  config.vm.network "private_network", type: "dhcp"
+
+  config.vm.synced_folder ".", "/vagrant", :nfs => true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # View the documentation for the provider you are using for more
+  # information on available options.
+  config.vm.provider :virtualbox do |v|
+      v.memory = 2048
+      v.name = "Zikula Core"
+      v.cpus = 1
+  end
+
+  config.vm.provision :shell, :path => "vagrant-bootstrap.sh"
+end

--- a/vagrant-bootstrap.sh
+++ b/vagrant-bootstrap.sh
@@ -1,0 +1,119 @@
+#! /usr/bin/env bash
+# Based on https://gist.github.com/rrosiek/8190550
+# by Ryan Rosiek
+
+# Variables
+DBHOST=localhost
+DBNAME=zikula
+DBUSER=zikula
+DBPASSWD=zikula
+
+echo -e "\n--- Mkay, installing now... ---\n"
+
+echo -e "\n--- Updating packages list ---\n"
+apt-get -qq update
+
+echo -e "\n--- Install base packages ---\n"
+apt-get -y install vim curl build-essential python-software-properties git > /dev/null 2>&1
+
+echo -e "\n--- Add some repos to update our distro ---\n"
+add-apt-repository ppa:ondrej/php5 > /dev/null 2>&1
+add-apt-repository ppa:chris-lea/node.js > /dev/null 2>&1
+
+echo -e "\n--- Updating packages list ---\n"
+apt-get -qq update
+
+echo -e "\n--- Install MySQL specific packages and settings ---\n"
+echo "mysql-server mysql-server/root_password password $DBPASSWD" | debconf-set-selections
+echo "mysql-server mysql-server/root_password_again password $DBPASSWD" | debconf-set-selections
+echo "phpmyadmin phpmyadmin/dbconfig-install boolean true" | debconf-set-selections
+echo "phpmyadmin phpmyadmin/app-password-confirm password $DBPASSWD" | debconf-set-selections
+echo "phpmyadmin phpmyadmin/mysql/admin-pass password $DBPASSWD" | debconf-set-selections
+echo "phpmyadmin phpmyadmin/mysql/app-pass password $DBPASSWD" | debconf-set-selections
+echo "phpmyadmin phpmyadmin/reconfigure-webserver multiselect none" | debconf-set-selections
+apt-get -y install mysql-server-5.6 phpmyadmin > /dev/null 2>&1
+
+echo -e "\n--- Setting up our MySQL user and db ---\n"
+mysql -uroot -p$DBPASSWD -e "CREATE DATABASE $DBNAME"
+mysql -uroot -p$DBPASSWD -e "grant all privileges on $DBNAME.* to '$DBUSER'@'localhost' identified by '$DBPASSWD'"
+
+echo -e "\n--- Installing PHP-specific packages ---\n"
+apt-get -y install php5 apache2 libapache2-mod-php5 php5-curl php5-gd php5-mcrypt php5-mysql php-apc > /dev/null 2>&1
+
+echo -e "\n--- Enabling mod-rewrite ---\n"
+a2enmod rewrite > /dev/null 2>&1
+
+echo -e "\n--- Allowing Apache override to all ---\n"
+sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf
+
+echo -e "\n--- Setting document root to public directory ---\n"
+rm -rf /var/www
+ln -fs /vagrant/src /var/www
+
+echo -e "\n--- We definitly need to see the PHP errors, turning them on ---\n"
+sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php5/apache2/php.ini
+sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/apache2/php.ini
+
+echo -e "\n--- We also need to set the default timezone. ---\n"
+sed -i "s/^;date.timezone =$/date.timezone = \"Europe\/Berlin\"/" /etc/php5/apache2/php.ini
+
+echo -e "\n--- Configure Apache to use phpmyadmin ---\n"
+echo -e "\n\nListen 81\n" >> /etc/apache2/ports.conf
+cat > /etc/apache2/conf-available/phpmyadmin.conf << "EOF"
+<VirtualHost *:81>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /usr/share/phpmyadmin
+    DirectoryIndex index.php
+    ErrorLog ${APACHE_LOG_DIR}/phpmyadmin-error.log
+    CustomLog ${APACHE_LOG_DIR}/phpmyadmin-access.log combined
+</VirtualHost>
+EOF
+a2enconf phpmyadmin > /dev/null 2>&1
+
+echo -e "\n--- Add environment variables to Apache ---\n"
+cat > /etc/apache2/sites-enabled/000-default.conf <<EOF
+<VirtualHost *:80>
+    DocumentRoot /var/www
+    ErrorLog \${APACHE_LOG_DIR}/error.log
+    CustomLog \${APACHE_LOG_DIR}/access.log combined
+    SetEnv DB_HOST $DBHOST
+    SetEnv DB_NAME $DBNAME
+    SetEnv DB_USER $DBUSER
+    SetEnv DB_PASS $DBPASSWD
+</VirtualHost>
+EOF
+
+echo -e "\n--- Restarting Apache ---\n"
+service apache2 restart > /dev/null 2>&1
+
+echo -e "\n--- Installing Composer for PHP package management ---\n"
+curl --silent https://getcomposer.org/installer | php
+mv composer.phar /usr/local/bin/composer
+
+echo -e "\n--- Installing PHPUnit ---\n"
+curl --silent -L https://phar.phpunit.de/phpunit.phar > phpunit.phar
+mv phpunit.phar /usr/local/bin/phpunit
+
+echo -e "\n--- Installing NodeJS and NPM ---\n"
+apt-get -y install nodejs > /dev/null 2>&1
+curl --silent https://npmjs.org/install.sh | sh > /dev/null 2>&1
+
+echo -e "\n--- Installing javascript components ---\n"
+npm install -g gulp bower > /dev/null 2>&1
+
+echo -e "\n--- Installing utilities ---\n"
+npm install -g how2 > /dev/null 2>&1
+
+echo -e "\n--- Updating project components and pulling latest versions ---\n"
+cd /vagrant
+sudo -u vagrant -H sh -c "composer install"
+
+echo -e "\n--- Add environment variables locally ---\n"
+cat >> /home/vagrant/.bashrc <<EOF
+# Set envvars
+export DB_HOST=$DBHOST
+export DB_NAME=$DBNAME
+export DB_USER=$DBUSER
+export DB_PASS=$DBPASSWD
+cd /vagrant
+EOF


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | ---
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Doc PR            | ---
| Changelog updated | yes

This allows you to reliably setup a complete Zikula development environment based on an Ubuntu VM with just a single command: `vagrant up`.