### PR TITLE
Properly format requirements for browser view.

### DIFF
--- a/src/lib/requirementCheck.php
+++ b/src/lib/requirementCheck.php
@@ -26,10 +26,16 @@ function requirementCheck($parameters)
         $versionChecker->runSymfonyChecks();
         if (!empty($versionChecker->requirementsErrors)) {
             // formatting for both HTML and CLI display
+            if (isset($_SERVER['HTTP_HOST'])) {
+                echo "<html><body><pre>";
+            }
             echo 'The following errors were discovered when checking the' .PHP_EOL. 'Zikula Core system/environment requirements:' . PHP_EOL;
             echo '******************************************************' . PHP_EOL . PHP_EOL;
             foreach ($versionChecker->requirementsErrors as $error) {
                 echo $error . PHP_EOL;
+            }
+            if (isset($_SERVER['HTTP_HOST'])) {
+                echo "</pre></body></html>";
             }
             die();
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Changelog updated | no

A browser (i.e.) Firefox interprets it as HTML and as such won't display line breaks without the `<pre>` block.