### PR TITLE
Use admin interface controller directly

### DIFF
--- a/src/system/AdminModule/Resources/views/plugins/function.adminfooter.php
+++ b/src/system/AdminModule/Resources/views/plugins/function.adminfooter.php
@@ -24,11 +24,11 @@ function smarty_function_adminfooter($params, \Zikula_View $view)
     // check to make sure adminmodule is available and route is available
     $router = $view->getContainer()->get('router');
     try {
-        $router->generate('zikulaadminmodule_admin_adminfooter');
+        $router->generate('zikulaadminmodule_admininterface_footer');
     } catch (\Symfony\Component\Routing\Exception\RouteNotFoundException $e) {
         return '';
     }
-    $path = ['_controller' => 'ZikulaAdminModule:Admin:adminfooter'];
+    $path = ['_controller' => 'ZikulaAdminModule:AdminInterface:footer'];
     $subRequest = $view->getRequest()->duplicate([], null, $path);
 
     return $view->getContainer()

--- a/src/system/AdminModule/Resources/views/plugins/function.adminheader.php
+++ b/src/system/AdminModule/Resources/views/plugins/function.adminheader.php
@@ -24,14 +24,14 @@ function smarty_function_adminheader($params, $view)
     // check to make sure adminmodule is available and route is available
     $router = $view->getContainer()->get('router');
     try {
-        $router->generate('zikulaadminmodule_admin_adminheader');
+        $router->generate('zikulaadminmodule_admininterface_header');
     } catch (\Symfony\Component\Routing\Exception\RouteNotFoundException $e) {
         $url = $view->getContainer()->get('router')->generate('zikularoutesmodule_route_reload', ['lct' => 'admin', 'confirm' => 1]);
 
         return '<div class="alert alert-danger"><i class="fa fa-exclamation-triangle fa-2x"></i> ' . __f('Routes must be reloaded. Click %s to reload all routes.', "<a href='$url'>" . __('here') . '</a>') . '</div>';
     }
 
-    $path = ['_controller' => 'ZikulaAdminModule:Admin:adminheader'];
+    $path = ['_controller' => 'ZikulaAdminModule:AdminInterface:header'];
     $subRequest = $view->getRequest()->duplicate([], null, $path);
 
     return $view->getContainer()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description
This PR avoids a useless indirection by calling the legacy `admin` controller header/footer.
