### PR TITLE
[WIP] Disable automatic block wrapping for Core 2.0 themes.

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -4,6 +4,8 @@ CHANGELOG - ZIKULA 1.4.x
 * 1.4.3 (?)
 
  - BC Breaks:
+    - Blocks are no longer wrapped in helper div for Core 2.0 type themes (#2920)
+        - This behaviour was moved to templates. See Andreas08Theme and SeaBreezeTheme for usage examples.
     - Assetic Bundle has been removed (#2939).
     - User block function removed. It is going to be added to the Profile module instead.
     - Old Authentication_Method_Api system has been completely removed.

--- a/src/system/ThemeModule/AbstractTheme.php
+++ b/src/system/ThemeModule/AbstractTheme.php
@@ -54,7 +54,7 @@ abstract class AbstractTheme extends AbstractBundle
 
     /**
      * generate a response wrapped in the theme
-     *   wrap the maincontent in a unique div.
+     *
      * @param string $realm
      * @param Response $response
      * @param string $moduleName
@@ -63,14 +63,14 @@ abstract class AbstractTheme extends AbstractBundle
     public function generateThemedResponse($realm, Response $response, $moduleName = null)
     {
         $template = $this->config[$realm]['page'];
-        $content = '<div id="z-maincontent" class="'
-            . ($realm == 'home' ? 'z-homepage' : '')
-            . (isset($moduleName) ? ' z-module-' . strtolower($moduleName) : '') . '">'
-            . $response->getContent()
-            . '</div>';
-        $response->setContent($content);
+        
+        $templateParameters = [
+            'realm' => (isset($realm) ? $realm : ''),
+            'modulename' => (isset($moduleName) ? $moduleName : ''),
+            'maincontent' => $response->getContent()
+        ];        
 
-        return $this->getContainer()->get('templating')->renderResponse($this->name . ':' . $template, ['maincontent' => $response->getContent()]);
+        return $this->getContainer()->get('templating')->renderResponse($this->name . ':' . $template, $templateParameters);
     }
 
     /**

--- a/src/system/ThemeModule/AbstractTheme.php
+++ b/src/system/ThemeModule/AbstractTheme.php
@@ -81,7 +81,7 @@ abstract class AbstractTheme extends AbstractBundle
      * @param $blockTitle
      * @return string
      */
-    public function generateThemedBlockContent($realm, $positionName, $blockContent, $blockTitle)
+    public function generateThemedBlockContent($realm, $blockType, $bid, $positionName, $blockContent, $blockTitle)
     {
         if (isset($this->config[$realm]['block']['positions'][$positionName])) {
             $template = $this->name . ':' . $this->config[$realm]['block']['positions'][$positionName];
@@ -91,6 +91,9 @@ abstract class AbstractTheme extends AbstractBundle
         }
 
         $templateParameters = [
+            'btype' => strtolower($blockType),
+            'bid' => $bid,
+            'position' => strtolower($positionName),
             'title' => $blockTitle,
             'content' => $blockContent
         ];

--- a/src/system/ThemeModule/AbstractTheme.php
+++ b/src/system/ThemeModule/AbstractTheme.php
@@ -63,12 +63,12 @@ abstract class AbstractTheme extends AbstractBundle
     public function generateThemedResponse($realm, Response $response, $moduleName = null)
     {
         $template = $this->config[$realm]['page'];
-        
+
         $templateParameters = [
             'realm' => (isset($realm) ? $realm : ''),
             'modulename' => (isset($moduleName) ? $moduleName : ''),
             'maincontent' => $response->getContent()
-        ];        
+            ];
 
         return $this->getContainer()->get('templating')->renderResponse($this->name . ':' . $template, $templateParameters);
     }

--- a/src/system/ThemeModule/Engine/Engine.php
+++ b/src/system/ThemeModule/Engine/Engine.php
@@ -145,7 +145,7 @@ class Engine
         if (!isset($activeTheme) || !$activeTheme->isTwigBased()) {
             return false;
         }
-        
+
         $bid = !empty($blockInfo['bid']) ? $blockInfo['bid'] : 'none';
         $blockType = !empty($blockInfo['blocktype']) ? $blockInfo['blocktype'] : 'none';
         $position = !empty($blockInfo['position']) ? $blockInfo['position'] : 'none';

--- a/src/system/ThemeModule/Engine/Engine.php
+++ b/src/system/ThemeModule/Engine/Engine.php
@@ -145,8 +145,11 @@ class Engine
         if (!isset($activeTheme) || !$activeTheme->isTwigBased()) {
             return false;
         }
+        
+        $bid = !empty($blockInfo['bid']) ? $blockInfo['bid'] : 'none';
+        $blockType = !empty($blockInfo['blocktype']) ? $blockInfo['blocktype'] : 'none';
         $position = !empty($blockInfo['position']) ? $blockInfo['position'] : 'none';
-        $content = $activeTheme->generateThemedBlockContent($this->getRealm(), $position, $blockInfo['content'], $blockInfo['title']);
+        $content = $activeTheme->generateThemedBlockContent($this->getRealm(), $blockType, $bid, $position, $blockInfo['content'], $blockInfo['title']);
 
         return $content;
     }
@@ -166,7 +169,7 @@ class Engine
     {
         if (!$legacy) {
             // legacy blocks are already themed at this point. @todo at Core-2.0 remove $legacy param and this check.
-            $content = $this->getTheme()->generateThemedBlockContent($this->getRealm(), $positionName, $content, $title);
+            return $this->getTheme()->generateThemedBlockContent($this->getRealm(), $blockType, $bid, $positionName, $content, $title);
         }
 
         // always wrap the block (in the previous versions this was configurable, but no longer) @todo remove comment

--- a/src/system/ThemeModule/Engine/Engine.php
+++ b/src/system/ThemeModule/Engine/Engine.php
@@ -172,13 +172,13 @@ class Engine
             return $this->getTheme()->generateThemedBlockContent($this->getRealm(), $blockType, $bid, $positionName, $content, $title);
         }
 
-        // always wrap the block (in the previous versions this was configurable, but no longer) @todo remove comment
+        // @deprecated always wrap the block (in the previous versions this was configurable, but no longer) BC for legacy
         return $this->wrapBlockContentWithUniqueDiv($content, $positionName, $blockType, $bid);
     }
 
     /**
      * Enclose themed block content in a unique div which is useful in applying styling.
-     *
+     * @deprecated
      * @param string $content
      * @param string $positionName
      * @param string $blockType

--- a/src/themes/Andreas08Theme/Resources/views/Block/block.html.twig
+++ b/src/themes/Andreas08Theme/Resources/views/Block/block.html.twig
@@ -2,5 +2,7 @@
 <h3 class="theme_blocktitle">{{ title }}</h3>
 {% endif %}
 <div class="theme_blockcontent">
-    {{ content|raw }}
+    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+        {{ content|raw }}
+    </div>
 </div>

--- a/src/themes/Andreas08Theme/Resources/views/Block/block.html.twig
+++ b/src/themes/Andreas08Theme/Resources/views/Block/block.html.twig
@@ -1,8 +1,8 @@
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
 {% if title is not empty %}
 <h3 class="theme_blocktitle">{{ title }}</h3>
 {% endif %}
 <div class="theme_blockcontent">
-    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
         {{ content|raw }}
-    </div>
+</div>
 </div>

--- a/src/themes/Andreas08Theme/Resources/views/Block/searchblock.html.twig
+++ b/src/themes/Andreas08Theme/Resources/views/Block/searchblock.html.twig
@@ -1,3 +1,5 @@
 <!-- Start Search Block -->
-{{ content|raw }}
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {{ content|raw }}
+</div>
 <!--  End Search Block  -->

--- a/src/themes/Andreas08Theme/Resources/views/Block/topnavblock.html.twig
+++ b/src/themes/Andreas08Theme/Resources/views/Block/topnavblock.html.twig
@@ -1,3 +1,5 @@
 <!-- Start Top Navigation Block -->
-{{ content|raw }}
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {{ content|raw }}
+</div>
 <!--  End Top Navigation Block  -->

--- a/src/themes/Andreas08Theme/Resources/views/Body/1col.html.twig
+++ b/src/themes/Andreas08Theme/Resources/views/Body/1col.html.twig
@@ -1,5 +1,7 @@
 <div id="theme_content" class="clearfix">
     <div id="theme_maincontent" class="col-xs-12">
-        {{ maincontent|raw }}
+        <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+            {{ maincontent|raw }}
+        </div>
     </div>
 </div>

--- a/src/themes/Andreas08Theme/Resources/views/Body/2col.html.twig
+++ b/src/themes/Andreas08Theme/Resources/views/Body/2col.html.twig
@@ -3,6 +3,8 @@
         {{ showblockposition('left') }}
     </div>
     <div id="theme_maincontent" class="col-xs-9">
-        {{ maincontent|raw }}
+        <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+            {{ maincontent|raw }}
+        </div>
     </div>
 </div>

--- a/src/themes/Andreas08Theme/Resources/views/Body/2col_w_centerblock.html.twig
+++ b/src/themes/Andreas08Theme/Resources/views/Body/2col_w_centerblock.html.twig
@@ -4,6 +4,8 @@
     </div>
     <div id="theme_maincontent" class="col-xs-9">
         {{ showblockposition('center') }}
-        {{ maincontent|raw }}
+        <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+            {{ maincontent|raw }}
+        </div>
     </div>
 </div>

--- a/src/themes/Andreas08Theme/Resources/views/Body/3col.html.twig
+++ b/src/themes/Andreas08Theme/Resources/views/Body/3col.html.twig
@@ -3,7 +3,9 @@
         {{ showblockposition('left') }}
     </div>
     <div id="theme_maincontent" class="col-xs-6">
-        {{ maincontent|raw }}
+        <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+            {{ maincontent|raw }}
+        </div>
     </div>
     <div id="theme_rightcol" class="col-xs-3">
         {{ showblockposition('right') }}

--- a/src/themes/Andreas08Theme/Resources/views/Body/3col_w_centerblock.html.twig
+++ b/src/themes/Andreas08Theme/Resources/views/Body/3col_w_centerblock.html.twig
@@ -4,7 +4,9 @@
     </div>
     <div id="theme_maincontent" class="col-xs-6">
         {{ showblockposition('center') }}
-        {{ maincontent|raw }}
+        <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+            {{ maincontent|raw }}
+        </div>
     </div>
     <div id="theme_rightcol" class="col-xs-3">
         {{ showblockposition('right') }}

--- a/src/themes/BootstrapTheme/Resources/views/Block/block.html.twig
+++ b/src/themes/BootstrapTheme/Resources/views/Block/block.html.twig
@@ -1,4 +1,6 @@
 {% if title is not empty %}
 <h3>{{ title }}</h3>
 {% endif %}
-{{ content|raw }}
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {{ content|raw }}
+</div>

--- a/src/themes/BootstrapTheme/Resources/views/Block/block.html.twig
+++ b/src/themes/BootstrapTheme/Resources/views/Block/block.html.twig
@@ -1,6 +1,6 @@
-{% if title is not empty %}
-<h3>{{ title }}</h3>
-{% endif %}
 <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {% if title is not empty %}
+        <h3>{{ title }}</h3>
+    {% endif %}
     {{ content|raw }}
 </div>

--- a/src/themes/BootstrapTheme/Resources/views/Block/searchblock.html.twig
+++ b/src/themes/BootstrapTheme/Resources/views/Block/searchblock.html.twig
@@ -1,3 +1,5 @@
 <!-- Start Search Block -->
-{{ content|raw }}
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {{ content|raw }}
+</div>
 <!--  End Search Block  -->

--- a/src/themes/BootstrapTheme/Resources/views/Block/topnavblock.html.twig
+++ b/src/themes/BootstrapTheme/Resources/views/Block/topnavblock.html.twig
@@ -1,3 +1,5 @@
 <!-- Start Top Navigation Block -->
-{{ content|raw }}
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {{ content|raw }}
+</div>
 <!--  End Top Navigation Block  -->

--- a/src/themes/BootstrapTheme/Resources/views/Body/1col.html.twig
+++ b/src/themes/BootstrapTheme/Resources/views/Body/1col.html.twig
@@ -1,3 +1,5 @@
 <div class="container">
-    {{ maincontent|raw }}
+    <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+        {{ maincontent|raw }}
+    </div>
 </div>

--- a/src/themes/BootstrapTheme/Resources/views/Body/2col.html.twig
+++ b/src/themes/BootstrapTheme/Resources/views/Body/2col.html.twig
@@ -5,7 +5,9 @@
         </div>
         <div id="theme_maincontent" class="col-sm-9">
             {{ showflashes() }}
-            {{ maincontent|raw }}
+            <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                {{ maincontent|raw }}
+            </div>
         </div>
     </div>
 </div>

--- a/src/themes/BootstrapTheme/Resources/views/Body/2col_w_centerblock.html.twig
+++ b/src/themes/BootstrapTheme/Resources/views/Body/2col_w_centerblock.html.twig
@@ -6,7 +6,9 @@
         <div id="theme_maincontent" class="col-sm-9">
             {{ showflashes() }}
             {{ showblockposition('center') }}
-            {{ maincontent|raw }}
+            <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                {{ maincontent|raw }}
+            </div>
         </div>
     </div>
 </div>

--- a/src/themes/BootstrapTheme/Resources/views/Body/3col.html.twig
+++ b/src/themes/BootstrapTheme/Resources/views/Body/3col.html.twig
@@ -6,7 +6,9 @@
         </div>
         <div class="col-sm-4">
             {{ showflashes() }}
-            {{ maincontent|raw }}
+            <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                {{ maincontent|raw }}
+            </div>
         </div>
         <div class="col-sm-4">
             {{ showblockposition('right') }}

--- a/src/themes/BootstrapTheme/Resources/views/Body/3col_w_centerblock.html.twig
+++ b/src/themes/BootstrapTheme/Resources/views/Body/3col_w_centerblock.html.twig
@@ -13,7 +13,9 @@
         </div>
         <div class="col-sm-4">
             {{ showflashes() }}
-            {{ maincontent|raw }}
+            <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                {{ maincontent|raw }}
+            </div>
         </div>
         <div class="col-sm-4">
             {{ showblockposition('right') }}

--- a/src/themes/SeaBreezeTheme/Resources/views/Block/ccblock.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/Block/ccblock.html.twig
@@ -3,6 +3,8 @@
 <h3>{{ title }}</h3>
 {% endif %}
 <div class="sbCenterContent">
-    {{ content|raw }}
+    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+        {{ content|raw }}
+    </div>
 </div>
 <!--  End Center Block  -->

--- a/src/themes/SeaBreezeTheme/Resources/views/Block/ccblock.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/Block/ccblock.html.twig
@@ -1,9 +1,9 @@
 <!-- Start Center Block -->
-{% if title is not empty %}
-<h3>{{ title }}</h3>
-{% endif %}
-<div class="sbCenterContent">
-    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {% if title is not empty %}
+        <h3>{{ title }}</h3>
+    {% endif %}
+    <div class="sbCenterContent">
         {{ content|raw }}
     </div>
 </div>

--- a/src/themes/SeaBreezeTheme/Resources/views/Block/lsblock.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/Block/lsblock.html.twig
@@ -1,9 +1,9 @@
 <!-- Start Left Block Start -->
-{% if title is not empty  %}
-<h3 class="blocktitle">{{ title }}</h3>
-{% endif %}
-<div class="sbLeftContent">
-    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {% if title is not empty  %}
+        <h3 class="blocktitle">{{ title }}</h3>
+    {% endif %}
+    <div class="sbLeftContent">
         {{ content|raw }}
     </div>
 </div>

--- a/src/themes/SeaBreezeTheme/Resources/views/Block/lsblock.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/Block/lsblock.html.twig
@@ -3,6 +3,8 @@
 <h3 class="blocktitle">{{ title }}</h3>
 {% endif %}
 <div class="sbLeftContent">
-    {{ content|raw }}
+    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+        {{ content|raw }}
+    </div>
 </div>
 <!-- Start Left Block End -->

--- a/src/themes/SeaBreezeTheme/Resources/views/Block/rsblock.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/Block/rsblock.html.twig
@@ -1,9 +1,9 @@
 <!-- Start Right Side Block -->
-{% if title is not empty  %}
-<h3 class="blocktitle">{{ title }}</h3>
-{% endif %}
-<div class="sbRightContent">
-    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {% if title is not empty  %}
+        <h3 class="blocktitle">{{ title }}</h3>
+    {% endif %}
+    <div class="sbRightContent">
         {{ content|raw }}
     </div>
 </div>

--- a/src/themes/SeaBreezeTheme/Resources/views/Block/rsblock.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/Block/rsblock.html.twig
@@ -3,6 +3,8 @@
 <h3 class="blocktitle">{{ title }}</h3>
 {% endif %}
 <div class="sbRightContent">
-    {{ content|raw }}
+    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+        {{ content|raw }}
+    </div>
 </div>
 <!-- End Right Block -->

--- a/src/themes/SeaBreezeTheme/Resources/views/Block/searchblock.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/Block/searchblock.html.twig
@@ -1,3 +1,5 @@
 <!-- Start Search Block -->
-{{ content|raw }}
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    {{ content|raw }}
+</div>
 <!-- End Search Block -->

--- a/src/themes/SeaBreezeTheme/Resources/views/Block/topnavblock.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/Block/topnavblock.html.twig
@@ -1,7 +1,7 @@
 <!-- Start Top Navigation Block -->
-<div id="navi" class="z-clearer">
-    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+<div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+    <div id="navi" class="z-clearer">
         {{ content|raw }}
     </div>
-</div>
+</div>        
 <!-- End Top Navigation Block -->

--- a/src/themes/SeaBreezeTheme/Resources/views/Block/topnavblock.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/Block/topnavblock.html.twig
@@ -1,5 +1,7 @@
 <!-- Start Top Navigation Block -->
 <div id="navi" class="z-clearer">
-    {{ content|raw }}
+    <div class="z-block z-blockposition-{{ position|lower }} z-bkey-{{ btype|lower }} z-bid-{{ bid }}">
+        {{ content|raw }}
+    </div>
 </div>
 <!-- End Top Navigation Block -->

--- a/src/themes/SeaBreezeTheme/Resources/views/admin.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/admin.html.twig
@@ -6,7 +6,9 @@
         <div id="pagewidth">
             <div id="wrapper" class="clearfix">
                 <div id="maincol">
-                    {{ maincontent|raw }}
+                    <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                        {{ maincontent|raw }}
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/themes/SeaBreezeTheme/Resources/views/home.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/home.html.twig
@@ -12,7 +12,9 @@
                 </div>
                 <div id="maincol">
                     {{ showblockposition('center') }}
-                    {{ maincontent|raw }}
+                    <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                        {{ maincontent|raw }}
+                    </div>
                 </div>
                 <div id="rightcol">{{ showblockposition('right') }}</div>
             </div>

--- a/src/themes/SeaBreezeTheme/Resources/views/master.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/master.html.twig
@@ -11,7 +11,9 @@
                      </div>
                 </div>
                 <div id="maincol">
-                    {{ maincontent|raw }}
+                    <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                        {{ maincontent|raw }}
+                    </div>
                 </div>
                 <div id="rightcol">{{ showblockposition('right') }}</div>
             </div>

--- a/src/themes/SeaBreezeTheme/Resources/views/nocolumns.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/nocolumns.html.twig
@@ -6,7 +6,9 @@
         <div id="pagewidth">
             <div id="wrapper" class="clearfix">
                 <div id="maincol">
-                    {{ maincontent|raw }}
+                    <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                        {{ maincontent|raw }}
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/themes/SeaBreezeTheme/Resources/views/noleftcolumn.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/noleftcolumn.html.twig
@@ -6,7 +6,9 @@
         <div id="pagewidth">
             <div id="wrapper" class="clearfix">
                 <div id="maincol">
-                    {{ maincontent|raw }}
+                    <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                        {{ maincontent|raw }}
+                    </div>
                 </div>
                 <div id="rightcol">{{ showblockposition('right') }}</div>
             </div>

--- a/src/themes/SeaBreezeTheme/Resources/views/norightcolumn.html.twig
+++ b/src/themes/SeaBreezeTheme/Resources/views/norightcolumn.html.twig
@@ -11,7 +11,9 @@
                      </div>
                 </div>
                 <div id="maincol">
-                    {{ maincontent|raw }}
+                    <div id="z-maincontent" class="{% if realm == 'home' %}z-homepage{% endif %} z-module-{{ modulename|lower }}">    
+                        {{ maincontent|raw }}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description
This allows for core 2.0 blocks to not be automatically wrapped in div. All html wrapping functions should be deprecated and removed in Core 2.0. To maintain functionality theme developer can use block related variables in block template.


## Todos
- [x] Tests
- [x] Changelog

Not yet finished... @craigh  this is what I think might be a good solution to get rid of those wrappings in core 2.0 completely.