### PR TITLE
Making clickable link, leaving the caret as the trigger for the dropd…

### DIFF
--- a/src/lib/legacy/viewplugins/function.modulelinks.php
+++ b/src/lib/legacy/viewplugins/function.modulelinks.php
@@ -245,7 +245,7 @@ function smarty_function_modulelinks($params, Zikula_View $view)
                     $icon = '<span class="fa fa-'.$menuitem['icon'].'"></span> ';
                 }
                 if (isset($menuitem['links'])) {
-                    $html .= '<a href="#" class="dropdown-toggle" data-toggle="dropdown" style="text-decoration: none;">' . $icon . $menuitem['text'] . '&nbsp;<b class="caret"></b></a>';
+                    $html .= '<a href="'.DataUtil::formatForDisplay($menuitem['url']).'">' . $icon . $menuitem['text'] . '</a>&nbsp;<a href="#" class="dropdown-toggle" data-toggle="dropdown" style="text-decoration: none;"><b class="caret"></b></a>';
                 } else {
                     $html .= '<a href="'.DataUtil::formatForDisplay($menuitem['url']).'"'.$attr.'>'.$icon.$menuitem['text'].'</a>';
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | - |
| Refs tickets | - |
| License | MIT |
| Changelog updated | [yes/no] |
## Description

Making clickable link, leaving the caret as the trigger for the dropdown.
