### PR TITLE
do not install PageLock by default, fixed #3162

### DIFF
--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxInstallController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxInstallController.php
@@ -179,7 +179,7 @@ class AjaxInstallController extends AbstractController
         /** @var ExtensionEntity[] $extensions */
         $extensions = $this->container->get('zikula_extensions_module.extension_repository')->findAll();
         foreach ($extensions as $extension) {
-            if (\ZikulaKernel::isCoreModule($extension->getName())) {
+            if ($extension->getName() != 'ZikulaPageLockModule' && \ZikulaKernel::isCoreModule($extension->getName())) {
                 $extension->setState(ExtensionApi::STATE_ACTIVE);
             }
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #3162 
| Refs tickets      | -
| License           | MIT
| Changelog updated | no
