### PR TITLE
fixed processing disabled search plugins

### DIFF
--- a/src/lib/Zikula/Bundle/FormExtensionBundle/Resources/views/Form/bootstrap_3_zikula_admin_layout.html.twig
+++ b/src/lib/Zikula/Bundle/FormExtensionBundle/Resources/views/Form/bootstrap_3_zikula_admin_layout.html.twig
@@ -29,8 +29,8 @@ col-sm-9
 
 {% block checkbox_widget -%}
     {% set parent_label_class = parent_label_class|default('') -%}
-    {% if 'checkbox-inline' in parent_label_class %}
-        {{- form_label(form, null, { widget: parent() }) -}}
+    {% if 'checkbox-inline' not in parent_label_class %}
+        {{ parent() }}
     {% else -%}
         <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
     {%- endif %}

--- a/src/system/SearchModule/Controller/ConfigController.php
+++ b/src/system/SearchModule/Controller/ConfigController.php
@@ -55,13 +55,23 @@ class ConfigController extends AbstractController
             $plugins[] = ['title' => $searchableModule['name']];
         }
 
+        $disabledPlugins = [];
+
         // get the disabled state
         foreach ($plugins as $key => $plugin) {
             if (!isset($plugin['title'])) {
                 continue;
             }
-            $plugins[$key]['disabled'] = $this->getVar('disable_' . $plugin['title']);
+            $modVarKey = 'disable_' . $plugin['title'];
+            if (!isset($modVars[$modVarKey])) {
+                continue;
+            }
+            if ($modVars[$modVarKey]) {
+                $disabledPlugins[] = $plugin['title'];
+            }
+            unset($modVars[$modVarKey]);
         }
+        $modVars['plugins'] = $disabledPlugins;
 
         $form = $this->createForm('Zikula\SearchModule\Form\Type\ConfigType',
             $modVars, [
@@ -82,11 +92,11 @@ class ConfigController extends AbstractController
 
                 // loop round the plugins
                 foreach ($plugins as $searchPlugin) {
-                    if (!isset($plugin['title'])) {
+                    if (!isset($searchPlugin['title'])) {
                         continue;
                     }
                     // set the disabled flag
-                    $disabledFlag = isset($formData['disable_' . $plugin['title']]) ? $formData['disable_' . $plugin['title']] : false;
+                    $disabledFlag = in_array($searchPlugin['title'], $formData['plugins']);
                     $this->setVar('disable_' . $searchPlugin['title'], $disabledFlag);
                 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #2967 
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description
This fixes two problems:
1. checkbox labels were not shown
2. disabled plugins were not properly saved
