### PR TITLE
Init category name and description by languages if not set

### DIFF
--- a/src/lib/util/CategoryUtil.php
+++ b/src/lib/util/CategoryUtil.php
@@ -112,6 +112,17 @@ class CategoryUtil
         // convert to array
         $cat = $category->toArray();
 
+        // set name and description by languages if not set
+        $languages = ZLanguage::getInstalledLanguages();
+        foreach ($languages as $lang) {
+            if (!isset($cat['display_name'][$lang])) {
+                $cat['display_name'][$lang] = isset($cat['display_name']['en']) ? $cat['display_name']['en'] : '';
+            }
+            if (!isset($cat['display_desc'][$lang])) {
+                $cat['display_desc'][$lang] = isset($cat['display_desc']['en']) ? $cat['display_desc']['en'] : '';
+            }
+        }
+
         // assign parent_id
         // this makes the rootcat's parent 0 as it's stored as null in the database
         $cat['parent_id'] = (null === $cat['parent']) ? null : $category['parent']->getId();
@@ -162,8 +173,19 @@ class CategoryUtil
         $categories = $query->getResult();
 
         $cats = [];
+        $languages = ZLanguage::getInstalledLanguages();
         foreach ($categories as $category) {
             $cat = $category->toArray();
+
+            // set name and description by languages if not set
+            foreach ($languages as $lang) {
+                if (!isset($cat['display_name'][$lang])) {
+                    $cat['display_name'][$lang] = isset($cat['display_name']['en']) ? $cat['display_name']['en'] : '';
+                }
+                if (!isset($cat['display_desc'][$lang])) {
+                    $cat['display_desc'][$lang] = isset($cat['display_desc']['en']) ? $cat['display_desc']['en'] : '';
+                }
+            }
 
             // this makes the rotocat's parent 0 as it's stored as null in the database
             $cat['parent_id'] = (null === $cat['parent']) ? null : $category['parent']->getId();


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | - #3124
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description
After new language installation, it is available immediately in Zikula, but in database categories name and description remain untouched. So, check for missing language items (name and description) and init them at the point when getting from database.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog

