### PR TITLE
easier password reset process, fixed #1781, plus some minor fixes

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -4,7 +4,7 @@ CHANGELOG - ZIKULA 1.4.x
 * 1.4.4 (?)
 
  - BC Breaks:
-    - Password reminder has been removed (#1682, #3172) in favour of easier lost password functionality (#1781).
+    - Password reminder has been removed (#1682, #3172) in favour of easier lost password functionality (#1781, #3178).
 
  - Deprecated:
     - ExtMenu and MenuTree blocks are deprecated and will not be refactored to Twig/Core-2.0.
@@ -24,6 +24,9 @@ CHANGELOG - ZIKULA 1.4.x
     - Fixed regression in argument typehints in UserUtil (#3123).
     - Fixed some problems with the Zikula Symfony Translator (#3161).
     - Fixed upgrade in Settings module for shorturl value to boolean (#3166).
+
+ - Features:
+    - Lost password functionality has been simplified to work without an additional (confusing) confirmation step (#1781, #3178).
 
  - Core-2.0 Features:
     - Added mailProtect filter for safe display of email addresses in Twig templates (#3041).

--- a/src/system/UsersModule/Controller/UserController.php
+++ b/src/system/UsersModule/Controller/UserController.php
@@ -111,7 +111,7 @@ class UserController extends \Zikula_AbstractController
     {
         @trigger_error('This method is deprecated. Please use AccountController::confirmationCodeAction', E_USER_DEPRECATED);
 
-        return new RedirectResponse($this->get('router')->generate('zikulazauthmodule_account_confirmationcode'));
+        return new RedirectResponse($this->get('router')->generate('zikulazauthmodule_account_lostpassword'));
     }
 
     /**

--- a/src/system/UsersModule/Resources/views/Account/menu.html.twig
+++ b/src/system/UsersModule/Resources/views/Account/menu.html.twig
@@ -7,7 +7,6 @@
         <li><a href="{{ path('zikulausersmodule_registration_register') }}">{{ __('I would like to create a new account.') }}</a></li>
         <li><a href="{{ path('zikulazauthmodule_account_lostusername') }}">{{ __('I have forgotten my account information (for example, my user name).') }}</a></li>
         <li><a href="{{ path('zikulazauthmodule_account_lostpassword') }}">{{ __('I have forgotten my password.') }}</a></li>
-        <li><a href="{{ path('zikulazauthmodule_account_confirmationcode') }}">{{ __('I have received a password recovery code, and would like to enter it.') }}</a></li>
     </ul>
 {% endif %}
 

--- a/src/system/ZAuthModule/Container/LinkContainer.php
+++ b/src/system/ZAuthModule/Container/LinkContainer.php
@@ -161,10 +161,6 @@ class LinkContainer implements LinkContainerInterface
                 [
                     'text' => $this->translator->__('Recover Lost Password'),
                     'url' => $this->router->generate('zikulazauthmodule_account_lostpassword')
-                ],
-                [
-                    'text' => $this->translator->__('Enter Password Recovery Code'),
-                    'url' => $this->router->generate('zikulazauthmodule_account_confirmationcode')
                 ]
             ],
             'text' => $this->translator->__('Recover account information or password'),

--- a/src/system/ZAuthModule/Controller/AccountController.php
+++ b/src/system/ZAuthModule/Controller/AccountController.php
@@ -186,24 +186,13 @@ class AccountController extends AbstractController
             return $this->redirectToRoute($redirectToRoute);
         }
 
-        $user = $this->get('zikula_users_module.user_repository')->findBy([
-            'uid' => $requestDetails['userId'],
-            'uname' => $requestDetails['userName'],
-            'email' => $requestDetails['emailAddress']
-        ]);
-
-        if (count($user) > 1) {
-            $this->addFlash('error', $this->__('There are too many users registered with that address. Please contact the system administrator for assistance.'));
-
-            return $this->redirectToRoute($redirectToRoute);
-        } elseif (count($user) < 1) {
+        /** @var UserEntity $user */
+        $user = $this->get('zikula_users_module.user_repository')->find($requestDetails['userId']);
+        if (null === $user) {
             $this->addFlash('error', $this->__('User not found. Please contact the system administrator for assistance.'));
 
             return $this->redirectToRoute($redirectToRoute);
         }
-
-        /** @var UserEntity $user */
-        $user = $user[0];
 
         if (!$lostPasswordVerificationHelper->checkConfirmationCode($user->getUid(), $requestDetails['confirmationCode'])) {
             $this->addFlash('error', $this->__('Your request could not be processed due to invalid arguments. Maybe your link is expired?'));

--- a/src/system/ZAuthModule/Controller/AccountController.php
+++ b/src/system/ZAuthModule/Controller/AccountController.php
@@ -13,6 +13,7 @@ namespace Zikula\ZAuthModule\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
@@ -33,7 +34,7 @@ class AccountController extends AbstractController
      * @Route("/lost-user-name")
      * @Template
      * @param Request $request
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function lostUserNameAction(Request $request)
     {
@@ -75,7 +76,7 @@ class AccountController extends AbstractController
      * @Route("/lost-password")
      * @Template
      * @param Request $request
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function lostPasswordAction(Request $request)
     {
@@ -99,15 +100,17 @@ class AccountController extends AbstractController
                 $user = $this->get('zikula_users_module.user_repository')->find($mapping->getUid());
                 switch ($user->getActivated()) {
                     case UsersConstant::ACTIVATED_ACTIVE:
-                        $newConfirmationCode = $this->get('zikula_zauth_module.user_verification_repository')->setVerificationCode($mapping->getUid());
+                        $changePasswordExpireDays = $this->getVar(ZAuthConstant::MODVAR_EXPIRE_DAYS_CHANGE_PASSWORD, ZAuthConstant::DEFAULT_EXPIRE_DAYS_CHANGE_PASSWORD);
+                        $lostPasswordId = $this->get('zikula_zauth_module.helper.lost_password_verification_helper')->createLostPasswordId($mapping);
                         $sent = $this->get('zikula_zauth_module.helper.mail_helper')->sendNotification($mapping->getEmail(), 'lostpassword', [
                             'uname' => $mapping->getUname(),
-                            'code' => $newConfirmationCode,
-                            'requestedByAdmin' => false
+                            'validDays' => $changePasswordExpireDays,
+                            'lostPasswordId' => $lostPasswordId,
+                            'requestedByAdmin' => false,
                         ]);
                         if ($sent) {
-                            $this->addFlash('status', $this->__f('Done! The confirmation code for %s has been sent via e-mail.', ['%s' => $data[$field]]));
-                            $redirectToRoute = 'zikulazauthmodule_account_confirmationcode';
+                            $this->addFlash('status', $this->__f('Done! The confirmation link for %s has been sent via e-mail.', ['%s' => $data[$field]]));
+                            $redirectToRoute = 'zikulausersmodule_account_menu';
                         } else {
                             $this->addFlash('error', $this->__f('Unable to send email to the requested %s. Please try your %o or contact the system administrator for assistance.', ['%s' => $map[$field], '%o' => $map[$inverse]]));
                         }
@@ -147,55 +150,88 @@ class AccountController extends AbstractController
     }
 
     /**
-     * @Route("/lost-password/code")
+     * @Route("/lost-password/reset")
      * @Template
      * @param Request $request
      * @return array
      */
-    public function confirmationCodeAction(Request $request)
+    public function lostPasswordResetAction(Request $request)
     {
+        $redirectToRoute = 'zikulausersmodule_account_menu';
+
         if ($this->get('zikula_users_module.current_user')->isLoggedIn()) {
-            return $this->redirectToRoute('zikulausersmodule_account_menu');
+            return $this->redirectToRoute($redirectToRoute);
+        }
+
+        if (!$request->query->has('id')) {
+            $this->addFlash('error', $this->__('Your request could not be processed due to missing arguments.'));
+
+            return $this->redirectToRoute($redirectToRoute);
+        }
+
+        $lostPasswordVerificationHelper = $this->get('zikula_zauth_module.helper.lost_password_verification_helper');
+        $requestDetails = [];
+
+        try {
+            $requestDetails = $lostPasswordVerificationHelper->decodeLostPasswordId($request->query->get('id'));
+        } catch (Exception $e) {
+            $this->addFlash('error', $this->__('Your request could not be processed.') . ' ' . $e->getMessage());
+
+            return $this->redirectToRoute($redirectToRoute);
+        }
+
+        if ($requestDetails['userId'] == '' || $requestDetails['userName'] == '' || $requestDetails['emailAddress'] == '') {
+            $this->addFlash('error', $this->__('Your request could not be processed due to invalid arguments.'));
+
+            return $this->redirectToRoute($redirectToRoute);
+        }
+
+        $user = $this->get('zikula_users_module.user_repository')->findBy([
+            'uid' => $requestDetails['userId'],
+            'uname' => $requestDetails['userName'],
+            'email' => $requestDetails['emailAddress']
+        ]);
+
+        if (count($user) > 1) {
+            $this->addFlash('error', $this->__('There are too many users registered with that address. Please contact the system administrator for assistance.'));
+
+            return $this->redirectToRoute($redirectToRoute);
+        } elseif (count($user) < 1) {
+            $this->addFlash('error', $this->__('User not found. Please contact the system administrator for assistance.'));
+
+            return $this->redirectToRoute($redirectToRoute);
+        }
+
+        /** @var UserEntity $user */
+        $user = $user[0];
+
+        if (!$lostPasswordVerificationHelper->checkConfirmationCode($user->getUid(), $requestDetails['confirmationCode'])) {
+            $this->addFlash('error', $this->__('Your request could not be processed due to invalid arguments. Maybe your link is expired?'));
+
+            return $this->redirectToRoute($redirectToRoute);
         }
 
         $form = $this->createForm('Zikula\ZAuthModule\Form\Type\LostPasswordType', [], [
                 'translator' => $this->get('translator.default'),
-                'includeCode' => true,
+                'includeReset' => true
             ]
         );
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            $map = ['uname' => $this->__('username'), 'email' => $this->__('email address')];
             $data = $form->getData();
-            $field = empty($data['uname']) ? 'email' : 'uname';
-            $user = $this->get('zikula_users_module.user_repository')->findBy([$field => $data[$field]]);
-            if (count($user) == 1) {
-                /** @var UserEntity $user */
-                $user = $user[0];
-                $changePasswordExpireDays = $this->getVar(ZAuthConstant::MODVAR_EXPIRE_DAYS_CHANGE_PASSWORD, ZAuthConstant::DEFAULT_EXPIRE_DAYS_CHANGE_PASSWORD);
-                $this->get('zikula_zauth_module.user_verification_repository')->purgeExpiredRecords($changePasswordExpireDays);
-                /** @var UserVerificationEntity $userVerificationEntity */
-                $userVerificationEntity = $this->get('zikula_zauth_module.user_verification_repository')->findOneBy(['uid' => $user->getUid(), 'changetype' => ZAuthConstant::VERIFYCHGTYPE_PWD]);
-                if (isset($userVerificationEntity) && (\UserUtil::passwordsMatch($data['code'], $userVerificationEntity->getVerifycode()))) {
-                    $mapping = $this->get('zikula_zauth_module.authentication_mapping_repository')->getByZikulaId($user->getUid());
-                    $mapping->setPass(\UserUtil::getHashedPassword($data['pass']));
-                    $this->get('zikula_zauth_module.authentication_mapping_repository')->persistAndFlush($mapping);
-                    $this->get('zikula_users_module.helper.access_helper')->login($user);
-                    $this->addFlash('success', $this->__('Code is confirmed. You are now logged in with your new password.'));
 
-                    return $this->redirectToRoute('zikulausersmodule_account_menu');
-                } else {
-                    $this->addFlash('error', $this->__('Invalid or expired code.'));
-                }
-            } elseif (count($user) > 1) {
-                $this->addFlash('error', $this->__('There are too many users registered with that address. Please contact the system administrator for assistance.'));
-            } else {
-                $this->addFlash('error', $this->__f('%s not found. Please contact the system administrator for assistance.', ['%s' => ucwords($map[$field])]));
-            }
+            $mappingRepository = $this->get('zikula_zauth_module.authentication_mapping_repository');
+            $mapping = $mappingRepository->getByZikulaId($user->getUid());
+            $mapping->setPass(\UserUtil::getHashedPassword($data['pass']));
+            $mappingRepository->persistAndFlush($mapping);
+            $this->get('zikula_users_module.helper.access_helper')->login($user);
+            $this->addFlash('success', $this->__('Your change has been successfully saved. You are now logged in with your new password.'));
+
+            return $this->redirectToRoute($redirectToRoute);
         }
 
         return [
-            'form' => $form->createView(),
+            'form' => $form->createView()
         ];
     }
 
@@ -221,10 +257,10 @@ class AccountController extends AbstractController
             $currentUser = $this->get('zikula_users_module.current_user');
             $code = $this->get('zikula_zauth_module.user_verification_repository')->setVerificationCode($currentUser->get('uid'), ZAuthConstant::VERIFYCHGTYPE_EMAIL, $data['email']);
             $templateArgs = [
-                'uname'     => $currentUser->get('uname'),
-                'email'     => $currentUser->get('email'),
-                'newemail'  => $data['email'],
-                'url'       => $this->get('router')->generate('zikulazauthmodule_account_confirmchangedemail', ['code' => $code], RouterInterface::ABSOLUTE_URL),
+                'uname'    => $currentUser->get('uname'),
+                'email'    => $currentUser->get('email'),
+                'newemail' => $data['email'],
+                'url'      => $this->get('router')->generate('zikulazauthmodule_account_confirmchangedemail', ['code' => $code], RouterInterface::ABSOLUTE_URL),
             ];
             $sent = $this->get('zikula_zauth_module.helper.mail_helper')->sendNotification($data['email'], 'userverifyemail', $templateArgs);
             if ($sent) {
@@ -338,7 +374,7 @@ class AccountController extends AbstractController
             'login' => $login,
             'form' => $form->createView(),
             'user' => $mapping,
-            'modvars' => $this->getVars(),
+            'modvars' => $this->getVars()
         ];
     }
 }

--- a/src/system/ZAuthModule/Controller/UserAdministrationController.php
+++ b/src/system/ZAuthModule/Controller/UserAdministrationController.php
@@ -318,14 +318,16 @@ class UserAdministrationController extends AbstractController
         if (!$this->hasPermission('ZikulaZAuthModule', $mapping->getUname() . '::' . $mapping->getUid(), ACCESS_MODERATE)) {
             throw new AccessDeniedException();
         }
-        $newConfirmationCode = $this->get('zikula_zauth_module.user_verification_repository')->setVerificationCode($mapping->getUid());
+        $changePasswordExpireDays = $this->getVar(ZAuthConstant::MODVAR_EXPIRE_DAYS_CHANGE_PASSWORD, ZAuthConstant::DEFAULT_EXPIRE_DAYS_CHANGE_PASSWORD);
+        $lostPasswordId = $this->get('zikula_zauth_module.helper.lost_password_verification_helper')->createLostPasswordId($mapping);
         $mailSent = $this->get('zikula_zauth_module.helper.mail_helper')->sendNotification($mapping->getEmail(), 'lostpassword', [
             'uname' => $mapping->getUname(),
-            'code' => $newConfirmationCode,
+            'validDays' => $changePasswordExpireDays,
+            'lostPasswordId' => $lostPasswordId,
             'requestedByAdmin' => true
         ]);
         if ($mailSent) {
-            $this->addFlash('status', $this->__f('Done! The password recovery verification code for %s has been sent via e-mail.', ['%s' => $mapping->getUname()]));
+            $this->addFlash('status', $this->__f('Done! The password recovery verification link for %s has been sent via e-mail.', ['%s' => $mapping->getUname()]));
         }
 
         return $this->redirectToRoute('zikulazauthmodule_useradministration_list');

--- a/src/system/ZAuthModule/Entity/UserVerificationEntity.php
+++ b/src/system/ZAuthModule/Entity/UserVerificationEntity.php
@@ -23,7 +23,8 @@ use Zikula\Core\Doctrine\EntityAccess;
  * @ORM\Table(name="users_verifychg")
  *
  * Account-change verification table.
- * Holds a one-time use, expirable verification code used when a user needs to change his email address
+ * Holds a one-time use, expirable verification code used when a user needs to change his email address,
+ * reset his password and has not answered any security questions,
  * or when a new user is registering with the site for the first time.
  */
 class UserVerificationEntity extends EntityAccess

--- a/src/system/ZAuthModule/Entity/UserVerificationEntity.php
+++ b/src/system/ZAuthModule/Entity/UserVerificationEntity.php
@@ -23,8 +23,7 @@ use Zikula\Core\Doctrine\EntityAccess;
  * @ORM\Table(name="users_verifychg")
  *
  * Account-change verification table.
- * Holds a one-time use, expirable verification code used when a user needs to changs his email address,
- * reset his password and has not answered any security questions,
+ * Holds a one-time use, expirable verification code used when a user needs to change his email address
  * or when a new user is registering with the site for the first time.
  */
 class UserVerificationEntity extends EntityAccess

--- a/src/system/ZAuthModule/Form/Type/LostPasswordType.php
+++ b/src/system/ZAuthModule/Form/Type/LostPasswordType.php
@@ -35,11 +35,6 @@ class LostPasswordType extends AbstractType
                     'label' => $options['translator']->__('Email Address'),
                     'input_group' => ['left' => '<i class="fa fa-at"></i>'],
                 ])
-                ->add('submit', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', [
-                    'label' => $options['translator']->__('Submit'),
-                    'icon' => 'fa-check',
-                    'attr' => ['class' => 'btn btn-success']
-                ])
             ;
         } else {
             $builder
@@ -61,6 +56,13 @@ class LostPasswordType extends AbstractType
                 ])
             ;
         }
+        $builder
+            ->add('submit', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', [
+                'label' => $options['translator']->__('Submit'),
+                'icon' => 'fa-check',
+                'attr' => ['class' => 'btn btn-success']
+            ])
+        ;
     }
 
     public function getBlockPrefix()
@@ -77,7 +79,7 @@ class LostPasswordType extends AbstractType
             'translator' => null,
             'includeReset' => false,
             'constraints' => new Callback(['callback' => function ($data, ExecutionContextInterface $context) use ($resolver) {
-                if (empty($data['uname']) && empty($data['email'])) {
+                if (!isset($data['pass']) && empty($data['uname']) && empty($data['email'])) {
                     $context->buildViolation(__('Error! You must enter either your username or email address.'))
                         ->addViolation();
                 }

--- a/src/system/ZAuthModule/Form/Type/LostPasswordType.php
+++ b/src/system/ZAuthModule/Form/Type/LostPasswordType.php
@@ -23,29 +23,26 @@ class LostPasswordType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder
-            ->add('uname', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
-                'required' => false,
-                'label' => $options['translator']->__('User name'),
-                'input_group' => ['left' => '<i class="fa fa-user"></i>'],
-            ])
-            ->add('email', 'Symfony\Component\Form\Extension\Core\Type\EmailType', [
-                'required' => false,
-                'label' => $options['translator']->__('Email Address'),
-                'input_group' => ['left' => '<i class="fa fa-at"></i>'],
-            ])
-            ->add('submit', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', [
-                'label' => $options['translator']->__('Submit'),
-                'icon' => 'fa-check',
-                'attr' => ['class' => 'btn btn-success']
-            ])
-        ;
-        if ($options['includeCode']) {
+        if (!$options['includeReset']) {
             $builder
-                ->add('code', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
-                    'label' => $options['translator']->__('Confirmation code'),
-                    'input_group' => ['left' => '<i class="fa fa-code"></i>'],
+                ->add('uname', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                    'required' => false,
+                    'label' => $options['translator']->__('User name'),
+                    'input_group' => ['left' => '<i class="fa fa-user"></i>'],
                 ])
+                ->add('email', 'Symfony\Component\Form\Extension\Core\Type\EmailType', [
+                    'required' => false,
+                    'label' => $options['translator']->__('Email Address'),
+                    'input_group' => ['left' => '<i class="fa fa-at"></i>'],
+                ])
+                ->add('submit', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', [
+                    'label' => $options['translator']->__('Submit'),
+                    'icon' => 'fa-check',
+                    'attr' => ['class' => 'btn btn-success']
+                ])
+            ;
+        } else {
+            $builder
                 ->add('pass', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', [
                     'type' => 'Symfony\Component\Form\Extension\Core\Type\PasswordType',
                     'first_options' => [
@@ -78,7 +75,7 @@ class LostPasswordType extends AbstractType
     {
         $resolver->setDefaults([
             'translator' => null,
-            'includeCode' => false,
+            'includeReset' => false,
             'constraints' => new Callback(['callback' => function ($data, ExecutionContextInterface $context) use ($resolver) {
                 if (empty($data['uname']) && empty($data['email'])) {
                     $context->buildViolation(__('Error! You must enter either your username or email address.'))

--- a/src/system/ZAuthModule/Helper/AdministrationActionsHelper.php
+++ b/src/system/ZAuthModule/Helper/AdministrationActionsHelper.php
@@ -110,7 +110,7 @@ class AdministrationActionsHelper
         if ($hasModeratePermissionToUser) {
             $actions['sendconfirm'] = [
                 'url' => $this->router->generate('zikulazauthmodule_useradministration_sendconfirmation', ['mapping' => $mapping->getId()]),
-                'text' => $this->translator->__f('Send password recovery code to %sub%', ["%sub%" => $mapping->getUname()]),
+                'text' => $this->translator->__f('Send password recovery e-mail to %sub%', ["%sub%" => $mapping->getUname()]),
                 'icon' => 'key',
             ];
         }

--- a/src/system/ZAuthModule/Helper/LostPasswordVerificationHelper.php
+++ b/src/system/ZAuthModule/Helper/LostPasswordVerificationHelper.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - http://zikula.org/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\ZAuthModule\Helper;
+
+use Zikula\ExtensionsModule\Api\VariableApi;
+use Zikula\ZAuthModule\Entity\AuthenticationMappingEntity;
+use Zikula\ZAuthModule\Entity\RepositoryInterface\UserVerificationRepositoryInterface;
+use Zikula\ZAuthModule\Entity\UserVerificationEntity;
+use Zikula\ZAuthModule\ZAuthConstant;
+
+class LostPasswordVerificationHelper
+{
+    /**
+     * @var UserVerificationRepositoryInterface
+     */
+    private $userVerificationRepository;
+
+    /**
+     * @var VariableApi
+     */
+    private $variableApi;
+
+    /**
+     * LostPasswordVerificationHelper constructor.
+     *
+     * @param UserVerificationRepositoryInterface $userVerificationRepository
+     * @param VariableApi                         $variableApi
+     */
+    public function __construct(UserVerificationRepositoryInterface $userVerificationRepository, VariableApi $variableApi) {
+        $this->userVerificationRepository = $userVerificationRepository;
+        $this->variableApi = $variableApi;
+    }
+
+    /**
+     * Concatenation delimiter
+     */
+    private $delimiter = '#';
+
+    /**
+     * Amount of encoding iterations
+     */
+    private $iterations = 3;
+
+    /**
+     * Creates an identifier for the lost password link.
+     * This link carries the user's id, name and email address as well as the actual confirmation code.
+     *
+     * @param AuthenticationMappingEntity $mapping
+     * @return string The created identifier
+     */
+    public function createLostPasswordId(AuthenticationMappingEntity $mapping)
+    {
+        $confirmationCode = $this->userVerificationRepository->setVerificationCode($mapping->getUid());
+
+        $params = [
+            $mapping->getUid(),
+            $mapping->getUname(),
+            $mapping->getEmail(),
+            $confirmationCode
+        ];
+
+        $id = implode($this->delimiter, $params);
+
+        for ($i = 1; $i <= $this->iterations; $i++) {
+            $id = base64_encode($id);
+        }
+
+        return $id;
+    }
+
+    /**
+     * Decodes a given link identifier.
+     *
+     * @param string $identifier
+     * @return array The extracted values
+     */
+    public function decodeLostPasswordId($identifier = '')
+    {
+        if (empty($identifier)) {
+            throw new Exception('Invalid id in lost password verification helper.');
+        }
+
+        $id = $identifier;
+        for ($i = 1; $i <= $this->iterations; $i++) {
+            $id = base64_decode($id);
+        }
+
+        $params = explode($this->delimiter, $id);
+        if (count($params) != 4) {
+            throw new Exception('Unexpected extraction results in lost password verification helper.');
+        }
+
+        return [
+            'userId' => $params[0],
+            'userName' => $params[1],
+            'emailAddress' => $params[2],
+            'confirmationCode' => $params[3]
+        ];
+    }
+
+    /**
+     * Check if confirmation code is neither expired nor invalid.
+     *
+     * @param integer $userId
+     * @param string  $code
+     * @return bool True if code is valid, false otherwise
+     */
+    public function checkConfirmationCode($userId, $code)
+    {
+        $changePasswordExpireDays = $this->variableApi->get('ZikulaZAuthModule', ZAuthConstant::MODVAR_EXPIRE_DAYS_CHANGE_PASSWORD, ZAuthConstant::DEFAULT_EXPIRE_DAYS_CHANGE_PASSWORD);
+        $this->userVerificationRepository->purgeExpiredRecords($changePasswordExpireDays);
+
+        /** @var UserVerificationEntity $userVerificationEntity */
+        $userVerificationEntity = $this->userVerificationRepository->findOneBy([
+            'uid' => $userId,
+            'changetype' => ZAuthConstant::VERIFYCHGTYPE_PWD
+        ]);
+
+        if (!isset($userVerificationEntity) || (!\UserUtil::passwordsMatch($code, $userVerificationEntity->getVerifycode()))) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/system/ZAuthModule/Helper/LostPasswordVerificationHelper.php
+++ b/src/system/ZAuthModule/Helper/LostPasswordVerificationHelper.php
@@ -35,7 +35,8 @@ class LostPasswordVerificationHelper
      * @param UserVerificationRepositoryInterface $userVerificationRepository
      * @param VariableApi                         $variableApi
      */
-    public function __construct(UserVerificationRepositoryInterface $userVerificationRepository, VariableApi $variableApi) {
+    public function __construct(UserVerificationRepositoryInterface $userVerificationRepository, VariableApi $variableApi)
+    {
         $this->userVerificationRepository = $userVerificationRepository;
         $this->variableApi = $variableApi;
     }

--- a/src/system/ZAuthModule/Helper/MailHelper.php
+++ b/src/system/ZAuthModule/Helper/MailHelper.php
@@ -90,10 +90,10 @@ class MailHelper
         $message = \Swift_Message::newInstance();
         $message->setFrom([$this->variableApi->getSystemVar('adminmail') => $sitename]);
         $message->setTo([$toAddress]);
-        $message->setSubject($subject);
-        $message->setBody($html ? $htmlBody : $textBody);
+        $body = $html ? $htmlBody : $textBody;
+        $altBody = $html ? $textBody : '';
 
-        return $this->mailerApi->sendMessage($message, null, null, $textBody, $html);
+        return $this->mailerApi->sendMessage($message, $subject, $body, $altBody, $html);
     }
 
     private function generateEmailSubject($notificationType, array $templateArgs = [])

--- a/src/system/ZAuthModule/Resources/config/services.xml
+++ b/src/system/ZAuthModule/Resources/config/services.xml
@@ -12,6 +12,7 @@
 
         <parameter key="zikula_zauth_module.helper.administration_actions_helper.class">Zikula\ZAuthModule\Helper\AdministrationActionsHelper</parameter>
         <parameter key="zikula_zauth_module.helper.file_io.class">Zikula\ZAuthModule\Helper\FileIOHelper</parameter>
+        <parameter key="zikula_zauth_module.helper.lost_password_verification_helper.class">Zikula\ZAuthModule\Helper\LostPasswordVerificationHelper</parameter>
         <parameter key="zikula_zauth_module.helper.registration_verification_helper.class">Zikula\ZAuthModule\Helper\RegistrationVerificationHelper</parameter>
         <parameter key="zikula_zauth_module.helper.mail_helper.class">Zikula\ZAuthModule\Helper\MailHelper</parameter>
 
@@ -62,6 +63,10 @@
             <argument type="service" id="zikula_zauth_module.helper.mail_helper" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="zikula_users_module.current_user" />
+        </service>
+        <service id="zikula_zauth_module.helper.lost_password_verification_helper" class="%zikula_zauth_module.helper.lost_password_verification_helper.class%" lazy="true">
+            <argument type="service" id="zikula_zauth_module.user_verification_repository" />
+            <argument type="service" id="zikula_extensions_module.api.variable" />
         </service>
         <service id="zikula_zauth_module.helper.registration_verification_helper" class="%zikula_zauth_module.helper.registration_verification_helper.class%" lazy="true">
             <argument type="service" id="zikula_permissions_module.api.permission" />

--- a/src/system/ZAuthModule/Resources/views/Account/changeEmail.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Account/changeEmail.html.twig
@@ -6,7 +6,7 @@
 {{ moduleHeader('user', __('Email address manager'), '', true) }}
 
 <p class="alert alert-info">
-    {{ __f('Notice: Please enter your new e-mail address, the same address again for verification, and then click save. The site uses this address to send you mail (when you request a new password, for instance). Your currently-recorded e-mail address is %s.', {'%s': currentUser.email}) }}
+    {{ __f('Notice: Please enter your new e-mail address, the same address again for verification, and then click save. The site uses this address to send you mail (when you request a new password, for instance). Your currently-recorded e-mail address is %email%.', { '%email%': currentUser.email }) }}
     {{ __('You will receive an e-mail to your new e-mail address to confirm the change.') }}
 </p>
 

--- a/src/system/ZAuthModule/Resources/views/Account/lostPassword.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Account/lostPassword.html.twig
@@ -5,7 +5,7 @@
 {{ polyfill() }}
 {{ moduleHeader('user', __('Account information recovery'), '', true) }}
 
-<p class="alert alert-info">{{ __('Please enter your e-mail address below and click the submit button. You will be sent an e-mail with your account information.') }}</p>
+<p class="alert alert-info">{{ __('Please enter your user name or e-mail address below and click the submit button. You will be sent an e-mail with further instructions.') }}</p>
 
 <div class="well">
     {{ form_start(form) }}

--- a/src/system/ZAuthModule/Resources/views/Account/lostPasswordReset.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Account/lostPasswordReset.html.twig
@@ -5,17 +5,11 @@
 {{ polyfill() }}
 {{ moduleHeader('user', __('Account information recovery'), '', true) }}
 
-<p class="alert alert-info">{{ __('Please complete the form below to reset your password and login.') }}</p>
+<p class="alert alert-info">{{ __('Please complete the form below to reset your password.') }}</p>
 
 <div class="well">
     {{ form_start(form) }}
     {{ form_errors(form) }}
-    {{ form_row(form.uname) }}
-    <div class="form-group">
-        <label class="col-sm-3 control-label">{{ __('OR') }}</label>
-    </div>
-    {{ form_row(form.email) }}
-    {{ form_row(form.code) }}
     <div class="alert alert-info">{{ __('Create a new password.') }}</div>
     {{ form_row(form.pass) }}
     {{ form_end(form) }}

--- a/src/system/ZAuthModule/Resources/views/Account/lostUserName.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Account/lostUserName.html.twig
@@ -10,5 +10,6 @@
 <div>
     {{ form_start(form) }}
     {{ form_errors(form) }}
+    {{ form_row(form.email) }}
     {{ form_end(form) }}
 </div>

--- a/src/system/ZAuthModule/Resources/views/Authentication/EmailLoginBlock.topnav.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Authentication/EmailLoginBlock.topnav.html.twig
@@ -31,7 +31,6 @@
             <li role="separator" class="divider"></li>
             <li><a href="{{ path('zikulazauthmodule_account_lostusername') }}">{{ __('Recover lost username') }}</a></li>
             <li><a href="{{ path('zikulazauthmodule_account_lostpassword') }}">{{ __('Recover lost password') }}</a></li>
-            <li><a href="{{ path('zikulazauthmodule_account_confirmationcode') }}">{{ __('Enter recovery code') }}</a></li>
         </ul>
     </div>
 

--- a/src/system/ZAuthModule/Resources/views/Authentication/UnameLoginBlock.topnav.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Authentication/UnameLoginBlock.topnav.html.twig
@@ -31,7 +31,6 @@
             <li role="separator" class="divider"></li>
             <li><a href="{{ path('zikulazauthmodule_account_lostusername') }}">{{ __('Recover lost username') }}</a></li>
             <li><a href="{{ path('zikulazauthmodule_account_lostpassword') }}">{{ __('Recover lost password') }}</a></li>
-            <li><a href="{{ path('zikulazauthmodule_account_confirmationcode') }}">{{ __('Enter recovery code') }}</a></li>
         </ul>
     </div>
 

--- a/src/system/ZAuthModule/Resources/views/Email/lostpassword.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/lostpassword.html.twig
@@ -1,19 +1,21 @@
 <p>{{ __('Hello!') }}</p>
 
-<p>{{ __f('The user account \'%1$s\' at %2$s has this e-mail address associated with it.', {"%1$s": uname, "%2$s": getModVar('ZConfig', 'sitename')}) }}</p>
+<p>{{ __f('The user account \'%username%\' at %sitename% has this e-mail address associated with it.', { '%username%': uname, '%sitename%': getModVar('ZConfig', 'sitename') }) }}</p>
 
 {% if requestedByAdmin %}
-<p>{{ __f('The administrator at %sub% requested that you receive a confirmation code that will allow you to reset your password.', {"%sub%": getModVar('ZConfig', 'sitename')}) }}</p>
+<p>{{ __f('The administrator at %sub% requested that you reset your password.', { '%sub%': getModVar('ZConfig', 'sitename')}) }}</p>
 {% else %}
-<p>{{ __f('Someone with the IP address %sub% has just requested a confirmation code to allow the password for your account to be reset.', {"%sub%": app.request.server.get('REMOTE_ADDR')}) }}</p>
+<p>{{ __f('Someone with the IP address %sub% has just requested your account password to be reset.', { '%sub%': app.request.server.get('REMOTE_ADDR')}) }}</p>
 {% endif %}
 
-<p>{{ __f('The confirmation code is: %sub%', {"%sub%": code}) }}</p>
+<p>{{ __('You can now create a new password by clicking on this link:') }} <a href="{{ url('zikulazauthmodule_account_lostpasswordreset', { id: lostPasswordId }) }}">{{ __('Reset My Password') }}</a>.<br>
+{{ __f('(If you cannot click on the link, you can copy this URL and paste it into your browser: %sub% )', { '%sub%': url('zikulazauthmodule_account_lostpasswordreset', { id: lostPasswordId }) }) }}</p>
 
-<p>{{ __('With this confirmation code, you can now create a new password by clicking on this link:') }} <a href="{{ path('zikulazauthmodule_account_lostpassword', {code:code}) }}">{{ __('Reset My Password') }}</a>.<br>
-{{ __f('(If you cannot click on the link, you can copy this URL and paste it into your browser: %sub% )', {"%sub%": path('zikulazauthmodule_account_lostpassword', {code:code})}) }}</p>
+{% if validDays > 0 %}
+    <p>{{ __f('This link expires in %amountOfDays% days.', { '%amountOfDays%': validDays }) }}</p>
+{% endif %}
 
 <p>{% if not requestedByAdmin %}{{ __('If the request was not made by you then you don\'t need to take any action.') }} {% endif %}
-    {{ __('The password won\'t be changed unless the confirmation code is used, and you are the only recipient of this message.') }}
+    {{ __('The password won\'t be changed unless you choose a new one using the link above, and you are the only recipient of this message.') }}
     {% if not requestedByAdmin %} {{ __('You can just delete the message and log-in with your existing password next time you visit the site.') }}{% endif %}
 </p>

--- a/src/system/ZAuthModule/Resources/views/Email/lostpassword.txt.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/lostpassword.txt.twig
@@ -1,18 +1,20 @@
 {{ __('Hello!') }}
 
-{{ __f('The user account \'%1$s\' at %2$s has this e-mail address associated with it.', {"%1$s": uname, "%2$s": getModVar('ZConfig', 'sitename')}) }}
+{{ __f('The user account \'%username%\' at %sitename% has this e-mail address associated with it.', { '%username%': uname, '%sitename%': getModVar('ZConfig', 'sitename') }) }}
 
 {% if requestedByAdmin %}
-{{ __f('The administrator at %sub% requested that you receive a confirmation code that will allow you to reset your password.', {"%sub%": getModVar('ZConfig', 'sitename')}) }}
+{{ __f('The administrator at %sub% requested that reset your password.', { '%sub%': getModVar('ZConfig', 'sitename') }) }}
 {% else %}
-{{ __f('Someone with the IP address %sub% has just requested a confirmation code to allow the password for your account to be reset.', {"%sub%": app.request.server.get('REMOTE_ADDR')}) }}
+{{ __f('Someone with the IP address %sub% has just requested your account password to be reset.', { '%sub%': app.request.server.get('REMOTE_ADDR') }) }}
 {% endif %}
 
-{{ __f('The confirmation code is: %sub%', {"%sub%": code}) }}
-
-{{ __f('With this confirmation code, you can now create a new password by clicking on this link: %sub%', {"%sub%": path('zikulazauthmodule_account_lostpassword', {code:code})}) }}
+{{ __f('You can now create a new password by clicking on this link: %sub%', { '%sub%': url('zikulazauthmodule_account_lostpasswordreset', { id: lostPasswordId }) }) }}
 {{ __('(If you cannot click on the link, you can copy the URL and paste it into your browser.)') }}
 
+{% if validDays > 0 %}
+    {{ __f('This link expires in %amountOfDays% days.', { '%amountOfDays%': validDays }) }}
+
+{% endif %}
 {% if not requestedByAdmin %}{{ __('If the request was not made by you then you don\'t need to take any action.') }} {% endif %}
-{{ __('The password won\'t be changed unless the confirmation code is used, and you are the only recipient of this message.') }}
+{{ __('The password won\'t be changed unless you choose a new one using the link above, and you are the only recipient of this message.') }}
 {% if not requestedByAdmin %} {{ __('You can just delete the message and log-in with your existing password next time you visit the site.') }}{% endif %}

--- a/src/system/ZAuthModule/Resources/views/Email/lostuname.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/lostuname.html.twig
@@ -9,7 +9,7 @@
 <p>{{ __f('The user name for your account is: %1s', {"%sub%": uname}) }}</p>
 
 <p>
-    {% if not requestedByAdmin %}{{ __('If the request was not made by you then you don\'t need to take any action.') }} {% endif %}
+    {% if not requestedByAdmin %}{{ __('If the request was not made by you then you don\'t need to worry.') }} {% endif %}
     {{ __('You are the only recipient of this message, and your user name has not been sent to any other e-mail address.') }}
     {% if not requestedByAdmin %} {{ __('You can just delete this message.') }}{% endif %}
 </p>

--- a/src/system/ZAuthModule/Resources/views/Email/lostuname.txt.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/lostuname.txt.twig
@@ -8,6 +8,6 @@
 
 {{ __f('The user name for your account is: %1s', {"%sub%": uname}) }}
 
-{% if not requestedByAdmin %}{{ __('If the request was not made by you then you don\'t need to take any action.') }} {% endif %}
+{% if not requestedByAdmin %}{{ __('If the request was not made by you you don\'t need to worry.') }} {% endif %}
 {{ __('You are the only recipient of this message, and your user name has not been sent to any other e-mail address.') }}
 {% if not requestedByAdmin %} {{ __('You can just delete this message.') }}{% endif %}

--- a/src/themes/BootstrapTheme/Resources/ZikulaUsersModule/views/Account/menu.html.twig
+++ b/src/themes/BootstrapTheme/Resources/ZikulaUsersModule/views/Account/menu.html.twig
@@ -7,7 +7,6 @@
         <li><a href="{{ path('zikulausersmodule_registration_register') }}">{{ __('I would like to create a new account.') }}</a></li>
         <li><a href="{{ path('zikulazauthmodule_account_lostusername') }}">{{ __('I have forgotten my account information (for example, my user name).') }}</a></li>
         <li><a href="{{ path('zikulazauthmodule_account_lostpassword') }}">{{ __('I have forgotten my password.') }}</a></li>
-        <li><a href="{{ path('zikulazauthmodule_account_confirmationcode') }}">{{ __('I have received a password recovery code, and would like to enter it.') }}</a></li>
     </ul>
 {% endif %}
 <ul class="list-group">


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes (email related)
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #1781 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

**Notes:**

This does still use the verification entity and confirmation codes. So for example the expiry is still handled by that.

But there are some essential behavioural differences:

1. The code is wrapped into an encoded identifier together with the user id, the user name and the email address. This identifier is appended to the url contained in the email text.
2. After extracting the identifier arguments the user is selected using the user id.
3. The code is checked before the form even displays.
4. The form contains only two password fields now.
5. A new helper class (`LostPasswordVerificationHelper`) encapsulates the details, making the controllers a bit more slim.

This PR also addresses some minor bugs I've found, like non-absolute urls in the email templates and wrong usage of the `MailerApi` in the `MailHelper` class.