### PR TITLE
assign config array unencoded to let template access it's members

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -12,6 +12,7 @@ CHANGELOG - ZIKULA 1.4.x
    - Fixed display of checkboxes in topnav login blocks and authentication method selector (#3044).
    - Removed permanent display of template information in html source (#3068).
    - Fixed errors in PageLock module (#3089 - #3096).
+   - Fixed problem in JS Config template with debug mode enabled (#3105, #3106).
 
  - Features:
    - Added mailProtect filter for safe display of email addresses in Twig templates (#3041).

--- a/src/system/ThemeModule/EventListener/AddJSConfigListener.php
+++ b/src/system/ThemeModule/EventListener/AddJSConfigListener.php
@@ -122,7 +122,7 @@ class AddJSConfigListener implements EventSubscriberInterface
         $config = array_map('htmlspecialchars', $config);
         $content = $this->templating->render('@ZikulaThemeModule/Engine/JSConfig.html.twig', [
             'compat' => $this->compat,
-            'config' => json_encode($config)
+            'config' => $config
         ]);
         $this->headers->add([$content => 0]);
     }

--- a/src/system/ThemeModule/Resources/views/Engine/JSConfig.html.twig
+++ b/src/system/ThemeModule/Resources/views/Engine/JSConfig.html.twig
@@ -5,5 +5,5 @@
     document.location.ajaxtimeout={{ config.ajaxtimeout }};
 {% endif %}
 if (typeof(Zikula) == 'undefined') {var Zikula = {};}
-Zikula.Config = {{ config|raw }};
+Zikula.Config = {{ config|json_encode|raw }};
 /* ]]> */</script>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #3105 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes
