### PR TITLE
Correct issues with blocks module upgrade 

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -93,6 +93,8 @@ CHANGELOG - ZIKULA 1.4.x
     - Fix post installation login (#2187)
     - Improved compatibility of zikula-specific bootstrap overrides with respect to navbars.
     - Improved handling of 'utility' themes via GET and add ability to restrict access via permissions on a more granular level.
+    - Correct method arguments provided by BC block method when displaying block. (#2934)
+    - Fix block module upgrade (#2957, #2835)
  - Features:
     - Add new advanced block filtering based on a combination of any query parameter or request attributes.
     - Add core routing for all legacy urls (both normal and 'shorturls').

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxUpgradeController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxUpgradeController.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Zikula\Bundle\CoreBundle\YamlDumper;
+use Zikula\ThemeModule\Entity\Repository\ThemeEntityRepository;
 
 /**
  * Class AjaxUpgradeController
@@ -138,7 +139,16 @@ class AjaxUpgradeController extends AbstractController
     private function regenerateThemes()
     {
         // regenerate the themes list
-        return $this->container->get('zikula_theme_module.helper.bundle_sync_helper')->regenerate();
+        $this->container->get('zikula_theme_module.helper.bundle_sync_helper')->regenerate();
+        // set all themes as active @todo this is probably overkill
+        $themes = $this->container->get('zikula_theme_module.theme_entity.repository')->findAll();
+        /** @var \Zikula\ThemeModule\Entity\ThemeEntity $theme */
+        foreach ($themes as $theme) {
+            $theme->setState(ThemeEntityRepository::STATE_ACTIVE);
+        }
+        $this->container->get('doctrine')->getManager()->flush();
+
+        return true;
     }
 
     private function from140to141()

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxUpgradeController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxUpgradeController.php
@@ -167,6 +167,8 @@ class AjaxUpgradeController extends AbstractController
         \SessionUtil::delVar('interactive_init');
         \SessionUtil::delVar('interactive_remove');
         \SessionUtil::delVar('interactive_upgrade');
+
+        return true;
     }
 
     private function finalizeParameters()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #2957, #2835 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

@paustian can you copy paste the fix here and see if your upgrade works correctly?

The issue is present in 1.4.2 and prevents upgrade. this fixes #2957 hopefully.