### PR TITLE
fixed translator usage in Extensions form types

### DIFF
--- a/src/system/ExtensionsModule/Controller/ConfigController.php
+++ b/src/system/ExtensionsModule/Controller/ConfigController.php
@@ -42,7 +42,8 @@ class ConfigController extends AbstractController
         }
 
         $form = $this->createFormBuilder($this->getVars())
-            ->add('itemsperpage', 'Symfony\Component\Form\Extension\Core\Type\IntegerType', ['label' => $this->__('Items per page'),
+            ->add('itemsperpage', 'Symfony\Component\Form\Extension\Core\Type\IntegerType', [
+                'label' => $this->__('Items per page'),
                 'constraints' => [
                     new NotBlank(),
                     new GreaterThan(0)

--- a/src/system/ExtensionsModule/Controller/ModuleController.php
+++ b/src/system/ExtensionsModule/Controller/ModuleController.php
@@ -177,11 +177,11 @@ class ModuleController extends AbstractController
             $extension->setDescription($metaData['description']);
         }
 
-        $form = $this->createForm('Zikula\ExtensionsModule\Form\Type\ExtensionModifyType', $extension);
+        $form = $this->createForm('Zikula\ExtensionsModule\Form\Type\ExtensionModifyType', $extension, [
+            'translator' => $this->get('translator.default')
+        ]);
 
-        $form->handleRequest($request);
-
-        if ($form->isValid()) {
+        if ($form->handleRequest($request)->isValid()) {
             if ($form->get('defaults')->isClicked()) {
                 $this->addFlash('info', $this->__('Default values reloaded. Save to confirm.'));
 
@@ -243,10 +243,13 @@ class ModuleController extends AbstractController
     public function installAction(Request $request, ExtensionEntity $extension)
     {
         $unsatisfiedDependencies = $this->get('zikula_extensions_module.extension_dependency_helper')->getUnsatisfiedExtensionDependencies($extension);
-        $form = $this->createForm('Zikula\ExtensionsModule\Form\Type\ExtensionInstallType', ['dependencies' => $this->formatDependencyCheckboxArray($unsatisfiedDependencies)]);
-        $form->handleRequest($request);
+        $form = $this->createForm('Zikula\ExtensionsModule\Form\Type\ExtensionInstallType', [
+            'dependencies' => $this->formatDependencyCheckboxArray($unsatisfiedDependencies)
+        ], [
+            'translator' => $this->get('translator.default')
+        ]);
 
-        if ($form->isValid() || empty($unsatisfiedDependencies)) {
+        if ($form->handleRequest($request)->isValid() || empty($unsatisfiedDependencies)) {
             if ($form->get('install')->isClicked() || empty($unsatisfiedDependencies)) {
                 $extensionsInstalled = [];
                 $data = $form->getData();
@@ -402,9 +405,8 @@ class ModuleController extends AbstractController
                 ]
             ])
             ->getForm();
-        $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->handleRequest($request)->isValid()) {
             if ($form->get('uninstall')->isClicked()) {
                 // remove dependent extensions
                 if (!$this->get('zikula_extensions_module.extension_helper')->uninstallArray($requiredDependents)) {

--- a/src/system/ExtensionsModule/Form/Type/ExtensionInstallType.php
+++ b/src/system/ExtensionsModule/Form/Type/ExtensionInstallType.php
@@ -12,24 +12,33 @@ namespace Zikula\ExtensionsModule\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * Extension installation form type.
+ */
 class ExtensionInstallType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $translator = $options['translator'];
+
         $builder
             ->add('dependencies', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', [
                 'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\CheckboxType',
             ])
             ->add('install', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', [
-                'label' => $this->__('Install'),
+                'label' => $translator->__('Install'),
                 'icon' => 'fa-plus',
                 'attr' => [
                     'class' => 'btn btn-success'
                 ]
             ])
             ->add('cancel', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', [
-                'label' => $this->__('Cancel'),
+                'label' => $translator->__('Cancel'),
                 'icon' => 'fa-times',
                 'attr' => [
                     'class' => 'btn btn-default'
@@ -38,8 +47,21 @@ class ExtensionInstallType extends AbstractType
         ;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getBlockPrefix()
     {
         return 'zikulaextensionsmodule_extensioninstall';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translator' => null
+        ]);
     }
 }

--- a/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
+++ b/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
@@ -14,31 +14,39 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * Extension modification form type.
+ */
 class ExtensionModifyType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $translator = $options['translator'];
+
         $builder
             ->add('id', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
             ->add('displayname', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->add('url', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->add('description', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->add('save', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', [
-                'label' => $this->__('Save'),
+                'label' => $translator->__('Save'),
                 'icon' => 'fa-check',
                 'attr' => [
                     'class' => 'btn btn-success'
                 ]
             ])
             ->add('defaults', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', [
-                'label' => $this->__('Reload Defaults'),
+                'label' => $translator->__('Reload Defaults'),
                 'icon' => 'fa-refresh',
                 'attr' => [
                     'class' => 'btn btn-warning'
                 ]
             ])
             ->add('cancel', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', [
-                'label' => $this->__('Cancel'),
+                'label' => $translator->__('Cancel'),
                 'icon' => 'fa-times',
                 'attr' => [
                     'class' => 'btn btn-default'
@@ -47,18 +55,22 @@ class ExtensionModifyType extends AbstractType
         ;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getBlockPrefix()
     {
         return 'zikulaextensionsmodule_extensionmodify';
     }
 
     /**
-     * @param OptionsResolver $resolver
+     * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'data_class' => 'Zikula\ExtensionsModule\Entity\ExtensionEntity',
+            'translator' => null
         ]);
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | https://github.com/Guite/MostGenerator/issues/737
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description
This PR fixes invalid usage of Gettext methods in the Extension form types.
