### PR TITLE
Create EventEnabledTwigEngine

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -9,11 +9,13 @@ CHANGELOG - ZIKULA 1.4.x
 
  - Fixes:
    - Fixed display of checkboxes in topnav login blocks and authentication method selector (#3044).
+   - Removed permanent display of template information in html source (#3068).
 
  - Features:
    - Added mailProtect filter for safe display of email addresses (#3041).
 
  - Core-2.0 Features:
+   - Added display of template name as html comment in source when in dev environment (#3068).
 
  - Vendor upgdates:
     - sensio distribution bundle updated from 5.0.8 to 5.0.9

--- a/src/docs/Core-2.0/Events/TwigRenderEvents.md
+++ b/src/docs/Core-2.0/Events/TwigRenderEvents.md
@@ -1,0 +1,16 @@
+Twig Render Events
+==================
+
+class: `\Zikula\ThemeModule\ThemeEvents`
+
+    /**
+     * Occurs immediately before twig theme engine renders a template.
+     * subject is \Zikula\ThemeModule\Bridge\Event\TwigPreRenderEvent
+     */
+    const PRE_RENDER = 'theme.pre_render';
+
+    /**
+     * Occurs immediately after twig theme engine renders a template.
+     * subject is \Zikula\ThemeModule\Bridge\Event\TwigPostRenderEvent
+     */
+    const POST_RENDER = 'theme.post_render';

--- a/src/docs/Core-2.0/Themes/ExposingTemplateNames.md
+++ b/src/docs/Core-2.0/Themes/ExposingTemplateNames.md
@@ -1,0 +1,11 @@
+Exposing Template Names
+=======================
+
+In past versions of zikula, the user was able to expose template names inside the html source by triggering a flag
+in the theme settings at `/theme/admin/config`.
+
+This functionality is modified for Core-2.0 compatible Twig-based themes.
+
+Now template names are exposed in the HTML source automatically by a listener
+`Zikula\ThemeModule\EventListener\TemplateNameExposeListener` whenever the `env` parameter is set to `dev` inside
+the `app/config/custom_parameters.yml` file.

--- a/src/system/ThemeModule/Bridge/Event/TwigPostRenderEvent.php
+++ b/src/system/ThemeModule/Bridge/Event/TwigPostRenderEvent.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - http://zikula.org/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\ThemeModule\Bridge\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class TwigPostRenderEvent extends Event
+{
+    /**
+     * @var string
+     */
+    protected $templateName;
+
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * TwigPostRenderEvent constructor.
+     * @param string $content
+     * @param string $name
+     * @param array $parameters
+     */
+    public function __construct($content, $name, array $parameters = [])
+    {
+        $this->content = $content;
+        $this->templateName = $name;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemplateName()
+    {
+        return $this->templateName;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param string $content
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+}

--- a/src/system/ThemeModule/Bridge/Event/TwigPreRenderEvent.php
+++ b/src/system/ThemeModule/Bridge/Event/TwigPreRenderEvent.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - http://zikula.org/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\ThemeModule\Bridge\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class TwigPreRenderEvent extends Event
+{
+    /**
+     * @var string
+     */
+    protected $templateName;
+
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * TwigPreRenderEvent constructor.
+     * @param string $name
+     * @param array $parameters
+     */
+    public function __construct($name, array $parameters = [])
+    {
+        $this->templateName = $name;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemplateName()
+    {
+        return $this->templateName;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setTemplateName($name)
+    {
+        $this->templateName = $name;
+    }
+
+    /**
+     * @param array $parameters
+     */
+    public function setParameters($parameters)
+    {
+        $this->parameters = $parameters;
+    }
+}

--- a/src/system/ThemeModule/Bridge/Twig/EventEnabledTwigEngine.php
+++ b/src/system/ThemeModule/Bridge/Twig/EventEnabledTwigEngine.php
@@ -41,7 +41,7 @@ class EventEnabledTwigEngine extends TwigEngine
      *
      * @throws \Twig_Error if something went wrong like a thrown exception while rendering the template
      */
-    public function render($name, array $parameters = array())
+    public function render($name, array $parameters = [])
     {
         $preEvent = new TwigPreRenderEvent($name, $parameters);
         $this->eventDispatcher->dispatch(ThemeEvents::PRE_RENDER, $preEvent);

--- a/src/system/ThemeModule/Bridge/Twig/EventEnabledTwigEngine.php
+++ b/src/system/ThemeModule/Bridge/Twig/EventEnabledTwigEngine.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - http://zikula.org/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\ThemeModule\Bridge\Twig;
+
+use Symfony\Bundle\TwigBundle\TwigEngine;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Zikula\ThemeModule\Bridge\Event\TwigPostRenderEvent;
+use Zikula\ThemeModule\Bridge\Event\TwigPreRenderEvent;
+use Zikula\ThemeModule\ThemeEvents;
+
+class EventEnabledTwigEngine extends TwigEngine
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * This overrides the TwigEngine::render method in order to dispatch events both before and after rendering the content.
+     *
+     * It also supports \Twig_Template as name parameter.
+     *
+     * @throws \Twig_Error if something went wrong like a thrown exception while rendering the template
+     */
+    public function render($name, array $parameters = array())
+    {
+        $preEvent = new TwigPreRenderEvent($name, $parameters);
+        $this->eventDispatcher->dispatch(ThemeEvents::PRE_RENDER, $preEvent);
+
+        $content = $this->load($preEvent->getTemplateName())->render($preEvent->getParameters());
+
+        $postEvent = new TwigPostRenderEvent($content, $preEvent->getTemplateName(), $preEvent->getParameters());
+        $this->eventDispatcher->dispatch(ThemeEvents::POST_RENDER, $postEvent);
+
+        return $postEvent->getContent();
+    }
+}

--- a/src/system/ThemeModule/DependencyInjection/ZikulaThemeExtension.php
+++ b/src/system/ThemeModule/DependencyInjection/ZikulaThemeExtension.php
@@ -30,5 +30,6 @@ class ZikulaThemeExtension extends Extension
 
         $loader->load('services.xml');
         $loader->load('theme_engine.xml');
+        $loader->load('legacy.xml');
     }
 }

--- a/src/system/ThemeModule/EventListener/TemplateNameExposeListener.php
+++ b/src/system/ThemeModule/EventListener/TemplateNameExposeListener.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - http://zikula.org/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\ThemeModule\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Zikula\ThemeModule\Bridge\Event\TwigPostRenderEvent;
+use Zikula\ThemeModule\ThemeEvents;
+
+class TemplateNameExposeListener implements EventSubscriberInterface
+{
+    private $env;
+
+    public function __construct($env)
+    {
+        $this->env = $env;
+    }
+
+    /**
+     * This listener decorates the rendered output to include the template name in the html source as an html comment.
+     * @param TwigPostRenderEvent $event
+     */
+    public function exposeTemplateNames(TwigPostRenderEvent $event)
+    {
+        if ($this->env == 'dev') {
+            $name = $event->getTemplateName();
+            $name = $name instanceof \Twig_Template ? $name->getTemplateName() : $name;
+            $content = '<!-- ' . $name . ' -->' . $event->getContent() . '<!-- /' . $name . ' -->';
+            $event->setContent($content);
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ThemeEvents::POST_RENDER => [
+                ['exposeTemplateNames']
+            ]
+        ];
+    }
+}

--- a/src/system/ThemeModule/Resources/config/legacy.xml
+++ b/src/system/ThemeModule/Resources/config/legacy.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="zikula_core.legacy.theme_template_override_listener.class">Zikula\ThemeModule\EventListener\ThemeTemplateOverrideYamlListener</parameter>
+        <parameter key="zikula.config_template_override_listener.class">Zikula\ThemeModule\EventListener\ConfigTemplateOverrideYamlListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="zikula_core.legacy.theme_template_override_listener" class="%zikula_core.legacy.theme_template_override_listener.class%">
+            <tag name="kernel.event_subscriber" />
+            <deprecated>The "%service_id%" service is deprecated and will be removed in Core-2.0.</deprecated>
+        </service>
+        <service id="zikula.config_template_override_listener" class="%zikula.config_template_override_listener.class%">
+            <tag name="kernel.event_subscriber" />
+            <deprecated>The "%service_id%" service is deprecated and will be removed in Core-2.0.</deprecated>
+        </service>
+        <!-- service aliases -->
+        <service id="zikula.theme_template_override_listener" alias="zikula_core.legacy.theme_template_override_listener" />
+    </services>
+</container>

--- a/src/system/ThemeModule/Resources/config/theme_engine.xml
+++ b/src/system/ThemeModule/Resources/config/theme_engine.xml
@@ -5,10 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <!-- deprecated params -->
-        <parameter key="zikula_core.legacy.theme_template_override_listener.class">Zikula\ThemeModule\EventListener\ThemeTemplateOverrideYamlListener</parameter>
-        <parameter key="zikula.config_template_override_listener.class">Zikula\ThemeModule\EventListener\ConfigTemplateOverrideYamlListener</parameter>
-        <!-- non-legacy -->
         <parameter key="zikula_core.internal.theme.create_themed_response_listener.class">Zikula\ThemeModule\EventListener\CreateThemedResponseListener</parameter>
         <parameter key="zikula_core.internal.theme.default_page_asset_setter_listener.class">Zikula\ThemeModule\EventListener\DefaultPageAssetSetterListener</parameter>
         <parameter key="zikula_core.internal.theme.default_page_var_setter_listener.class">Zikula\ThemeModule\EventListener\DefaultPageVarSetterListener</parameter>
@@ -16,6 +12,7 @@
         <parameter key="zikula_core.internal.theme.template_path_override_listener.class">Zikula\ThemeModule\EventListener\TemplatePathOverrideListener</parameter>
         <parameter key="zikula_core.internal.theme.module_stylesheet_insert_listener.class">Zikula\ThemeModule\EventListener\ModuleStylesheetInsertListener</parameter>
         <parameter key="zikula_core.internal.theme.add_jsconfig_listener.class">Zikula\ThemeModule\EventListener\AddJSConfigListener</parameter>
+        <parameter key="zikula_core.internal.theme.template_name_expose_listener.class">Zikula\ThemeModule\EventListener\TemplateNameExposeListener</parameter>
         <parameter key="zikula_core.common.theme_engine.class">Zikula\ThemeModule\Engine\Engine</parameter>
         <parameter key="zikula_core.common.theme.assets.js.class">Zikula\ThemeModule\Engine\AssetBag</parameter>
         <parameter key="zikula_core.common.theme.assets.css.class">Zikula\ThemeModule\Engine\AssetBag</parameter>
@@ -27,20 +24,10 @@
         <parameter key="zikula_core.common.theme.asset_helper.class">Zikula\ThemeModule\Engine\Asset</parameter>
         <parameter key="zikula_core.internal.theme.js_resolver.class">Zikula\ThemeModule\Engine\Asset\JsResolver</parameter>
         <parameter key="zikula_core.internal.theme.css_resolver.class">Zikula\ThemeModule\Engine\Asset\CssResolver</parameter>
+        <parameter key="zikula_core.internal.theme.decorated_twig_engine.class">Zikula\ThemeModule\Bridge\Twig\EventEnabledTwigEngine</parameter>
     </parameters>
 
     <services>
-        <!-- @deprecated legacy services - remove at Core-2.0 -->
-        <service id="zikula_core.legacy.theme_template_override_listener" class="%zikula_core.legacy.theme_template_override_listener.class%">
-            <tag name="kernel.event_subscriber" />
-            <deprecated>The "%service_id%" service is deprecated and will be removed in Core-2.0.</deprecated>
-        </service>
-        <service id="zikula.config_template_override_listener" class="%zikula.config_template_override_listener.class%">
-            <tag name="kernel.event_subscriber" />
-            <deprecated>The "%service_id%" service is deprecated and will be removed in Core-2.0.</deprecated>
-        </service>
-
-        <!-- non-legacy -->
         <service id="zikula_core.internal.theme.create_themed_response_listener" class="%zikula_core.internal.theme.create_themed_response_listener.class%">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
@@ -100,6 +87,11 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="zikula_core.internal.theme.template_name_expose_listener" class="%zikula_core.internal.theme.template_name_expose_listener.class%">
+            <argument>%env%</argument>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="zikula_core.common.theme_engine" class="%zikula_core.common.theme_engine.class%">
             <argument type="service" id="request_stack" strict="false" />
             <argument type="service" id="annotation_reader" />
@@ -141,8 +133,16 @@
             <argument type="service" id="assets.packages" />
         </service>
 
+        <service id="templating.engine.decorating_twig" class="%zikula_core.internal.theme.decorated_twig_engine.class%" decorates="templating.engine.twig" public="false">
+            <argument type="service" id="twig" />
+            <argument type="service" id="templating.name_parser" />
+            <argument type="service" id="templating.locator" />
+            <call method="setEventDispatcher">
+                <argument type="service" id="event_dispatcher" />
+            </call>
+        </service>
+
         <!-- Alias for services. These service names are @deprecated and will be removed in Core-2.0 -->
-        <service id="zikula.theme_template_override_listener" alias="zikula_core.legacy.theme_template_override_listener" />
         <service id="theme.theme_listener" alias="zikula_core.internal.theme.create_themed_response_listener" />
         <service id="theme.asset_helper" alias="zikula_core.common.theme.asset_helper" />
         <service id="theme.pagevars" alias="zikula_core.common.theme.pagevars" />

--- a/src/system/ThemeModule/ThemeEvents.php
+++ b/src/system/ThemeModule/ThemeEvents.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - http://zikula.org/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\ThemeModule;
+
+class ThemeEvents
+{
+    /**
+     * Occurs immediately before twig theme engine renders a template.
+     * subject is \Zikula\ThemeModule\Bridge\Event\TwigPreRenderEvent
+     */
+    const PRE_RENDER = 'theme.pre_render';
+
+    /**
+     * Occurs immediately after twig theme engine renders a template.
+     * subject is \Zikula\ThemeModule\Bridge\Event\TwigPostRenderEvent
+     */
+    const POST_RENDER = 'theme.post_render';
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | #3068
| License           | MIT
| Changelog updated | yes

## Description
- create and document an EventEnabledTwigEngine so actions can be taken both before and after the twig rendering process.
- Enable a listener to decorate rendered templates with their template name as html comment when in dev env
- move legacy theme module services/listeners to own file (recommended in other modules/bundles)