### PR TITLE
Check if current theme is core 2.0 theme

### DIFF
--- a/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
+++ b/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
@@ -143,7 +143,7 @@ class DefaultPageAssetSetterListener implements EventSubscriberInterface
             if (!empty($this->params['zikula.stylesheet.bootstrap.min.path'])) {
                 // Core-2.0 Site method
                 $overrideBootstrapPath = $this->params['zikula.stylesheet.bootstrap.min.path'];
-            } elseif (!empty($this->themeEngine->getTheme()->getConfig()['bootstrapPath'])) {
+            } elseif (!empty($this->themeEngine->getTheme()) && !empty($this->themeEngine->getTheme()->getConfig()['bootstrapPath'])) {
                 // Core-2.0 Theme method
                 $overrideBootstrapPath = $this->themeEngine->getTheme()->getConfig()['bootstrapPath'];
             } else {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | [yes]
| New feature?      | [no]
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #2932 
| Refs tickets      | #2932
| License           | MIT
| Changelog updated | [no]

## Description
For legacy, themes getTheme() method returns null so getConfig does not exist.