### PR TITLE
Don't use `[false]` as $links if the ModUtil call returns false.

### DIFF
--- a/src/system/AdminModule/Controller/AdminInterfaceController.php
+++ b/src/system/AdminModule/Controller/AdminInterfaceController.php
@@ -301,11 +301,13 @@ class AdminInterfaceController extends AbstractController
             // url
             $menuTextUrl = isset($adminModule['capabilities']['admin']['route']) ? $this->get('router')->generate($adminModule['capabilities']['admin']['route']) : $adminModule['capabilities']['admin']['url'];
 
-            $linkCollection = $this->get('zikula.link_container_collector')->getLinks($adminModule['name'], 'admin');
-            $links = (false == $linkCollection)
-                ? (array) ModUtil::apiFunc($adminModule['name'], 'admin', 'getLinks')
-                : $linkCollection
-                ;
+            $links = $this->get('zikula.link_container_collector')->getLinks($adminModule['name'], 'admin');
+            if ($links == false) {
+                $links = \ModUtil::apiFunc($adminModule['name'], 'admin', 'getLinks');
+                if ($links == false) {
+                    $links = [];
+                }
+            }
 
             $module = [
                 'menutexturl' => $menuTextUrl,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Changelog updated | no

```php
$x = (array) false; // equal to $x = [false];
```