### PR TITLE
Fix wrong asset path and type

### DIFF
--- a/src/system/PermissionsModule/Resources/views/Admin/view.html.twig
+++ b/src/system/PermissionsModule/Resources/views/Admin/view.html.twig
@@ -6,7 +6,7 @@
     </script>
 {% endset %}
 {{ pageAddAsset('header', scriptInit) }}
-{{ pageAddAsset('stylesheet', asset('web/bootstrap-jqueryui/bootstrap-jqueryui.min.js')) }}
+{{ pageAddAsset('javascript', asset('bootstrap-jqueryui/bootstrap-jqueryui.min.js')) }}
 {{ pageAddAsset('javascript', zasset('@ZikulaPermissionsModule:js/Zikula.Permission.Admin.View.js')) }}
 
 {{ adminHeader() }}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | [yes]
| New feature?      | [no]
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | [yes/no]

## Description
This change fixes wrong bootstrap-jqueryui.min.js path and wrong asset type.