### PR TITLE
Fix output of theme maincontent to NOT automatically include a unique div

### DIFF
--- a/src/system/ThemeModule/AbstractTheme.php
+++ b/src/system/ThemeModule/AbstractTheme.php
@@ -44,13 +44,21 @@ abstract class AbstractTheme extends AbstractBundle
 
     /**
      * generate a response wrapped in the theme
+     *   wrap the maincontent in a unique div.
      * @param string $realm
      * @param Response $response
+     * @param string $moduleName
      * @return Response
      */
-    public function generateThemedResponse($realm, Response $response)
+    public function generateThemedResponse($realm, Response $response, $moduleName = null)
     {
         $template = $this->config[$realm]['page'];
+        $content = '<div id="z-maincontent" class="'
+            . ($realm == 'home' ? 'z-homepage' : '')
+            . (isset($moduleName) ? ' z-module-' . strtolower($moduleName)  : '') . '">'
+            . $response->getContent()
+            . '</div>';
+        $response->setContent($content);
 
         return $this->getContainer()->get('templating')->renderResponse($this->name . ':' . $template, array('maincontent' => $response->getContent()));
     }

--- a/src/system/ThemeModule/Engine/Engine.php
+++ b/src/system/ThemeModule/Engine/Engine.php
@@ -120,17 +120,9 @@ class Engine
         if (!isset($activeTheme) || !$activeTheme->isTwigBased()) {
             return false;
         }
-        // wrap page in unique div
-        $realm = $this->getRealm();
-        $attributes = $this->requestStack->getMasterRequest()->attributes->all();
-        $content = '<div id="z-maincontent" class="'
-            . ($realm == 'home' ? 'z-homepage' : '')
-            . (isset($attributes['_zkModule']) ? ' z-module-' . strtolower($attributes['_zkModule'])  : '') . '">'
-            . $response->getContent()
-            . '</div>';
-        $response->setContent($content);
 
-        $themedResponse = $activeTheme->generateThemedResponse($realm, $response);
+        $moduleName = $this->requestStack->getMasterRequest()->attributes->get('_zkModule');
+        $themedResponse = $activeTheme->generateThemedResponse($this->getRealm(), $response, $moduleName);
         $filteredResponse = $this->filter($themedResponse);
 
         return $filteredResponse;


### PR DESCRIPTION
Fix output of theme maincontent to NOT automatically include a unique div wrapper. Move wrapper to AbstractTheme.

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | #2819
| License           | MIT
| Changelog updated | no