### PR TITLE
Correct result highlighting.

### DIFF
--- a/src/system/SearchModule/Resources/views/User/results.html.twig
+++ b/src/system/SearchModule/Resources/views/User/results.html.twig
@@ -16,11 +16,11 @@
 <dl class="search_results">
     {% for result in results %}
     <dt class="search_hit">
-        {% if result.url|default %}<a href="{{ result.url|e('html_attr') }}">{% endif %}{{ result.title|zikulasearchmodule_highlightGoogleKeywords(q, limitSummary) }}{% if result.url|default %}</a>{% endif %}
+        {% if result.url|default %}<a href="{{ result.url|e('html_attr') }}">{% endif %}{{ result.title|zikulasearchmodule_highlightGoogleKeywords(q, limitSummary)|raw }}{% if result.url|default %}</a>{% endif %}
         &nbsp;&nbsp;<span class="sub">(<a href="{{ zikulasearchmodule_modUrlLegacy(result.module) }}">{{ result.displayname }}</a>)</span>
     </dt>
     <dd>
-        {{ result.text|zikulasearchmodule_highlightGoogleKeywords(q, limitSummary)|truncate(limitSummary, false, '&hellip;') }}
+        {{ result.text|truncate(limitSummary)|zikulasearchmodule_highlightGoogleKeywords(q, limitSummary)|raw }}
         {% if result.created is not empty %}
             <div class="search_created">{{ __f('Created on %s.', { '%s': result.created|localizeddate('long', 'none') }) }}</div>
         {% endif %}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

Search results were not properly highlighted before:
- HTML highlighting code was escaped.
- Closing `</strong>` from the highlighting was truncated.
