### PR TITLE
renamed/aliases services to follow naming convention, fixed #2550

### DIFF
--- a/src/app/config/config.yml
+++ b/src/app/config/config.yml
@@ -25,8 +25,8 @@ framework:
     trusted_proxies: ~
     session:
         name: %zikula.session.name%
-        handler_id: session.handler.legacy
-        storage_id: session.storage.legacy
+        handler_id: zikula_core.legacy.session_handler
+        storage_id: zikula_core.legacy.session_storage
         cookie_httponly: false
     fragments:       ~
 

--- a/src/lib/EventHandlers/SystemListeners.php
+++ b/src/lib/EventHandlers/SystemListeners.php
@@ -44,7 +44,7 @@ class SystemListeners extends Zikula_AbstractEventHandler
         if ($event['stage'] & Zikula_Core::STAGE_MODS) {
             // todo - handle this in DIC later
             // inject secret
-            $def = $this->serviceManager->get('token.generator');
+            $def = $this->serviceManager->get('zikula_core.internal.token.generator');
             $def->setSecret(System::getVar('signingkey'));
         }
     }

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
@@ -57,7 +57,7 @@
         </service>
 
         <service id="zikula_core.internal.token.generator" class="%zikula_core.internal.token.generator.class%">
-            <argument type="service" id="token.storage" />
+            <argument type="service" id="zikula_core.internal.token.storage" />
             <argument>_dummy</argument>
             <argument>%zikula_core.internal.token.max_life%</argument>
         </service>

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
@@ -63,7 +63,7 @@
         </service>
 
         <service id="zikula_core.internal.token.validator" class="%zikula_core.internal.token.validator.class%">
-            <argument type="service" id="token.generator" />
+            <argument type="service" id="zikula_core.internal.token.generator" />
         </service>
 
         <service id="zikula_core.common.csrf_token_handler" class="%zikula_core.common.csrf_token_handler.class%" >

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/core.xml
@@ -1,88 +1,85 @@
-<?xml version="1.0" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
     <parameters>
-        <parameter key="zikula.doctrine1_connector.class">Zikula\Bundle\CoreBundle\EventListener\Doctrine1ConnectorListener</parameter>
-        <parameter key="zikula.doctrine_connector.class">Zikula\Bundle\CoreBundle\EventListener\DoctrineListener</parameter>
+        <parameter key="zikula_core.internal.doctrine1_connector.class">Zikula\Bundle\CoreBundle\EventListener\Doctrine1ConnectorListener</parameter>
+        <parameter key="zikula_core.internal.doctrine_connector.class">Zikula\Bundle\CoreBundle\EventListener\DoctrineListener</parameter>
 
-        <parameter key="token.storage.class">Zikula\Core\Token\Storage\SessionStorage</parameter>
-        <parameter key="token.generator.class">Zikula\Core\Token\Generator</parameter>
-        <parameter key="token.validator.class">Zikula\Core\Token\Validator</parameter>
+        <parameter key="zikula_core.internal.token.storage.class">Zikula\Core\Token\Storage\SessionStorage</parameter>
+        <parameter key="zikula_core.internal.token.generator.class">Zikula\Core\Token\Generator</parameter>
+        <parameter key="zikula_core.internal.token.validator.class">Zikula\Core\Token\Validator</parameter>
         <parameter key="zikula_core.common.csrf_token_handler.class">Zikula\Core\Token\CsrfTokenHandler</parameter>
-        <parameter key="token.max_life">3600</parameter>
+        <parameter key="zikula_core.internal.token.max_life">3600</parameter>
 
-        <parameter key="markdown.class">Michelf\Markdown</parameter>
-        <parameter key="markdown_extra.class">Michelf\MarkdownExtra</parameter>
+        <parameter key="zikula_core.common.markdown.class">Michelf\Markdown</parameter>
+        <parameter key="zikula_core.common.markdown_extra.class">Michelf\MarkdownExtra</parameter>
 
         <!--<parameter key="zikula_core.class">Zikula\Core\Core</parameter>-->
-        <!--<parameter key="zikula.core_init_listener.class">Zikula\Bundle\CoreBundle\EventListener\InitListener</parameter>-->
+        <!--<parameter key="zikula_core.internal.core_init_listener.class">Zikula\Bundle\CoreBundle\EventListener\InitListener</parameter>-->
 
-        <parameter key="zikula.clickjack_protection_listener.class">Zikula\Bundle\CoreBundle\EventListener\ClickjackProtectionListener</parameter>
-        <parameter key="zikula.site_off_listener.class">Zikula\Bundle\CoreBundle\EventListener\SiteOffListener</parameter>
-        <parameter key="zikula.session_expire_listener.class">Zikula\Bundle\CoreBundle\EventListener\SessionExpireListener</parameter>
+        <parameter key="zikula_core.internal.clickjack_protection_listener.class">Zikula\Bundle\CoreBundle\EventListener\ClickjackProtectionListener</parameter>
+        <parameter key="zikula_core.internal.site_off_listener.class">Zikula\Bundle\CoreBundle\EventListener\SiteOffListener</parameter>
+        <parameter key="zikula_core.internal.session_expire_listener.class">Zikula\Bundle\CoreBundle\EventListener\SessionExpireListener</parameter>
         <parameter key="router_listener.class">Zikula\Bundle\CoreBundle\EventListener\RouterListener</parameter>
-        <parameter key="zikula.exception_listener.class">Zikula\Bundle\CoreBundle\EventListener\ExceptionListener</parameter>
-        <parameter key="zikula.output_compression_listener.class">Zikula\Bundle\CoreBundle\EventListener\OutputCompressionListener</parameter>
-        <parameter key="zikula.strip_front_controller_listener.class">Zikula\Bundle\CoreBundle\EventListener\StripFrontControllerListener</parameter>
-        <parameter key="zikula.doctrine.schema_tool.class">Zikula\Core\Doctrine\Helper\SchemaHelper</parameter>
+        <parameter key="zikula_core.internal.exception_listener.class">Zikula\Bundle\CoreBundle\EventListener\ExceptionListener</parameter>
+        <parameter key="zikula_core.internal.output_compression_listener.class">Zikula\Bundle\CoreBundle\EventListener\OutputCompressionListener</parameter>
+        <parameter key="zikula_core.internal.strip_front_controller_listener.class">Zikula\Bundle\CoreBundle\EventListener\StripFrontControllerListener</parameter>
+        <parameter key="zikula_core.common.doctrine.schema_tool.class">Zikula\Core\Doctrine\Helper\SchemaHelper</parameter>
         <parameter key="zikula_core.internal.bootstrap_helper.class">Zikula\Bundle\CoreBundle\Bundle\Helper\BootstrapHelper</parameter>
     </parameters>
-
     <services>
         <!--<service id="zikula" class="%zikula_core.class%">-->
             <!--<argument type="service" id="service_container" />-->
         <!--</service>-->
 
-        <service id="markdown_parser" class="%markdown.class%" />
-        <service id="markdown_extra_parser" class="%markdown_extra.class%" />
+        <service id="zikula_core.common.markdown_parser" class="%zikula_core.common.markdown.class%" />
+        <service id="zikula_core.common.markdown_extra_parser" class="%zikula_core.common.markdown_extra.class%" />
 
-        <!--<service id="zikula.core_init" class="%zikula.core_init_listener.class%">-->
+        <!--<service id="zikula_core.internal.core_init" class="%zikula_core.internal.core_init_listener.class%">-->
             <!--<tag name="zikula.event_subscriber" />-->
             <!--<argument type="service" id="service_container" />-->
         <!--</service>-->
 
-        <service id="zikula.doctrine1_init" class="%zikula.doctrine1_connector.class%">
+        <service id="zikula_core.internal.doctrine1_init" class="%zikula_core.internal.doctrine1_connector.class%">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="service_container" />
             <argument type="service" id="event_dispatcher" />
         </service>
 
-        <service id="zikula.doctrine_init" class="%zikula.doctrine_connector.class%">
+        <service id="zikula_core.internal.doctrine_init" class="%zikula_core.internal.doctrine_connector.class%">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="token.storage" class="%token.storage.class%">
+        <service id="zikula_core.internal.token.storage" class="%zikula_core.internal.token.storage.class%">
             <argument type="service" id="session" />
         </service>
 
-        <service id="token.generator" class="%token.generator.class%">
+        <service id="zikula_core.internal.token.generator" class="%zikula_core.internal.token.generator.class%">
             <argument type="service" id="token.storage" />
             <argument>_dummy</argument>
-            <argument>3600</argument>
+            <argument>%zikula_core.internal.token.max_life%</argument>
         </service>
 
-        <service id="token.validator" class="%token.validator.class%">
+        <service id="zikula_core.internal.token.validator" class="%zikula_core.internal.token.validator.class%">
             <argument type="service" id="token.generator" />
         </service>
 
         <service id="zikula_core.common.csrf_token_handler" class="%zikula_core.common.csrf_token_handler.class%" >
-            <argument type="service" id="token.generator" />
-            <argument type="service" id="token.validator" />
+            <argument type="service" id="zikula_core.internal.token.generator" />
+            <argument type="service" id="zikula_core.internal.token.validator" />
             <argument type="service" id="request_stack" />
             <argument type="service" id="zikula_extensions_module.api.variable" />
             <argument type="service" id="session" />
         </service>
 
-        <service id="zikula.clickjack_protection_listener" class="%zikula.clickjack_protection_listener.class%">
+        <service id="zikula_core.internal.clickjack_protection_listener" class="%zikula_core.internal.clickjack_protection_listener.class%">
             <tag name="kernel.event_subscriber" />
             <argument>%security.x_frame_options%</argument>
         </service>
 
-        <service id="zikula.site_off_listener" class="%zikula.site_off_listener.class%">
+        <service id="zikula_core.internal.site_off_listener" class="%zikula_core.internal.site_off_listener.class%">
             <argument type="service" id="zikula_extensions_module.api.variable" />
             <argument type="service" id="zikula_permissions_module.api.permission" />
             <argument type="service" id="zikula_users_module.current_user" />
@@ -93,12 +90,12 @@
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="zikula.session_expire_listener" class="%zikula.session_expire_listener.class%">
+        <service id="zikula_core.internal.session_expire_listener" class="%zikula_core.internal.session_expire_listener.class%">
             <argument>%installed%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="zikula.exception_listener" class="%zikula.exception_listener.class%">
+        <service id="zikula_core.internal.exception_listener" class="%zikula_core.internal.exception_listener.class%">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="logger" on-invalid="ignore" />
@@ -109,19 +106,19 @@
             <argument>%installed%</argument>
         </service>
 
-        <service id="zikula.output_compression_listener" class="%zikula.output_compression_listener.class%">
+        <service id="zikula_core.internal.output_compression_listener" class="%zikula_core.internal.output_compression_listener.class%">
             <argument type="service" id="zikula_extensions_module.api.variable" />
             <argument>%installed%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="zikula.strip_front_controller_listener" class="%zikula.strip_front_controller_listener.class%">
+        <service id="zikula_core.internal.strip_front_controller_listener" class="%zikula_core.internal.strip_front_controller_listener.class%">
             <argument type="service" id="zikula_extensions_module.api.variable" />
             <argument>%installed%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="zikula.doctrine.schema_tool" class="%zikula.doctrine.schema_tool.class%" lazy="true">
+        <service id="zikula_core.common.doctrine.schema_tool" class="%zikula_core.common.doctrine.schema_tool.class%" lazy="true">
             <argument type="service" id="doctrine.orm.default_entity_manager" />
         </service>
 
@@ -129,6 +126,5 @@
             <argument type="service" id="doctrine.dbal.default_connection" />
             <argument type="service" id="zikula.cache_clearer" />
         </service>
-
     </services>
 </container>

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/legacy_routing.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/legacy_routing.xml
@@ -1,17 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-
-    <!-- all these routes deprecated -->
-
+    <!-- all these routes are deprecated -->
     <route id="legacy" path="/">
         <default key="_controller">zikula_core.controller.legacy_controller:legacyAction</default>
         <condition>request.query.get('module') != '' and request.query.get('type') != '' and request.query.get('func') != ''</condition>
         <option key="i18n">false</option>
     </route>
-
     <route id="legacy_short_url" path="/{path}">
         <default key="_controller">zikula_core.controller.legacy_controller:shortUrlAction</default>
         <default key="path" />

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/routing.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/routing.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-
     <route id="home" path="/">
         <default key="_controller">zikula_core.controller.main_controller:homeAction</default>
         <condition>request.query.get('module') == ''</condition>

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/services.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
     <parameters>
         <parameter key="event_dispatcher.class">Zikula_EventManager</parameter>
         <!-- Make controller resolving working with Zikula base classes. -->
@@ -15,8 +13,8 @@
         <parameter key="zikula.cache_clearer.class">Zikula\Bundle\CoreBundle\CacheClearer</parameter>
         <parameter key="zikula.link_container_collector.class">Zikula\Core\LinkContainer\LinkContainerCollector</parameter>
     </parameters>
-
     <services>
+        <!-- Note: these services do not follow the service naming conventions on purpose (see #2550, maybe change for 2.0) -->
         <service id="zikula_core.controller.main_controller" class="%zikula_core.controller.main_controller.class%">
             <argument type="service" id="kernel" />
             <argument type="service" id="zikula_extensions_module.api.variable" />

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/session.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/session.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
     <parameters>
         <parameter key="session.class">Zikula_Session</parameter>
         <parameter key="session.flashbag.class">Symfony\Component\HttpFoundation\Session\Flash\FlashBag</parameter>
@@ -11,23 +9,22 @@
         <parameter key="session.storage.legacy.class">Zikula_Session_Storage_Legacy</parameter>
         <parameter key="session.handler.legacy.class">Zikula_Session_LegacyHandler</parameter>
     </parameters>
-
     <services>
-        <service id="session.storage.legacy" class="%session.storage.legacy.class%" public="false">
+        <service id="zikula_core.legacy.session_storage" class="%session.storage.legacy.class%" public="false">
             <argument type="service" id="zikula_extensions_module.api.variable" />
             <argument>%session.storage.options%</argument>
             <argument type="expression">null</argument>
             <argument type="expression">null</argument>
             <!--<argument type="service" id="session.handler" />-->
             <call method="setSaveHandler">
-                <argument type="service" id="session.handler.legacy" />
+                <argument type="service" id="zikula_core.legacy.session_handler" />
             </call>
         </service>
 
-        <service id="session.handler.legacy" class="%session.handler.legacy.class%" public="false">
+        <service id="zikula_core.legacy.session_handler" class="%session.handler.legacy.class%" public="false">
             <argument>%installed%</argument>
             <call method="setStorage">
-                <argument type="service" id="session.storage.legacy" />
+                <argument type="service" id="zikula_core.legacy.session_storage" />
             </call>
             <call method="setConnection">
                 <argument type="service" id="doctrine.dbal.default_connection" />

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/translation.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/translation.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
     <parameters>
         <parameter key="translator.class">Zikula\Common\Translator\Translator</parameter>
         <parameter key="zikula.extractor.file.php_extractor.class">Zikula\Bundle\CoreBundle\Translation\ZikulaPhpFileExtractor</parameter>
@@ -11,7 +9,6 @@
         <parameter key="zikula.dumper.pot_dumper.class">Zikula\Bundle\CoreBundle\Translation\Dumper\PotDumper</parameter>
         <parameter key="zikula.translation.loader.pot.class">Zikula\Bundle\CoreBundle\Translation\SymfonyLoader\MockPotFileLoader</parameter>
     </parameters>
-
     <services>
         <service id="translator.default" class="%translator.class%">
             <argument type="service" id="service_container" />
@@ -23,24 +20,23 @@
             </argument>
         </service>
 
-        <service id="zikula.extractor.file.php_extractor" class="%zikula.extractor.file.php_extractor.class%" public="false">
+        <service id="zikula_core.internal.translation_extractor.file.php_extractor" class="%zikula.extractor.file.php_extractor.class%" public="false">
             <argument type="service" id="jms_translation.doc_parser" />
             <argument type="service" id="kernel" strict="false" />
             <tag name="jms_translation.file_visitor" />
         </service>
 
-        <service id="zikula.extractor.file.twig_extractor" class="%zikula.extractor.file.twig_extractor.class%" public="false">
+        <service id="zikula_core.internal.translation_extractor.file.twig_extractor" class="%zikula.extractor.file.twig_extractor.class%" public="false">
             <argument type="service" id="twig" />
             <tag name="jms_translation.file_visitor" />
         </service>
 
-        <service id="zikula.dumper.pot_dumper" class="%zikula.dumper.pot_dumper.class%" public="false">
+        <service id="zikula_core.internal.translation_dumper.pot_dumper" class="%zikula.dumper.pot_dumper.class%" public="false">
             <tag name="jms_translation.dumper" format="pot" />
         </service>
 
-        <service id="translation.loader.pot" class="%zikula.translation.loader.pot.class%">
+        <service id="zikula_core.internal.translation_loader.pot" class="%zikula.translation.loader.pot.class%">
             <tag name="translation.loader" alias="pot" />
         </service>
-
     </services>
 </container>

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/twig.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/twig.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
     <parameters>
         <parameter key="twig.extension.zikula_gettext.class">Zikula\Bundle\CoreBundle\Twig\Extension\GettextExtension</parameter>
         <parameter key="twig.extension.zikula_core.class">Zikula\Bundle\CoreBundle\Twig\Extension\CoreExtension</parameter>
@@ -13,7 +11,6 @@
         <parameter key="twig.extension.date.class">Twig_Extensions_Extension_Date</parameter>
         <parameter key="twig.extension.array.class">Twig_Extensions_Extension_Array</parameter>
     </parameters>
-
     <services>
         <service id="twig.extension.zikula_gettext" class="%twig.extension.zikula_gettext.class%" public="false">
             <tag name="twig.extension" />

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/FinishCommand.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/FinishCommand.php
@@ -56,7 +56,7 @@ class FinishCommand extends AbstractCoreInstallerCommand
         foreach ($stages['stages'] as $key => $stage) {
             $io->text($stage[AjaxInstallerStage::PRE]);
             $io->text("<fg=blue;options=bold>" . $stage[AjaxInstallerStage::DURING] . "</fg=blue;options=bold>");
-            $status = $this->getContainer()->get('core_installer.controller.ajaxinstall')->commandLineAction($stage[AjaxInstallerStage::NAME]);
+            $status = $this->getContainer()->get('zikula_core_installer.controller.ajaxinstall')->commandLineAction($stage[AjaxInstallerStage::NAME]);
             if ($status) {
                 $io->success($stage[AjaxInstallerStage::SUCCESS]);
             } else {

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/StartCommand.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/StartCommand.php
@@ -59,13 +59,16 @@ class StartCommand extends AbstractCoreInstallerCommand
 
             return;
         }
-        $warnings = $this->getContainer()->get('core_installer.controller.util')->initPhp();
+
+        $controllerHelper = $this->getContainer()->get('zikula_core_installer.controller.util');
+
+        $warnings = $controllerHelper->initPhp();
         if (!empty($warnings)) {
             $this->printWarnings($output, $warnings);
 
             return;
         }
-        $checks = $this->getContainer()->get('core_installer.controller.util')->requirementsMet($this->getContainer());
+        $checks = $controllerHelper->requirementsMet($this->getContainer());
         if (true !== $checks) {
             $this->printRequirementsWarnings($output, $checks);
 
@@ -112,6 +115,7 @@ class StartCommand extends AbstractCoreInstallerCommand
                 return;
             }
         }
+
         // write the parameters to personal_config.php and custom_parameters.yml
         $yamlManager = new YamlDumper($this->getContainer()->get('kernel')->getRootDir() .'/config', 'custom_parameters.yml', 'parameters.yml');
         $params = array_merge($yamlManager->getParameters(), $settings);
@@ -119,7 +123,7 @@ class StartCommand extends AbstractCoreInstallerCommand
         $params['database_server_version'] = $dbh->getAttribute(\PDO::ATTR_SERVER_VERSION);
         $params['database_driver'] = 'pdo_' . $params['database_driver']; // doctrine requires prefix in custom_parameters.yml
         $yamlManager->setParameters($params);
-        $this->getContainer()->get('core_installer.config.util')->writeLegacyConfig($params);
+        $this->getContainer()->get('zikula_core_installer.config.util')->writeLegacyConfig($params);
         $this->getContainer()->get('zikula.cache_clearer')->clear('symfony.config');
 
         $io->success($this->translator->__('First stage of installation complete. Run `php app/console zikula:install:finish` to complete the installation.'));

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/UpgradeCommand.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/UpgradeCommand.php
@@ -81,13 +81,15 @@ class UpgradeCommand extends AbstractCoreInstallerCommand
         $initStage->isNecessary(); // runs init and upgradeUsersModule methods and intentionally returns false
         $io->success($this->translator->__('Initialization complete'));
 
-        $warnings = $this->getContainer()->get('core_installer.controller.util')->initPhp();
+        $controllerHelper = $this->getContainer()->get('zikula_core_installer.controller.util');
+
+        $warnings = $controllerHelper->initPhp();
         if (!empty($warnings)) {
             $this->printWarnings($output, $warnings);
 
             return;
         }
-        $checks = $this->getContainer()->get('core_installer.controller.util')->requirementsMet($this->getContainer());
+        $checks = $controllerHelper->requirementsMet($this->getContainer());
         if (true !== $checks) {
             $this->printRequirementsWarnings($output, $checks);
 
@@ -120,7 +122,7 @@ class UpgradeCommand extends AbstractCoreInstallerCommand
         foreach ($stages['stages'] as $key => $stage) {
             $io->text($stage[AjaxInstallerStage::PRE]);
             $io->text("<fg=blue;options=bold>" . $stage[AjaxInstallerStage::DURING] . "</fg=blue;options=bold>");
-            $status = $this->getContainer()->get('core_installer.controller.ajaxupgrade')->commandLineAction($stage[AjaxInstallerStage::NAME]);
+            $status = $this->getContainer()->get('zikula_core_installer.controller.ajaxupgrade')->commandLineAction($stage[AjaxInstallerStage::NAME]);
             if ($status) {
                 $io->success($stage[AjaxInstallerStage::SUCCESS]);
             } else {

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AbstractController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AbstractController.php
@@ -64,7 +64,7 @@ abstract class AbstractController
         $this->router = $this->container->get('router');
         $this->templatingService = $this->container->get('templating');
         $this->form = $this->container->get('form.factory');
-        $this->util = $this->container->get('core_installer.controller.util');
-        $this->configUtil = $this->container->get('core_installer.config.util');
+        $this->util = $this->container->get('zikula_core_installer.controller.util');
+        $this->configUtil = $this->container->get('zikula_core_installer.config.util');
     }
 }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxUpgradeController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxUpgradeController.php
@@ -64,7 +64,7 @@ class AjaxUpgradeController extends AbstractController
     {
         switch ($stageName) {
             case "loginadmin":
-                return $this->container->get('core_installer.controller.ajaxinstall')->loginAdmin();
+                return $this->container->get('zikula_core_installer.controller.ajaxinstall')->loginAdmin();
             case "upgrademodules":
                 $result = $this->upgradeModules();
                 if (count($result) === 0) {
@@ -75,7 +75,7 @@ class AjaxUpgradeController extends AbstractController
             case "installroutes":
                 return $this->installRoutesModule();
             case "reloadroutes":
-                return $this->container->get('core_installer.controller.ajaxinstall')->reloadRoutes();
+                return $this->container->get('zikula_core_installer.controller.ajaxinstall')->reloadRoutes();
             case "regenthemes":
                 return $this->regenerateThemes();
             case "from140to141":
@@ -103,7 +103,7 @@ class AjaxUpgradeController extends AbstractController
 
         $kernel = $this->container->get('kernel');
         $routeModuleName = 'ZikulaRoutesModule';
-        $install = $this->container->get('core_installer.controller.ajaxinstall')->installModule($routeModuleName);
+        $install = $this->container->get('zikula_core_installer.controller.ajaxinstall')->installModule($routeModuleName);
         if (!$install) {
             // error
             return false;
@@ -207,7 +207,7 @@ class AjaxUpgradeController extends AbstractController
         // install ZAuth
         $kernel = $this->container->get('kernel');
         $zAuthModuleName = 'ZikulaZAuthModule';
-        $install = $this->container->get('core_installer.controller.ajaxinstall')->installModule($zAuthModuleName);
+        $install = $this->container->get('zikula_core_installer.controller.ajaxinstall')->installModule($zAuthModuleName);
         if (!$install) {
             // error
             return false;

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/config/routing/routing.xml
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/config/routing/routing.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-
 <routes xmlns="http://symfony.com/schema/routing"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-
     <route id="install" path="/install/{stage}">
         <default key="_controller">core_installer.controller.installer:installAction</default>
         <default key="stage">null</default>
@@ -30,5 +28,4 @@
         <default key="_controller">core_installer.controller.doc:displayAction</default>
         <default key="name">INSTALL-1.4.md</default>
     </route>
-
 </routes>

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/config/services.xml
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/config/services.xml
@@ -1,56 +1,52 @@
-<?xml version="1.0" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
     <parameters>
-        <parameter key="core_installer.install_upgrade_check.class">Zikula\Bundle\CoreInstallerBundle\EventListener\InstallUpgradeCheckListener</parameter>
-        <parameter key="core_installer.controller.util.class">Zikula\Bundle\CoreInstallerBundle\Util\ControllerUtil</parameter>
-        <parameter key="core_installer.config.util.class">Zikula\Bundle\CoreInstallerBundle\Util\ConfigUtil</parameter>
-        <parameter key="core_installer.controller.installer.class">Zikula\Bundle\CoreInstallerBundle\Controller\InstallerController</parameter>
-        <parameter key="core_installer.controller.upgrader.class">Zikula\Bundle\CoreInstallerBundle\Controller\UpgraderController</parameter>
-        <parameter key="core_installer.controller.doc.class">Zikula\Bundle\CoreInstallerBundle\Controller\DocController</parameter>
-        <parameter key="core_installer.controller.ajaxinstall.class">Zikula\Bundle\CoreInstallerBundle\Controller\AjaxInstallController</parameter>
-        <parameter key="core_installer.controller.ajaxupgrade.class">Zikula\Bundle\CoreInstallerBundle\Controller\AjaxUpgradeController</parameter>
+        <parameter key="zikula_core_installer.install_upgrade_check.class">Zikula\Bundle\CoreInstallerBundle\EventListener\InstallUpgradeCheckListener</parameter>
+        <parameter key="zikula_core_installer.controller.util.class">Zikula\Bundle\CoreInstallerBundle\Util\ControllerUtil</parameter>
+        <parameter key="zikula_core_installer.config.util.class">Zikula\Bundle\CoreInstallerBundle\Util\ConfigUtil</parameter>
+        <parameter key="zikula_core_installer.controller.installer.class">Zikula\Bundle\CoreInstallerBundle\Controller\InstallerController</parameter>
+        <parameter key="zikula_core_installer.controller.upgrader.class">Zikula\Bundle\CoreInstallerBundle\Controller\UpgraderController</parameter>
+        <parameter key="zikula_core_installer.controller.doc.class">Zikula\Bundle\CoreInstallerBundle\Controller\DocController</parameter>
+        <parameter key="zikula_core_installer.controller.ajaxinstall.class">Zikula\Bundle\CoreInstallerBundle\Controller\AjaxInstallController</parameter>
+        <parameter key="zikula_core_installer.controller.ajaxupgrade.class">Zikula\Bundle\CoreInstallerBundle\Controller\AjaxUpgradeController</parameter>
     </parameters>
-
     <services>
-        <service id="core_installer.install_upgrade_check" class="%core_installer.install_upgrade_check.class%">
+        <service id="zikula_core_installer.install_upgrade_check" class="%zikula_core_installer.install_upgrade_check.class%">
             <argument type="service" id="service_container" />
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="core_installer.controller.util" class="%core_installer.controller.util.class%">
+        <service id="zikula_core_installer.controller.util" class="%zikula_core_installer.controller.util.class%">
         </service>
 
-        <service id="core_installer.config.util" class="%core_installer.config.util.class%">
+        <service id="zikula_core_installer.config.util" class="%zikula_core_installer.config.util.class%">
             <argument type="service" id="kernel" />
         </service>
 
-        <service id="core_installer.controller.installer" class="%core_installer.controller.installer.class%">
+        <service id="zikula_core_installer.controller.installer" class="%zikula_core_installer.controller.installer.class%">
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="core_installer.controller.upgrader" class="%core_installer.controller.upgrader.class%">
+        <service id="zikula_core_installer.controller.upgrader" class="%zikula_core_installer.controller.upgrader.class%">
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="core_installer.controller.ajaxinstall" class="%core_installer.controller.ajaxinstall.class%">
+        <service id="zikula_core_installer.controller.ajaxinstall" class="%zikula_core_installer.controller.ajaxinstall.class%">
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="core_installer.controller.ajaxupgrade" class="%core_installer.controller.ajaxupgrade.class%">
+        <service id="zikula_core_installer.controller.ajaxupgrade" class="%zikula_core_installer.controller.ajaxupgrade.class%">
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="core_installer.controller.doc" class="%core_installer.controller.doc.class%">
+        <service id="zikula_core_installer.controller.doc" class="%zikula_core_installer.controller.doc.class%">
             <argument type="service" id="kernel" />
             <argument type="service" id="router" />
             <argument type="service" id="templating" />
-            <argument type="service" id="markdown_extra_parser" />
+            <argument type="service" id="zikula_core.common.markdown_extra_parser" />
             <argument type="service" id="translator.default" />
         </service>
-
     </services>
 </container>

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/config/validators.xml
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/config/validators.xml
@@ -1,14 +1,11 @@
-<?xml version="1.0" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
     <parameters>
         <parameter key="zikula_core_installer_bundle.validator.constraints.valid_pdo_connection_validator.class">Zikula\Bundle\CoreInstallerBundle\Validator\Constraints\ValidPdoConnectionValidator</parameter>
         <parameter key="zikula_core_installer_bundle.validator.constraints.authenticate_admin_login_validator.class">Zikula\Bundle\CoreInstallerBundle\Validator\Constraints\AuthenticateAdminLoginValidator</parameter>
     </parameters>
-
     <services>
         <service id="zikula_core_installer_bundle.validator.constraints.valid_pdo_connection_validator" class="%zikula_core_installer_bundle.validator.constraints.valid_pdo_connection_validator.class%">
             <tag name="validator.constraint_validator" alias="zikula.core_installer.pdo_connection.validator" />

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/CreateAdminStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/CreateAdminStage.php
@@ -70,6 +70,6 @@ class CreateAdminStage implements StageInterface, FormHandlerInterface, InjectCo
 
     public function handleFormResult(FormInterface $form)
     {
-        $this->container->get('core_installer.controller.util')->writeEncodedAdminCredentials($this->yamlManager, $form->getData());
+        $this->container->get('zikula_core_installer.controller.util')->writeEncodedAdminCredentials($this->yamlManager, $form->getData());
     }
 }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/DbCredsStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/DbCredsStage.php
@@ -87,7 +87,7 @@ class DbCredsStage implements StageInterface, FormHandlerInterface, InjectContai
         $params['database_server_version'] = $dbh->getAttribute(\PDO::ATTR_SERVER_VERSION);
         $params['database_driver'] = 'pdo_' . $params['database_driver']; // doctrine requires prefix in custom_parameters.yml
         $this->writeParams($params);
-        $this->container->get('core_installer.config.util')->writeLegacyConfig($params);
+        $this->container->get('zikula_core_installer.config.util')->writeLegacyConfig($params);
     }
 
     private function writeParams($params)

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/RequirementsStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/RequirementsStage.php
@@ -41,12 +41,9 @@ class RequirementsStage implements StageInterface, InjectContainerInterface
 
     public function isNecessary()
     {
-        $this->requirementsMet = $this->container->get('core_installer.controller.util')->requirementsMet($this->container);
-        if ($this->requirementsMet === true) {
-            return false;
-        }
+        $this->requirementsMet = $this->container->get('zikula_core_installer.controller.util')->requirementsMet($this->container);
 
-        return true;
+        return !$this->requirementsMet;
     }
 
     public function getTemplateParams()

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Upgrade/LoginStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Upgrade/LoginStage.php
@@ -51,7 +51,7 @@ class LoginStage implements StageInterface, FormHandlerInterface, InjectContaine
 
     public function handleFormResult(FormInterface $form)
     {
-        $this->container->get('core_installer.controller.util')->writeEncodedAdminCredentials($this->yamlManager, $form->getData());
+        $this->container->get('zikula_core_installer.controller.util')->writeEncodedAdminCredentials($this->yamlManager, $form->getData());
     }
 
     public function isNecessary()

--- a/src/lib/Zikula/Bundle/FormExtensionBundle/Resources/config/services.xml
+++ b/src/lib/Zikula/Bundle/FormExtensionBundle/Resources/config/services.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
     <parameters>
         <parameter key="zikula.form.type.locale.class">Zikula\Bundle\FormExtensionBundle\Form\Type\LocaleType</parameter>
         <parameter key="zikula.form_extension.icon.class">Zikula\Bundle\FormExtensionBundle\Form\Extension\ButtonTypeIconExtension</parameter>

--- a/src/lib/Zikula/Bundle/HookBundle/Resources/config/services.yml
+++ b/src/lib/Zikula/Bundle/HookBundle/Resources/config/services.yml
@@ -1,45 +1,44 @@
 services:
+    zikula_hook_bundle.installer:
+        class: Zikula\Bundle\HookBundle\HookBundleInstaller
+        arguments: ["@zikula_core.common.doctrine.schema_tool"]
 
-  zikula_hook_bundle.installer:
-    class: Zikula\Bundle\HookBundle\HookBundleInstaller
-    arguments: [ "@zikula.doctrine.schema_tool" ]
+    zikula_hook_bundle.listener.core_installer_listener:
+        class: Zikula\Bundle\HookBundle\Listener\CoreInstallerListener
+        arguments: ["@zikula_hook_bundle.installer"]
+        tags:
+        - { name: kernel.event_subscriber }
 
-  zikula_hook_bundle.listener.core_installer_listener:
-    class: Zikula\Bundle\HookBundle\Listener\CoreInstallerListener
-    arguments: [ "@zikula_hook_bundle.installer" ]
-    tags:
-      - { name: kernel.event_subscriber }
+    zikula_hook_bundle.listener.hooks_listener:
+        class: Zikula\Bundle\HookBundle\Listener\HooksListener
+        arguments: ["@zikula_permissions_module.api.permission", "@zikula_extensions_module.api.capability", "@router"]
+        tags:
+        - { name: kernel.event_subscriber }
 
-  zikula_hook_bundle.listener.hooks_listener:
-    class: Zikula\Bundle\HookBundle\Listener\HooksListener
-    arguments: [ "@zikula_permissions_module.api.permission", "@zikula_extensions_module.api.capability", "@router" ]
-    tags:
-      - { name: kernel.event_subscriber }
+    twig.extension.zikula_hook:
+        class: Zikula\Bundle\HookBundle\Twig\Extension\HookExtension
+        arguments: ["@hook_dispatcher"]
+        tags:
+            - { name: twig.extension }
 
-  twig.extension.zikula_hook:
-    class: Zikula\Bundle\HookBundle\Twig\Extension\HookExtension
-    arguments: ["@hook_dispatcher"]
-    tags:
-        - { name: twig.extension }
+    hook_dispatcher.storage:
+        class: Zikula\Bundle\HookBundle\Dispatcher\Storage\Doctrine\DoctrineStorage
+        arguments: ["@doctrine.orm.default_entity_manager"]
 
-  hook_dispatcher.storage:
-    class: Zikula\Bundle\HookBundle\Dispatcher\Storage\Doctrine\DoctrineStorage
-    arguments: ["@doctrine.orm.default_entity_manager"]
+    hook_dispatcher.servicefactory:
+        class: Zikula\Bundle\HookBundle\Dispatcher\ServiceFactory
+        arguments: ["@service_container", "event_dispatcher"]
+        # note: the second args is intentionally a string.
 
-  hook_dispatcher.servicefactory:
-    class: Zikula\Bundle\HookBundle\Dispatcher\ServiceFactory
-    arguments: ["@service_container", "event_dispatcher"]
-    # note: the second args is intentionally a string.
+    hook_dispatcher:
+        class: Zikula_HookDispatcher
+        # at Core-2.0 use Zikula\Bundle\HookBundle\Dispatcher\HookDispatcher
+        arguments: ["@hook_dispatcher.storage", "@event_dispatcher", "@hook_dispatcher.servicefactory"]
 
-  hook_dispatcher:
-    class: Zikula_HookDispatcher
-    # at Core-2.0 use Zikula\Bundle\HookBundle\Dispatcher\HookDispatcher
-    arguments: ["@hook_dispatcher.storage", "@event_dispatcher", "@hook_dispatcher.servicefactory"]
+    zikula.hookmanager:
+        alias: hook_dispatcher
 
-  zikula.hookmanager:
-    alias: hook_dispatcher
-
-  zikula_hook_bundle.api.hook:
-    class: Zikula\Bundle\HookBundle\Api\HookApi
-    lazy: true
-    arguments: ["@translator.default", "@hook_dispatcher", "@event_dispatcher"]
+    zikula_hook_bundle.api.hook:
+        class: Zikula\Bundle\HookBundle\Api\HookApi
+        lazy: true
+        arguments: ["@translator.default", "@hook_dispatcher", "@event_dispatcher"]

--- a/src/lib/Zikula/Core/AbstractExtensionInstaller.php
+++ b/src/lib/Zikula/Core/AbstractExtensionInstaller.php
@@ -96,7 +96,7 @@ abstract class AbstractExtensionInstaller implements ExtensionInstallerInterface
         $this->container = $container;
         $this->setTranslator($container->get('translator'));
         $this->entityManager = $container->get('doctrine.entitymanager');
-        $this->schemaTool = $container->get('zikula.doctrine.schema_tool');
+        $this->schemaTool = $container->get('zikula_core.common.doctrine.schema_tool');
         $this->extensionName = $this->name; // for ExtensionVariablesTrait
         $this->variableApi = $container->get('zikula_extensions_module.api.variable'); // for ExtensionVariablesTrait
         $this->hookApi = $container->get('zikula_hook_bundle.api.hook');

--- a/src/lib/util/StringUtil.php
+++ b/src/lib/util/StringUtil.php
@@ -247,7 +247,7 @@ class StringUtil
     {
         $sm = ServiceUtil::getManager();
 
-        return $sm->get('markdown_parser');
+        return $sm->get('zikula_core.common.markdown_parser');
     }
 
     /**
@@ -259,6 +259,6 @@ class StringUtil
     {
         $sm = ServiceUtil::getManager();
 
-        return $sm->get('markdown_extra_parser');
+        return $sm->get('zikula_core.common.markdown_extra_parser');
     }
 }

--- a/src/system/SettingsModule/Resources/config/services.xml
+++ b/src/system/SettingsModule/Resources/config/services.xml
@@ -36,10 +36,5 @@
             <argument type="service" id="zikula_settings_module.locale_api" />
             <tag name="kernel.event_subscriber"/>
         </service>
-        <service id="zikula_settings_module.listener.locale_listener" class="%zikula_settings_module.listener.locale_listener.class%">
-            <argument type="service" id="kernel" />
-            <argument type="service" id="zikula_settings_module.locale_api" />
-            <tag name="kernel.event_subscriber"/>
-        </service>
     </services>
 </container>

--- a/src/system/SettingsModule/Resources/config/services.xml
+++ b/src/system/SettingsModule/Resources/config/services.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="zikula_settings_module.container.link_container.class">Zikula\SettingsModule\Container\LinkContainer</parameter>
-        <parameter key="zikulasettingsmodule.module_listener.class">Zikula\SettingsModule\Listener\ModuleListener</parameter>
+        <parameter key="zikula_settings_module.module_listener.class">Zikula\SettingsModule\Listener\ModuleListener</parameter>
         <parameter key="zikula_settings_module.locale_api.class">Zikula\SettingsModule\Api\LocaleApi</parameter>
         <parameter key="zikula_settings_module.listener.locale_listener.class">Zikula\SettingsModule\Listener\LocaleListener</parameter>
     </parameters>
@@ -16,7 +16,13 @@
             <tag name="zikula.link_container"/>
         </service>
 
-        <service id="zikulasettingsmodule.module_listener" class="%zikulasettingsmodule.module_listener.class%">
+        <service id="zikula_settings_module.module_listener" class="%zikula_settings_module.module_listener.class%">
+            <argument type="service" id="zikula_extensions_module.api.variable" />
+            <argument type="service" id="session" />
+            <tag name="kernel.event_subscriber" />
+        </service>
+        <!-- to be removed in 2.0 -->
+        <service id="zikulasettingsmodule.module_listener" alias="zikula_settings_module.module_listener" class="%zikula_settings_module.module_listener.class%">
             <argument type="service" id="zikula_extensions_module.api.variable" />
             <argument type="service" id="session" />
             <tag name="kernel.event_subscriber" />
@@ -25,6 +31,11 @@
         <service id="zikula_settings_module.locale_api" class="%zikula_settings_module.locale_api.class%">
         </service>
 
+        <service id="zikula_settings_module.listener.locale_listener" class="%zikula_settings_module.listener.locale_listener.class%">
+            <argument type="service" id="kernel" />
+            <argument type="service" id="zikula_settings_module.locale_api" />
+            <tag name="kernel.event_subscriber"/>
+        </service>
         <service id="zikula_settings_module.listener.locale_listener" class="%zikula_settings_module.listener.locale_listener.class%">
             <argument type="service" id="kernel" />
             <argument type="service" id="zikula_settings_module.locale_api" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #2550 |
| Refs tickets | - |
| License | MIT |
| Changelog updated | no |
## Todos
- [ ] Decide whether to convert `lib/Zikula/Bundle/CoreBundle/Resources/config/services.xml` too (I did not)
