### PR TITLE
Make sure `$properties['active']` exists.

### DIFF
--- a/src/system/BlocksModule/BlocksModuleInstaller.php
+++ b/src/system/BlocksModule/BlocksModuleInstaller.php
@@ -141,8 +141,10 @@ class BlocksModuleInstaller extends AbstractExtensionInstaller
                 foreach ($searchBlocks as $searchBlock) {
                     $properties = $searchBlock->getProperties();
                     $properties['displaySearchBtn'] = (bool) $properties['displaySearchBtn'];
-                    foreach ($properties['active'] as $module => $active) {
-                        $properties['active'][$module] = (bool) $active;
+                    if (isset($properties['active'])) {
+                        foreach ($properties['active'] as $module => $active) {
+                            $properties['active'][$module] = (bool) $active;
+                        }
                     }
                     $searchBlock->setProperties($properties);
                 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | ---
| Refs tickets      | ---
| License           | MIT
| Changelog updated | no

The `active` key wasn't set in my installation which caused an error during Blocks Module upgrade.