### PR TITLE
Don't use PHP_VERSION constant

### DIFF
--- a/src/system/ExtensionsModule/Helper/ExtensionDependencyHelper.php
+++ b/src/system/ExtensionsModule/Helper/ExtensionDependencyHelper.php
@@ -140,7 +140,9 @@ class ExtensionDependencyHelper
     private function bundleDependencySatisfied(ExtensionDependencyEntity &$dependency)
     {
         if ($dependency->getModname() == "php") {
-            $phpVersion = new version(PHP_VERSION);
+            // Do not use PHP_VERSION constant, because it might throw off
+            // the semver parser.
+            $phpVersion = new version(PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "." . PHP_RELEASE_VERSION);
             $requiredVersionExpression = new expression($dependency->getMinversion());
 
             if (!$requiredVersionExpression->satisfiedBy($phpVersion)) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Tests pass?       | ---
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Doc PR            | ---
| Changelog updated | no

`PHP_VERSION` is `5.5.33-1+deb.sury.org~trusty+2` in my case which the semver parser can't handle.