### PR TITLE
Disable slow debug toolbar components.

### DIFF
--- a/src/app/config/config_dev.yml
+++ b/src/app/config/config_dev.yml
@@ -23,3 +23,17 @@ monolog:
         chromephp:
             type:  chromephp
             level: info
+
+web_profiler_extra:
+    routing:
+        enabled:        false
+        display_in_wdt: true
+    container:
+        enabled:        false
+        display_in_wdt: true
+    twig:
+        enabled:        false
+        display_in_wdt: true
+    assetic:
+        enabled:        false
+        display_in_wdt: false


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Changelog updated | no

Speeds up Zikula noticably in dev/debug mode. These should be enabled only if needed.