### PR TITLE
Allow sub directories in Controller directory

### DIFF
--- a/src/system/RoutesModule/Routing/RouteLoader.php
+++ b/src/system/RoutesModule/Routing/RouteLoader.php
@@ -342,19 +342,14 @@ class RouteLoader extends Loader
      */
     private function sanitizeController($bundleName, $controllerString)
     {
-        if (strpos($controllerString, '::') === false) {
+        if (0 === preg_match('#^(.*?\\\\Controller\\\\(.+)Controller)::(.+)Action$#', $controllerString, $match)) {
             return $controllerString;
         }
-
-        $action = substr($controllerString, strpos($controllerString, '::') + 2);
-        $func = lcfirst(substr($action, 0, -6));
-
-        $a = strrpos($controllerString, '\\') + 1;
-        $b = strrpos($controllerString, '::');
-        $controller = substr($controllerString, $a, $b - $a);
-        $type = substr($controller, 0, -10);
-
-        return $bundleName . ':' . $type . ':' . $func;
+        
+        $controllerName = $match[2];
+        $actionName = $match[3];       
+  
+        return $bundleName . ':' . $controllerName . ':' . $actionName;
     }
 
     /**

--- a/src/system/RoutesModule/Routing/RouteLoader.php
+++ b/src/system/RoutesModule/Routing/RouteLoader.php
@@ -345,11 +345,9 @@ class RouteLoader extends Loader
         if (0 === preg_match('#^(.*?\\\\Controller\\\\(.+)Controller)::(.+)Action$#', $controllerString, $match)) {
             return $controllerString;
         }
-        
-        $controllerName = $match[2];
-        $actionName = $match[3];       
-  
-        return $bundleName . ':' . $controllerName . ':' . $actionName;
+            
+        // Bundle:controller:action
+        return $bundleName . ':' . $match[2] . ':' . $match[3];
     }
 
     /**

--- a/src/system/RoutesModule/Routing/RouteLoader.php
+++ b/src/system/RoutesModule/Routing/RouteLoader.php
@@ -262,7 +262,7 @@ class RouteLoader extends Loader
         $controller = $this->sanitizeController($bundleName, $defaults['_controller']);
         $controller = explode(':', $controller);
         $defaults['_zkType'] = $type = lcfirst($controller[1]);
-        $defaults['_zkFunc'] = $func = $controller[2];
+        $defaults['_zkFunc'] = $func = lcfirst($controller[2]);
         $defaults['_controller'] = $bundleName . ":" . $controller[1] . ":" . $func;
 
         $route->setDefaults($defaults);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | [yes]
| New feature?      | [yes]
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | [no]

## Description
This is a copy paste solution from https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php#L103

This change allows controllers to be organised in subdirectories