### PR TITLE
Use Imagick and Gmagick if available.

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -22,6 +22,7 @@ CHANGELOG - ZIKULA 1.4.x
     - Added whitespace trimming functionality for Twig themes (#2911).
     - Fixed getPluralOffset in Zikula.js to return numbers instead of boolean values (#3011)
     - Corrected issue with hook admin url and legacy modules (#2999).
+    - Imagine: Use Imagick or Gmagick in favour of Gd (#3016)
 
  - Features:
     - Add help text, alert text and input groups to forms utilizing the provided form themes (#2846, #2847).

--- a/src/plugins/Imagine/Plugin.php
+++ b/src/plugins/Imagine/Plugin.php
@@ -232,10 +232,10 @@ class SystemPlugin_Imagine_Plugin extends Zikula_AbstractPlugin implements Zikul
      */
     public function getImagineEngine()
     {
-        $engines = array('Imagick', 'Gmagick', 'Gd');
+        $engines = ['Imagick', 'Gmagick', 'Gd'];
         foreach ($engines as $engine) {
             try {
-                $class = "\\Imagine\\{$engine}\\Imagine";
+                $class = "Imagine\\$engine\\Imagine";
                 return new $class();
             } catch (RuntimeException $e) {
             }

--- a/src/plugins/Imagine/Plugin.php
+++ b/src/plugins/Imagine/Plugin.php
@@ -232,17 +232,16 @@ class SystemPlugin_Imagine_Plugin extends Zikula_AbstractPlugin implements Zikul
      */
     public function getImagineEngine()
     {
-        $imagine = null;
-        $engines = ['Imagick', 'Gmagick', 'Gd'];
+        $engines = array('Imagick', 'Gmagick', 'Gd');
         foreach ($engines as $engine) {
             try {
                 $class = "\\Imagine\\{$engine}\\Imagine";
-                $imagine = new $class();
+                return new $class();
             } catch (RuntimeException $e) {
             }
         }
 
-        return $imagine;
+        return null;
     }
 
     /**

--- a/src/plugins/Imagine/Plugin.php
+++ b/src/plugins/Imagine/Plugin.php
@@ -236,6 +236,7 @@ class SystemPlugin_Imagine_Plugin extends Zikula_AbstractPlugin implements Zikul
         foreach ($engines as $engine) {
             try {
                 $class = "Imagine\\$engine\\Imagine";
+
                 return new $class();
             } catch (RuntimeException $e) {
             }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Changelog updated | yes

In it's current implementation, it would always use Gd, regardless whether Imagick or Gmagick are installed.