### PR TITLE
Rss / Theme permission fixes

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -38,6 +38,7 @@ CHANGELOG - ZIKULA 1.4.x
     - Fix problems with legacy Themes (#2777)
     - Fix post installation login (#2187)
     - Improved compatibility of zikula-specific bootstrap overrides with respect to navbars.
+    - Improved handling of 'utility' themes via GET and add ability to restrict access via permissions on a more granular level.
  - Features:
     - Add new advanced block filtering based on a combination of any query parameter or request attributes.
     - Add core routing for all legacy urls (both normal and 'shorturls').

--- a/src/docs/Admin/ThemeChangePermissions.md
+++ b/src/docs/Admin/ThemeChangePermissions.md
@@ -1,0 +1,13 @@
+Allowing Themes to Change via Permissions
+=========================================
+
+Upon installation, a permissions rule is set up to allow any user to change the theme for three "utility" themes:
+
+    ZikulaThemeModule::ThemeChange    :(ZikulaRssTheme|ZikulaPrinterTheme|ZikulaAtomTheme):    ACCESS_COMMENT
+
+This means that Rss Feeds will work properly for users that are not logged in, etc.
+
+This rule can be optionally eliminated or changed based on the needs of the site.
+
+For a theme to be accessible via GET (e.g. `index.php?theme=ZikulaRssTheme`) the user must have `ACCESS_COMMENT`
+permissions access.

--- a/src/lib/util/UserUtil.php
+++ b/src/lib/util/UserUtil.php
@@ -1847,7 +1847,11 @@ class UserUtil
         $request = \ServiceUtil::get('request');
 
         $theme = FormUtil::getPassedValue('theme', null, 'GETPOST');
-        if (!empty($theme) && SecurityUtil::checkPermission('ZikulaThemeModule::ThemeChange', '::', ACCESS_COMMENT)) {
+        $themeinfo = ThemeUtil::getInfo(ThemeUtil::getIDFromName($theme));
+        if (!empty($theme) && (
+                SecurityUtil::checkPermission('ZikulaThemeModule::ThemeChange', ':' . $themeinfo['name'] . ':', ACCESS_COMMENT) ||
+                SecurityUtil::checkPermission('ZikulaThemeModule::ThemeChange', ':' . $themeinfo['displayname'] . ':', ACCESS_COMMENT))
+        ) {
             // theme passed as parameter takes priority, can be RSS, Atom, Printer or other
             $pagetheme = $theme;
         } else {
@@ -1871,9 +1875,7 @@ class UserUtil
         }
 
         // Page-specific theme
-        $qstring = System::serverGetVar('QUERY_STRING');
         if (!empty($pagetheme)) {
-            $themeinfo = ThemeUtil::getInfo(ThemeUtil::getIDFromName($pagetheme));
             if ($themeinfo['state'] == ThemeUtil::STATE_ACTIVE
                 && ($themeinfo['user']
                     || $themeinfo['system']

--- a/src/system/PermissionsModule/PermissionsModuleInstaller.php
+++ b/src/system/PermissionsModule/PermissionsModuleInstaller.php
@@ -58,7 +58,23 @@ class PermissionsModuleInstaller extends \Zikula_AbstractInstaller
     {
         // Upgrade dependent on old version number
         switch ($oldversion) {
-            case '1.1':
+            case '1.1.1':
+                $lastPerm = $this->entityManager->getRepository('ZikulaPermissionsModule:PermissionEntity')->findOneBy([], ['sequence' => 'DESC']);
+                // allow access to non-html themes
+                $record = new PermissionEntity();
+                $record['gid']       = -1;
+                $record['sequence']  = $lastPerm->getSequence();
+                $record['realm']     = 0;
+                $record['component'] = 'ZikulaThemeModule::ThemeChange';
+                $record['instance']  = ':(ZikulaRssTheme|ZikulaPrinterTheme|ZikulaAtomTheme):';
+                $record['level']     = ACCESS_COMMENT; // 300
+                $record['bond']      = 0;
+                $this->entityManager->persist($record);
+                $lastPerm->setSequence($record->getSequence() + 1);
+                $this->entityManager->flush();
+                $this->get('session')->addMessage('success', $this->__('A permission rule was added to allow users access to "utility" themes. Please check the sequence.'));
+
+            case '1.1.2':
             // future upgrade routines
         }
 
@@ -100,6 +116,17 @@ class PermissionsModuleInstaller extends \Zikula_AbstractInstaller
         $record['component'] = '.*';
         $record['instance']  = '.*';
         $record['level']     = ACCESS_ADMIN; // 800
+        $record['bond']      = 0;
+        $this->entityManager->persist($record);
+
+        // allow access to non-html themes
+        $record = new PermissionEntity();
+        $record['gid']       = -1;
+        $record['sequence']  = 2;
+        $record['realm']     = 0;
+        $record['component'] = 'ZikulaThemeModule::ThemeChange';
+        $record['instance']  = ':(ZikulaRssTheme|ZikulaPrinterTheme|ZikulaAtomTheme):';
+        $record['level']     = ACCESS_COMMENT; // 300
         $record['bond']      = 0;
         $this->entityManager->persist($record);
 

--- a/src/system/PermissionsModule/PermissionsModuleVersion.php
+++ b/src/system/PermissionsModule/PermissionsModuleVersion.php
@@ -30,7 +30,7 @@ class PermissionsModuleVersion extends \Zikula_AbstractVersion
         $meta['description'] = $this->__('User permissions manager.');
         //! module name that appears in URL
         $meta['url'] = $this->__('permissions');
-        $meta['version'] = '1.1.1';
+        $meta['version'] = '1.1.2';
         $meta['core_min'] = '1.4.0';
         $meta['securityschema'] = array('ZikulaPermissionsModule::' => '::');
 

--- a/src/system/ThemeModule/Engine/Engine.php
+++ b/src/system/ThemeModule/Engine/Engine.php
@@ -368,9 +368,8 @@ class Engine
     /**
      * Set the theme based on:
      *  1) manual setting
-     *  2) the request params (e.g. `?theme=MySpecialTheme`)
-     *  3) the request attributes (e.g. `_theme`)
-     *  4) the default system theme
+     *  2) the request attributes (e.g. `_theme`) @deprecated
+     *  3) the default system theme
      * @param string|null $newThemeName
      * @return mixed
      * kernel::getTheme() @throws \InvalidArgumentException if theme is invalid.
@@ -380,11 +379,8 @@ class Engine
         $activeTheme = !empty($newThemeName) ? $newThemeName : $this->variableApi->get(VariableApi::CONFIG, 'Default_Theme');
         $request = $this->requestStack->getMasterRequest();
         if (isset($request)) {
-            // @todo do we want to allow changing the theme by the request?
-            $themeByRequest = $request->get('theme', null);
-            if (!empty($themeByRequest)) {
-                $activeTheme = $themeByRequest;
-            }
+            // This allows for setting the theme via the old method in \UserUtil::getTheme and check permissions
+            // This method is @deprecated and will be removed in Core-2.0
             $themeByRequest = $request->attributes->get('_theme');
             if (!empty($themeByRequest)) {
                 $activeTheme = $themeByRequest;

--- a/src/system/ThemeModule/composer.json
+++ b/src/system/ThemeModule/composer.json
@@ -28,8 +28,8 @@
                 "user": {"route": "zikulathememodule_user_index"}
             },
             "securityschema": {
-                "ZikulaThemeModule::": "Theme name::",
-                "ZikulaThemeModule::ThemeChange": "::"
+                "ZikulaThemeModule::": "ThemeName::",
+                "ZikulaThemeModule::ThemeChange": ":(ThemeName|ThemeName):"
             }
         }
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | ---
| Refs tickets      | #2819, #1776
| License           | MIT
| Changelog updated | not yet

## Description
This adds a new default permission allowing everyone to change to RSS, Atom and Printer themes. It also includes the theme name in the theme change permission check.

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog
- [x] Test installation
- [x] Write upgrade procedure