### PR TITLE
increase length of session_id column in session table. refs #2840

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -16,6 +16,7 @@ CHANGELOG - ZIKULA 1.4.x
  - Fixes:
     - Fix error on creation of new ExtendedMenublock.
     - Fix display of blocks using theme overrides (#2872).
+    - Lengthen SesssionId column in session table (#2840).
 
  - Features:
     - Add help text, alert text and input groups to forms utilizing the provided form themes (#2846, #2847).

--- a/src/system/UsersModule/Entity/UserSessionEntity.php
+++ b/src/system/UsersModule/Entity/UserSessionEntity.php
@@ -30,7 +30,7 @@ class UserSessionEntity extends EntityAccess
      * Session ID: Primary identifier
      *
      * @ORM\Id
-     * @ORM\Column(type="string", length=40)
+     * @ORM\Column(type="string", length=60)
      * @ORM\GeneratedValue(strategy="NONE")
      */
     private $sessid;

--- a/src/system/UsersModule/UsersModuleInstaller.php
+++ b/src/system/UsersModule/UsersModuleInstaller.php
@@ -130,6 +130,8 @@ class UsersModuleInstaller extends AbstractExtensionInstaller
                 // expire all sessions so everyone has to login again (to force migration)
                 $this->entityManager->createQuery('DELETE FROM Zikula\UsersModule\Entity\UserSessionEntity')->execute();
             case '3.0.0':
+                $this->schemaTool->update(['Zikula\UsersModule\Entity\UserSessionEntity']);
+            case '3.0.1':
                 // current version
         }
 

--- a/src/system/UsersModule/composer.json
+++ b/src/system/UsersModule/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "zikula/users-module",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "Provides an interface for administering user accounts.",
     "type": "zikula-module",
     "license": "LGPL-3.0+",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no maybe?
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | #2840 
| License           | MIT
| Changelog updated | yes

## Description
lengthen the column to allow for longer session ids. addresses concern raised on forum and outlined again in #2840 

I'm concerned that this will truncate the session table, forcing all to login again. My local tests are inconclusive. @cmfcmf @Guite @Kaik thoughts or testing?
