### PR TITLE
Correct Core Installer Translation

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -25,6 +25,8 @@ CHANGELOG - ZIKULA 1.4.x
     - Fixed some problems with the Zikula Symfony Translator (#3161, #3117).
     - Fixed upgrade in Settings module for shorturl value to boolean (#3166).
     - Fixed logical problem in CategoryUtil::hasCategoryAccess() (#3171, #3190).
+    - Fixed issue where upgrader also showed partial theme (#3087)
+    - Fixed many issues with translation in the Core installer and upgrader (#2919, #3192)
 
  - Features:
     - Lost password functionality has been simplified to work without an additional (confusing) confirmation step (#1781, #3178).

--- a/src/app/config/parameters.yml
+++ b/src/app/config/parameters.yml
@@ -1,7 +1,7 @@
 parameters:
     installed:        false
     env:              prod
-    debug:            false
+    debug:            true
     compat_layer:     true
     script_position:  head
     # script_position defines the location where javascripts will be placed in the page

--- a/src/app/config/parameters.yml
+++ b/src/app/config/parameters.yml
@@ -1,7 +1,7 @@
 parameters:
     installed:        false
     env:              prod
-    debug:            true
+    debug:            false
     compat_layer:     true
     script_position:  head
     # script_position defines the location where javascripts will be placed in the page

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/config/routing.xml
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/config/routing.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="home" path="/">
         <default key="_controller">zikula_core.controller.main_controller:homeAction</default>
-        <condition>request.query.get('module') == ''</condition>
+        <condition>request == null or request.query.get('module') == ''</condition>
         <option key="i18n">false</option>
     </route>
 </routes>

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/FinishCommand.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/FinishCommand.php
@@ -51,7 +51,7 @@ class FinishCommand extends AbstractCoreInstallerCommand
         $io->comment($this->translator->__f('Configuring Zikula installation in %env% environment.', ['%env%' => $env]));
 
         // install!
-        $ajaxInstallerStage = new AjaxInstallerStage();
+        $ajaxInstallerStage = new AjaxInstallerStage($this->getContainer());
         $stages = $ajaxInstallerStage->getTemplateParams();
         foreach ($stages['stages'] as $key => $stage) {
             $io->text($stage[AjaxInstallerStage::PRE]);

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/StartCommand.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/Install/StartCommand.php
@@ -82,17 +82,17 @@ class StartCommand extends AbstractCoreInstallerCommand
         }
 
         // get the settings from user input
-        $settings = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\LocaleType', $input, $output);
-        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\RequestContextType', $input, $output);
+        $settings = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\LocaleType', $input, $output, ['translator' => $this->translator]);
+        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\RequestContextType', $input, $output, ['translator' => $this->translator]);
         foreach ($data as $k => $v) {
             $newKey = str_replace(':', '.', $k);
             $data[$newKey] = $v;
             unset($data[$k]);
         }
         $settings = array_merge($settings, $data);
-        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\DbCredsType', $input, $output);
+        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\DbCredsType', $input, $output, ['translator' => $this->translator]);
         $settings = array_merge($settings, $data);
-        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\CreateAdminType', $input, $output);
+        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\CreateAdminType', $input, $output, ['translator' => $this->translator]);
         foreach ($data as $k => $v) {
             $data[$k] = base64_encode($v); // encode so values are 'safe' for json
         }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/UpgradeCommand.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/UpgradeCommand.php
@@ -97,13 +97,13 @@ class UpgradeCommand extends AbstractCoreInstallerCommand
         }
 
         // get the settings from user input
-        $settings = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\LocaleType', $input, $output);
-        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\LoginType', $input, $output);
+        $settings = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\LocaleType', $input, $output, ['translator' => $this->translator]);
+        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\LoginType', $input, $output, ['translator' => $this->translator]);
         foreach ($data as $k => $v) {
             $data[$k] = base64_encode($v); // encode so values are 'safe' for json
         }
         $settings = array_merge($settings, $data);
-        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\RequestContextType', $input, $output);
+        $data = $this->getHelper('form')->interactUsingForm('Zikula\Bundle\CoreInstallerBundle\Form\Type\RequestContextType', $input, $output, ['translator' => $this->translator]);
         foreach ($data as $k => $v) {
             $newKey = str_replace(':', '.', $k);
             $data[$newKey] = $v;

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/UpgradeCommand.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Command/UpgradeCommand.php
@@ -117,7 +117,7 @@ class UpgradeCommand extends AbstractCoreInstallerCommand
         $yamlManager->setParameters($params);
 
         // upgrade!
-        $ajaxInstallerStage = new AjaxUpgraderStage();
+        $ajaxInstallerStage = new AjaxUpgraderStage($this->getContainer());
         $stages = $ajaxInstallerStage->getTemplateParams();
         foreach ($stages['stages'] as $key => $stage) {
             $io->text($stage[AjaxInstallerStage::PRE]);

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxInstallController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/AjaxInstallController.php
@@ -337,8 +337,8 @@ class AjaxInstallController extends AbstractController
     public function reloadRoutes()
     {
         // fire MODULE_INSTALL event to reload all routes
-        $event = new ModuleStateEvent($this->container->get('kernel')->getModule('ZikulaRoutesModule'));
-        $this->container->get('event_dispatcher')->dispatch(CoreEvents::MODULE_POSTINSTALL, $event);
+//        $event = new ModuleStateEvent($this->container->get('kernel')->getModule('ZikulaRoutesModule'));
+//        $this->container->get('event_dispatcher')->dispatch(CoreEvents::MODULE_POSTINSTALL, $event);
 
         return true;
     }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/InstallerController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/InstallerController.php
@@ -48,6 +48,7 @@ class InstallerController extends AbstractController
             $request->getSession()->getFlashBag()->add('warning', implode('<hr>', $ini_warnings));
         }
 
+        $request->setLocale($this->container->getParameter('locale'));
         // begin the wizard
         $wizard = new Wizard($this->container, realpath(__DIR__ . '/../Resources/config/install_stages.yml'));
         $currentStage = $wizard->getCurrentStage($stage);
@@ -68,7 +69,8 @@ class InstallerController extends AbstractController
             $form->handleRequest($request);
             if ($form->isSubmitted() && $form->isValid()) {
                 $currentStage->handleFormResult($form);
-                $url = $this->router->generate('install', ['stage' => $wizard->getNextStage()->getName()], RouterInterface::ABSOLUTE_URL);
+                $params = ['stage' => $wizard->getNextStage()->getName(), '_locale' => $this->container->getParameter('locale')];
+                $url = $this->router->generate('install', $params);
 
                 return new RedirectResponse($url);
             }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/InstallerController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/InstallerController.php
@@ -14,7 +14,6 @@ namespace Zikula\Bundle\CoreInstallerBundle\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Zikula\Bundle\CoreInstallerBundle\Form\AbstractType;
 use Zikula\Component\Wizard\FormHandlerInterface;
 use Zikula\Component\Wizard\Wizard;
 use Zikula\Component\Wizard\WizardCompleteInterface;

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/InstallerController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/InstallerController.php
@@ -14,10 +14,10 @@ namespace Zikula\Bundle\CoreInstallerBundle\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Zikula\Bundle\CoreInstallerBundle\Form\AbstractType;
 use Zikula\Component\Wizard\FormHandlerInterface;
 use Zikula\Component\Wizard\Wizard;
 use Zikula\Component\Wizard\WizardCompleteInterface;
-use Symfony\Component\Routing\RouterInterface;
 use Zikula\Core\Response\PlainResponse;
 
 /**

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/UpgraderController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/UpgraderController.php
@@ -14,6 +14,7 @@ namespace Zikula\Bundle\CoreInstallerBundle\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Zikula\Bundle\CoreInstallerBundle\Form\AbstractType;
 use Zikula\Component\Wizard\FormHandlerInterface;
 use Zikula\Component\Wizard\Wizard;
 use Zikula\Component\Wizard\WizardCompleteInterface;
@@ -68,6 +69,9 @@ class UpgraderController extends AbstractController
         // handle the form
         if ($currentStage instanceof FormHandlerInterface) {
             $form = $this->form->create($currentStage->getFormType(), null, $currentStage->getFormOptions());
+            if ($form instanceof AbstractType) {
+                $form->setTranslator($this->translator);
+            }
             $form->handleRequest($request);
             if ($form->isSubmitted() && $form->isValid()) {
                 $currentStage->handleFormResult($form);

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/UpgraderController.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Controller/UpgraderController.php
@@ -14,11 +14,9 @@ namespace Zikula\Bundle\CoreInstallerBundle\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Zikula\Bundle\CoreInstallerBundle\Form\AbstractType;
 use Zikula\Component\Wizard\FormHandlerInterface;
 use Zikula\Component\Wizard\Wizard;
 use Zikula\Component\Wizard\WizardCompleteInterface;
-use Symfony\Component\Routing\RouterInterface;
 use Zikula\Core\Response\PlainResponse;
 
 /**
@@ -41,7 +39,7 @@ class UpgraderController extends AbstractController
         }
         // notinstalled?
         if (($this->container->getParameter('installed') == false)) {
-            return new RedirectResponse($this->router->generate('install', [], RouterInterface::ABSOLUTE_URL));
+            return new RedirectResponse($this->router->generate('install'));
         }
 
         // check php
@@ -51,6 +49,7 @@ class UpgraderController extends AbstractController
         }
 
         $this->container->setParameter('upgrading', true);
+        $request->setLocale($this->container->getParameter('locale'));
 
         // begin the wizard
         $wizard = new Wizard($this->container, realpath(__DIR__ . '/../Resources/config/upgrade_stages.yml'));
@@ -69,13 +68,11 @@ class UpgraderController extends AbstractController
         // handle the form
         if ($currentStage instanceof FormHandlerInterface) {
             $form = $this->form->create($currentStage->getFormType(), null, $currentStage->getFormOptions());
-            if ($form instanceof AbstractType) {
-                $form->setTranslator($this->translator);
-            }
             $form->handleRequest($request);
             if ($form->isSubmitted() && $form->isValid()) {
                 $currentStage->handleFormResult($form);
-                $url = $this->router->generate('upgrade', ['stage' => $wizard->getNextStage()->getName()], RouterInterface::ABSOLUTE_URL);
+                $params = ['stage' => $wizard->getNextStage()->getName(), '_locale' => $this->container->getParameter('locale')];
+                $url = $this->router->generate('upgrade', $params);
 
                 return new RedirectResponse($url);
             }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/EventListener/InstallUpgradeCheckListener.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/EventListener/InstallUpgradeCheckListener.php
@@ -43,28 +43,27 @@ class InstallUpgradeCheckListener implements EventSubscriberInterface
             $requiresUpgrade = $installed && version_compare($currentVersion, \Zikula_Core::VERSION_NUM, '<');
         }
 
-        // can't use $request->get('_route') to get any of the following
-        // all these routes are hard-coded in xml files
-        $requestedUri = $request->getRequestUri();
-        $uriContainsInstall = strpos($requestedUri, '/install') !== false;
-        $uriContainsUpgrade = strpos($requestedUri, '/upgrade') !== false;
-        $uriContainsLogin = strpos($requestedUri, '/login') !== false || strpos($requestedUri, '/upgrade-login') !== false; // @todo @deprecated at Core-2.0 remove later half
-        $uriContainsDoc = strpos($requestedUri, '/installdoc') !== false;
-        $uriContainsWdt = strpos($requestedUri, '/_wdt') !== false;
-        $uriContainsProfiler = strpos($requestedUri, '/_profiler') !== false;
-        $uriContainsRouter = strpos($requestedUri, '/js/routing?callback=fos.Router.setData') !== false;
-        $doNotRedirect = $uriContainsProfiler || $uriContainsWdt || $uriContainsRouter || $request->isXmlHttpRequest();
+        $routeInfo = $this->container->get('router')->match($request->getPathInfo());
+        $containsInstall = $routeInfo['_route'] == 'install';
+        $containsUpgrade = $routeInfo['_route'] == 'upgrade';
+        $containsLogin = $routeInfo['_controller'] == 'Zikula\\UsersModule\\Controller\\AccessController::loginAction' || $routeInfo['_controller'] == 'Zikula\\UsersModule\\Controller\\AccessController::upgradeAdminLoginAction'; // @todo @deprecated at Core-2.0 remove later half
+        $containsDoc = $routeInfo['_route'] == 'doc';
+        $containsWdt =  $routeInfo['_route'] == '_wdt';
+        $containsProfiler = strpos($routeInfo['_route'], '_profiler') !== false;
+        $containsRouter = $routeInfo['_route'] == 'fos_js_routing_js';
+        $doNotRedirect = $containsProfiler || $containsWdt || $containsRouter || $request->isXmlHttpRequest();
 
         // check if Zikula Core is not installed
-        if (!$installed && !$uriContainsDoc && !$uriContainsInstall && !$doNotRedirect) {
+        if (!$installed && !$containsDoc && !$containsInstall && !$doNotRedirect) {
             $this->container->get('router')->getContext()->setBaseUrl($request->getBasePath()); // compensate for sub-directory installs
             $url = $this->container->get('router')->generate('install');
+            $this->loadLocales();
             $response = new RedirectResponse($url);
             $response->send();
             \System::shutDown();
         }
         // check if Zikula Core requires upgrade
-        if ($requiresUpgrade && !$uriContainsLogin && !$uriContainsDoc && !$uriContainsUpgrade && !$doNotRedirect) {
+        if ($requiresUpgrade && !$containsLogin && !$containsDoc && !$containsUpgrade && !$doNotRedirect) {
             $this->container->get('router')->getContext()->setBaseUrl($request->getBasePath()); // compensate for sub-directory installs
             $url = $this->container->get('router')->generate('upgrade');
             $response = new RedirectResponse($url);
@@ -84,5 +83,22 @@ class InstallUpgradeCheckListener implements EventSubscriberInterface
                 ['onCoreInit']
             ],
         ];
+    }
+
+    /**
+     * Load locales from filesystem and setup jms_I18n_routing params
+     */
+    private function loadLocales()
+    {
+        // write locale choice to `config/dynamic/generated.yml`
+        $configDumper = $this->container->get('zikula.dynamic_config_dumper');
+        $config = $configDumper->getConfiguration('jms_i18n_routing');
+        $config['locales'] = \ZLanguage::getInstalledLanguages();
+        if (!in_array($this->container->getParameter('locale'), $config['locales'])) {
+            $this->container->setParameter('locale', $config['locales'][0]);
+            $config['default_locale'] = $config['locales'][0];
+        }
+        $configDumper->setConfiguration('jms_i18n_routing', $config);
+        $this->container->get('zikula.cache_clearer')->clear('symfony');
     }
 }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/AbstractType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/AbstractType.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - http://zikula.org/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\Bundle\CoreInstallerBundle\Form;
+
+use Symfony\Component\Form\AbstractType as BaseAbstractType;
+use Zikula\Common\Translator\TranslatorTrait;
+
+class AbstractType extends BaseAbstractType
+{
+    use TranslatorTrait;
+
+    public function setTranslator($translator)
+    {
+        $this->translator = $translator;
+    }
+}

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/CreateAdminType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/CreateAdminType.php
@@ -11,38 +11,40 @@
 
 namespace Zikula\Bundle\CoreInstallerBundle\Form\Type;
 
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\Regex;
+use Zikula\Bundle\CoreInstallerBundle\Form\AbstractType;
+use Zikula\Common\Translator\IdentityTranslator;
 use Zikula\UsersModule\Constant as UsersConstant;
 
 class CreateAdminType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $this->setTranslator($options['translator']);
         $builder
             ->add('username', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
-                'label' => __('Admin User Name'),
+                'label' => $this->__('Admin User Name'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
-                'data' => __('admin'),
+                'data' => $this->__('admin'),
                 'constraints' => [
                     new NotBlank(),
                     new Length(['min' => 5]),
                     new Regex([
                         'pattern' => '#' . UsersConstant::UNAME_VALIDATION_PATTERN . '#',
-                        'message' => __('Error! Usernames can only consist of a combination of letters, numbers and may only contain the symbols . and _')
+                        'message' => $this->__('Error! Usernames can only consist of a combination of letters, numbers and may only contain the symbols . and _')
                     ])
                 ]
             ])
             ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', [
                 'type' => 'password',
-                'invalid_message' => 'The password fields must match.',
+                'invalid_message' => $this->__('The password fields must match.'),
                 'options' => [
                     'label_attr' => [
                         'class' => 'col-sm-3'
@@ -53,11 +55,11 @@ class CreateAdminType extends AbstractType
                     ]
                 ],
                 'required' => true,
-                'first_options'  => ['label' => __('Admin Password')],
-                'second_options' => ['label' => __('Repeat Password')]
+                'first_options'  => ['label' => $this->__('Admin Password')],
+                'second_options' => ['label' => $this->__('Repeat Password')]
             ])
             ->add('email', 'Symfony\Component\Form\Extension\Core\Type\EmailType', [
-                'label' => __('Admin Email Address'),
+                'label' => $this->__('Admin Email Address'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
@@ -78,6 +80,7 @@ class CreateAdminType extends AbstractType
     {
         $resolver->setDefaults([
             'csrf_protection' => false,
+            'translator' => new IdentityTranslator()
 //                'csrf_field_name' => '_token',
 //                // a unique key to help generate the secret token
 //                'intention'       => '_zk_bdcreds',

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/DbCredsType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/DbCredsType.php
@@ -11,21 +11,23 @@
 
 namespace Zikula\Bundle\CoreInstallerBundle\Form\Type;
 
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
+use Zikula\Bundle\CoreInstallerBundle\Form\AbstractType;
 use Zikula\Bundle\CoreInstallerBundle\Validator\Constraints\ValidPdoConnection;
+use Zikula\Common\Translator\IdentityTranslator;
 
 class DbCredsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $this->setTranslator($options['translator']);
         $builder
             ->add('database_driver', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', [
-                'label' => __('Database type'),
+                'label' => $this->__('Database type'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
@@ -33,28 +35,28 @@ class DbCredsType extends AbstractType
                 'data' => 'mysql'
             ])
             ->add('dbtabletype', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', [
-                'label' => __('Storage Engine'),
+                'label' => $this->__('Storage Engine'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
                 'choices' => [
-                    'innodb' => __('InnoDB'),
-                    'myisam' => __('MyISAM')
+                    'innodb' => 'InnoDB',
+                    'myisam' => 'MyISAM'
                 ],
                 'data' => 'innodb'
             ])
             ->add('database_host', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
-                'label' => __('Database Host'),
+                'label' => $this->__('Database Host'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
-                'data' => __('localhost'),
+                'data' => 'localhost',
                 'constraints' => [
                     new NotBlank()
                 ]
             ])
             ->add('database_user', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
-                'label' => __('Database Username'),
+                'label' => $this->__('Database Username'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
@@ -63,14 +65,14 @@ class DbCredsType extends AbstractType
                 ]
             ])
             ->add('database_password', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', [
-                'label' => __('Database Password'),
+                'label' => $this->__('Database Password'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
                 'required' => false
             ])
             ->add('database_name', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
-                'label' => __('Database Name'),
+                'label' => $this->__('Database Name'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
@@ -79,7 +81,7 @@ class DbCredsType extends AbstractType
                     new Length(['max' => 64]),
                     new Regex([
                         'pattern' => '/^[\w-]*$/',
-                        'message' => __('Error! Invalid database name. Please use only letters, numbers, "-" or "_".')
+                        'message' => $this->__('Error! Invalid database name. Please use only letters, numbers, "-" or "_".')
                     ])
                 ]
             ])
@@ -95,17 +97,17 @@ class DbCredsType extends AbstractType
     {
         $types = [];
         if (function_exists('mysql_connect') || function_exists('mysqli_connect')) {
-            $types['mysql'] = __('MySQL');
+            $types['mysql'] = 'MySQL';
         }
         if (function_exists('mssql_connect')) {
-            $types['mssql'] = __('MSSQL (alpha)');
+            $types['mssql'] = 'MSSQL (alpha)';
         }
         if (function_exists('OCIPLogon')) {
-            $types['oci8'] = __('Oracle (alpha) via OCI8 driver');
-            $types['oracle'] = __('Oracle (alpha) via Oracle driver');
+            $types['oci8'] = 'Oracle (alpha) via OCI8 driver';
+            $types['oracle'] = 'Oracle (alpha) via Oracle driver';
         }
         if (function_exists('pg_connect')) {
-            $types['postgres'] = __('PostgreSQL');
+            $types['postgres'] = 'PostgreSQL';
         }
 
         return $types;
@@ -116,6 +118,7 @@ class DbCredsType extends AbstractType
         $resolver->setDefaults([
             'constraints' => new ValidPdoConnection(),
             'csrf_protection' => false,
+            'translator' => new IdentityTranslator()
 //                'csrf_field_name' => '_token',
 //                // a unique key to help generate the secret token
 //                'intention'       => '_zk_bdcreds',

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/LocaleType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/LocaleType.php
@@ -11,17 +11,19 @@
 
 namespace Zikula\Bundle\CoreInstallerBundle\Form\Type;
 
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Zikula\Bundle\CoreInstallerBundle\Form\AbstractType;
+use Zikula\Common\Translator\IdentityTranslator;
 
 class LocaleType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $this->setTranslator($options['translator']);
         $builder
             ->add('locale', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', [
-                'label' => __('Select your default language'),
+                'label' => $this->__('Select your default language'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
@@ -41,7 +43,8 @@ class LocaleType extends AbstractType
         $resolver->setDefaults([
             'csrf_protection' => false,
             'choices' => \ZLanguage::getInstalledLanguageNames(),
-            'choice' => 'en'
+            'choice' => 'en',
+            'translator' => new IdentityTranslator()
 //                'csrf_field_name' => '_token',
 //                // a unique key to help generate the secret token
 //                'intention'       => '_zk_bdcreds',

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/LoginType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/LoginType.php
@@ -11,29 +11,31 @@
 
 namespace Zikula\Bundle\CoreInstallerBundle\Form\Type;
 
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Zikula\Bundle\CoreInstallerBundle\Form\AbstractType;
 use Zikula\Bundle\CoreInstallerBundle\Validator\Constraints\AuthenticateAdminLogin;
+use Zikula\Common\Translator\IdentityTranslator;
 
 class LoginType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $this->setTranslator($options['translator']);
         $builder
             ->add('username', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
-                'label' => __('User Name'),
+                'label' => $this->__('User Name'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
-                'data' => __('admin'),
+                'data' => $this->__('admin'),
                 'constraints' => [
                     new NotBlank(),
                 ]
             ])
             ->add('password', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', [
-                'label' => __('Password'),
+                'label' => $this->__('Password'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
@@ -54,6 +56,7 @@ class LoginType extends AbstractType
         $resolver->setDefaults([
             'constraints' => new AuthenticateAdminLogin(),
             'csrf_protection' => false,
+            'translator' => new IdentityTranslator()
 //                'csrf_field_name' => '_token',
 //                // a unique key to help generate the secret token
 //                'intention'       => '_zk_bdcreds',

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/RequestContextType.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Form/Type/RequestContextType.php
@@ -11,28 +11,30 @@
 
 namespace Zikula\Bundle\CoreInstallerBundle\Form\Type;
 
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Zikula\Bundle\CoreInstallerBundle\Form\AbstractType;
+use Zikula\Common\Translator\IdentityTranslator;
 
 class RequestContextType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $this->setTranslator($options['translator']);
         $builder
             ->add('router:request_context:host', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
-                'label' => __('The root domain where you install Zikula, e.g. "example.com". Do not include subdirectories.'),
+                'label' => $this->__('The root domain where you install Zikula, e.g. "example.com". Do not include subdirectories.'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
-                'data' => __('localhost'),
+                'data' => $this->__('localhost'),
                 'constraints' => [
                     new NotBlank(),
                 ]
             ])
             ->add('router:request_context:scheme', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', [
-                'label' => __('Please enter the scheme of where you install Zikula, can be either "http" or "https"'),
+                'label' => $this->__('Please enter the scheme of where you install Zikula, can be either "http" or "https"'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
@@ -43,7 +45,7 @@ class RequestContextType extends AbstractType
                 'data' => 'http',
             ])
             ->add('router:request_context:base_url', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
-                'label' => __('Please enter the url path of the directory where you install Zikula, leave empty if you install it at the top level. Example: /my/sub-dir'),
+                'label' => $this->__('Please enter the url path of the directory where you install Zikula, leave empty if you install it at the top level. Example: /my/sub-dir'),
                 'label_attr' => [
                     'class' => 'col-sm-3'
                 ],
@@ -60,6 +62,7 @@ class RequestContextType extends AbstractType
     {
         $resolver->setDefaults([
             'csrf_protection' => false,
+            'translator' => new IdentityTranslator()
 //                'csrf_field_name' => '_token',
 //                // a unique key to help generate the secret token
 //                'intention'       => '_zk_bdcreds',

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/config/validators.xml
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Resources/config/validators.xml
@@ -8,11 +8,13 @@
     </parameters>
     <services>
         <service id="zikula_core_installer_bundle.validator.constraints.valid_pdo_connection_validator" class="%zikula_core_installer_bundle.validator.constraints.valid_pdo_connection_validator.class%">
+            <argument type="service" id="translator.default" />
             <tag name="validator.constraint_validator" alias="zikula.core_installer.pdo_connection.validator" />
         </service>
         <service id="zikula_core_installer_bundle.validator.constraints.authenticate_admin_login_validator" class="%zikula_core_installer_bundle.validator.constraints.authenticate_admin_login_validator.class%">
             <argument type="service" id="zikula_permissions_module.api.permission" />
             <argument type="service" id="doctrine.dbal.default_connection" />
+            <argument type="service" id="translator.default" />
             <tag name="validator.constraint_validator" alias="zikula.core_installer.authenticate_admin_login.validator" />
         </service>
     </services>

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/AjaxInstallerStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/AjaxInstallerStage.php
@@ -11,15 +11,30 @@
 
 namespace Zikula\Bundle\CoreInstallerBundle\Stage\Install;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Zikula\Common\Translator\TranslatorTrait;
+use Zikula\Component\Wizard\InjectContainerInterface;
 use Zikula\Component\Wizard\StageInterface;
 
-class AjaxInstallerStage implements StageInterface
+class AjaxInstallerStage implements StageInterface, InjectContainerInterface
 {
+    use TranslatorTrait;
+
     const NAME = 'name';
     const PRE = 'pre';
     const DURING = 'during';
     const SUCCESS = 'success';
     const FAIL = 'fail';
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->setTranslator($container->get('translator.default'));
+    }
+
+    public function setTranslator($translator)
+    {
+        $this->translator = $translator;
+    }
 
     public function getName()
     {
@@ -41,199 +56,199 @@ class AjaxInstallerStage implements StageInterface
         return ['stages' => [
             1 => [
                 self::NAME => 'bundles',
-                self::PRE => __('Symfony Bundles'),
-                self::DURING => __('Persisting Symfony Bundles'),
-                self::SUCCESS => __('Symfony Bundles persisted'),
-                self::FAIL => __('There was an error persisting the Symfony Bundles')
+                self::PRE => $this->__('Symfony Bundles'),
+                self::DURING => $this->__('Persisting Symfony Bundles'),
+                self::SUCCESS => $this->__('Symfony Bundles persisted'),
+                self::FAIL => $this->__('There was an error persisting the Symfony Bundles')
             ],
             2 => [
                 self::NAME => 'install_event',
-                self::PRE => __('Fire install event'),
-                self::DURING => __('Firing install event'),
-                self::SUCCESS => __('Fired install event'),
-                self::FAIL => __('There was an error firing the install event')
+                self::PRE => $this->__('Fire install event'),
+                self::DURING => $this->__('Firing install event'),
+                self::SUCCESS => $this->__('Fired install event'),
+                self::FAIL => $this->__('There was an error firing the install event')
             ],
             3 => [
                 self::NAME => 'extensions',
-                self::PRE => __('Zikula Extension Module'),
-                self::DURING => __('Installing Zikula Extensions Module'),
-                self::SUCCESS => __('Zikula Extensions Module installed'),
-                self::FAIL => __('There was an error installing Zikula Extensions Module')
+                self::PRE => $this->__('Zikula Extension Module'),
+                self::DURING => $this->__('Installing Zikula Extensions Module'),
+                self::SUCCESS => $this->__('Zikula Extensions Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Extensions Module')
             ],
             4 => [
                 self::NAME => 'settings',
-                self::PRE => __('Zikula Settings Module'),
-                self::DURING => __('Installing Zikula Settings Module'),
-                self::SUCCESS => __('Zikula Settings Module installed'),
-                self::FAIL => __('There was an error installing Zikula Settings Module')
+                self::PRE => $this->__('Zikula Settings Module'),
+                self::DURING => $this->__('Installing Zikula Settings Module'),
+                self::SUCCESS => $this->__('Zikula Settings Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Settings Module')
             ],
             5 => [
                 self::NAME => 'theme',
-                self::PRE => __('Zikula Theme Module'),
-                self::DURING => __('Installing Zikula Theme Module'),
-                self::SUCCESS => __('Zikula Theme Module installed'),
-                self::FAIL => __('There was an error installing Zikula Theme Module')
+                self::PRE => $this->__('Zikula Theme Module'),
+                self::DURING => $this->__('Installing Zikula Theme Module'),
+                self::SUCCESS => $this->__('Zikula Theme Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Theme Module')
             ],
             6 => [
                 self::NAME => 'admin',
-                self::PRE => __('Zikula Administration Module'),
-                self::DURING => __('Installing Zikula Administration Module'),
-                self::SUCCESS => __('Zikula Administration Module installed'),
-                self::FAIL => __('There was an error installing Zikula Administration Module')
+                self::PRE => $this->__('Zikula Administration Module'),
+                self::DURING => $this->__('Installing Zikula Administration Module'),
+                self::SUCCESS => $this->__('Zikula Administration Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Administration Module')
             ],
             7 => [
                 self::NAME => 'permissions',
-                self::PRE => __('Zikula Permissions Module'),
-                self::DURING => __('Installing Zikula Permissions Module'),
-                self::SUCCESS => __('Zikula Permissions Module installed'),
-                self::FAIL => __('There was an error installing Zikula Permissions Module')
+                self::PRE => $this->__('Zikula Permissions Module'),
+                self::DURING => $this->__('Installing Zikula Permissions Module'),
+                self::SUCCESS => $this->__('Zikula Permissions Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Permissions Module')
             ],
             8 => [
                 self::NAME => 'users',
-                self::PRE => __('Zikula Users Module'),
-                self::DURING => __('Installing Zikula Users Module'),
-                self::SUCCESS => __('Zikula Users Module installed'),
-                self::FAIL => __('There was an error installing Zikula Users Module')
+                self::PRE => $this->__('Zikula Users Module'),
+                self::DURING => $this->__('Installing Zikula Users Module'),
+                self::SUCCESS => $this->__('Zikula Users Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Users Module')
             ],
             9 => [
                 self::NAME => 'zauth',
-                self::PRE => __('Zikula ZAuth Module'),
-                self::DURING => __('Installing Zikula ZAuth Module'),
-                self::SUCCESS => __('Zikula ZAuth Module installed'),
-                self::FAIL => __('There was an error installing Zikula ZAuth Module')
+                self::PRE => $this->__('Zikula ZAuth Module'),
+                self::DURING => $this->__('Installing Zikula ZAuth Module'),
+                self::SUCCESS => $this->__('Zikula ZAuth Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula ZAuth Module')
             ],
             10 => [
                 self::NAME => 'groups',
-                self::PRE => __('Zikula Groups Module'),
-                self::DURING => __('Installing Zikula Groups Module'),
-                self::SUCCESS => __('Zikula Groups Module installed'),
-                self::FAIL => __('There was an error installing Zikula Groups Module')
+                self::PRE => $this->__('Zikula Groups Module'),
+                self::DURING => $this->__('Installing Zikula Groups Module'),
+                self::SUCCESS => $this->__('Zikula Groups Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Groups Module')
             ],
             11 => [
                 self::NAME => 'blocks',
-                self::PRE => __('Zikula Blocks Module'),
-                self::DURING => __('Installing Zikula Blocks Module'),
-                self::SUCCESS => __('Zikula Blocks Module installed'),
-                self::FAIL => __('There was an error installing Zikula Blocks Module')
+                self::PRE => $this->__('Zikula Blocks Module'),
+                self::DURING => $this->__('Installing Zikula Blocks Module'),
+                self::SUCCESS => $this->__('Zikula Blocks Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Blocks Module')
             ],
             12 => [
                 self::NAME => 'security',
-                self::PRE => __('Zikula Security Module'),
-                self::DURING => __('Installing Zikula Security Module'),
-                self::SUCCESS => __('Zikula Security Module installed'),
-                self::FAIL => __('There was an error installing Zikula Security Module')
+                self::PRE => $this->__('Zikula Security Module'),
+                self::DURING => $this->__('Installing Zikula Security Module'),
+                self::SUCCESS => $this->__('Zikula Security Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Security Module')
             ],
             13 => [
                 self::NAME => 'categories',
-                self::PRE => __('Zikula Categories Module'),
-                self::DURING => __('Installing Zikula Categories Module'),
-                self::SUCCESS => __('Zikula Categories Module installed'),
-                self::FAIL => __('There was an error installing Zikula Categories Module')
+                self::PRE => $this->__('Zikula Categories Module'),
+                self::DURING => $this->__('Installing Zikula Categories Module'),
+                self::SUCCESS => $this->__('Zikula Categories Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Categories Module')
             ],
             14 => [
                 self::NAME => 'mailer',
-                self::PRE => __('Zikula Mailer Module'),
-                self::DURING => __('Installing Zikula Mailer Module'),
-                self::SUCCESS => __('Zikula Mailer Module installed'),
-                self::FAIL => __('There was an error installing Zikula Mailer Module')
+                self::PRE => $this->__('Zikula Mailer Module'),
+                self::DURING => $this->__('Installing Zikula Mailer Module'),
+                self::SUCCESS => $this->__('Zikula Mailer Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Mailer Module')
             ],
             15 => [
                 self::NAME => 'search',
-                self::PRE => __('Zikula Search Module'),
-                self::DURING => __('Installing Zikula Search Module'),
-                self::SUCCESS => __('Zikula Search Module installed'),
-                self::FAIL => __('There was an error installing Zikula Search Module')
+                self::PRE => $this->__('Zikula Search Module'),
+                self::DURING => $this->__('Installing Zikula Search Module'),
+                self::SUCCESS => $this->__('Zikula Search Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Search Module')
             ],
             16 => [
                 self::NAME => 'routes',
-                self::PRE => __('Zikula Routes Module'),
-                self::DURING => __('Installing Zikula Routes Module'),
-                self::SUCCESS => __('Zikula Routes Module installed'),
-                self::FAIL => __('There was an error installing Zikula Routes Module')
+                self::PRE => $this->__('Zikula Routes Module'),
+                self::DURING => $this->__('Installing Zikula Routes Module'),
+                self::SUCCESS => $this->__('Zikula Routes Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Routes Module')
             ],
             17 => [
                 self::NAME => 'menu',
-                self::PRE => __('Zikula Menu Module'),
-                self::DURING => __('Installing Zikula Menu Module'),
-                self::SUCCESS => __('Zikula Menu Module installed'),
-                self::FAIL => __('There was an error installing Zikula Menu Module')
+                self::PRE => $this->__('Zikula Menu Module'),
+                self::DURING => $this->__('Installing Zikula Menu Module'),
+                self::SUCCESS => $this->__('Zikula Menu Module installed'),
+                self::FAIL => $this->__('There was an error installing Zikula Menu Module')
             ],
             18 => [
                 self::NAME => 'activatemodules',
-                self::PRE => __('Activate system modules'),
-                self::DURING => __('Activating system modules'),
-                self::SUCCESS => __('System modules activated'),
-                self::FAIL => __('There was an error activating system modules')
+                self::PRE => $this->__('Activate system modules'),
+                self::DURING => $this->__('Activating system modules'),
+                self::SUCCESS => $this->__('System modules activated'),
+                self::FAIL => $this->__('There was an error activating system modules')
             ],
             19 => [
                 self::NAME => 'categorize',
-                self::PRE => __('Module categorization'),
-                self::DURING => __('Moving modules to their default categories'),
-                self::SUCCESS => __('Modules moved to their default categories'),
-                self::FAIL => __('There was an error moving modules to their default categories')
+                self::PRE => $this->__('Module categorization'),
+                self::DURING => $this->__('Moving modules to their default categories'),
+                self::SUCCESS => $this->__('Modules moved to their default categories'),
+                self::FAIL => $this->__('There was an error moving modules to their default categories')
             ],
             20 => [
                 self::NAME => 'createblocks',
-                self::PRE => __('Create blocks'),
-                self::DURING => __('Creating default blocks'),
-                self::SUCCESS => __('Default blocks created'),
-                self::FAIL => __('There was an error creating default blocks')
+                self::PRE => $this->__('Create blocks'),
+                self::DURING => $this->__('Creating default blocks'),
+                self::SUCCESS => $this->__('Default blocks created'),
+                self::FAIL => $this->__('There was an error creating default blocks')
             ],
             21 => [
                 self::NAME => 'updateadmin',
-                self::PRE => __('Create admin account'),
-                self::DURING => __('Creating admin account'),
-                self::SUCCESS => __('Admin account created'),
-                self::FAIL => __('There was an error creating admin account')
+                self::PRE => $this->__('Create admin account'),
+                self::DURING => $this->__('Creating admin account'),
+                self::SUCCESS => $this->__('Admin account created'),
+                self::FAIL => $this->__('There was an error creating admin account')
             ],
             22 => [
                 self::NAME => 'loginadmin',
-                self::PRE => __('Login'),
-                self::DURING => __('Logging in as admin'),
-                self::SUCCESS => __('Logged in as admin'),
-                self::FAIL => __('There was an error logging in as admin')
+                self::PRE => $this->__('Login'),
+                self::DURING => $this->__('Logging in as admin'),
+                self::SUCCESS => $this->__('Logged in as admin'),
+                self::FAIL => $this->__('There was an error logging in as admin')
             ],
             23 => [
                 self::NAME => 'finalizeparameters',
-                self::PRE => __('Finalize parameters'),
-                self::DURING => __('Finalizing parameters'),
-                self::SUCCESS => __('Parameters finalized'),
-                self::FAIL => __('There was an error finalizing the parameters')
+                self::PRE => $this->__('Finalize parameters'),
+                self::DURING => $this->__('Finalizing parameters'),
+                self::SUCCESS => $this->__('Parameters finalized'),
+                self::FAIL => $this->__('There was an error finalizing the parameters')
             ],
             24 => [
                 self::NAME => 'reloadroutes',
-                self::PRE => __('Reload routes'),
-                self::DURING => __('Reloading routes (takes longer...)'),
-                self::SUCCESS => __('Routes reloaded'),
-                self::FAIL => __('There was an error reloading the routes')
+                self::PRE => $this->__('Reload routes'),
+                self::DURING => $this->__('Reloading routes (takes longer...)'),
+                self::SUCCESS => $this->__('Routes reloaded'),
+                self::FAIL => $this->__('There was an error reloading the routes')
             ],
             25 => [
                 self::NAME => 'plugins',
-                self::PRE => __('System Plugins'),
-                self::DURING => __('Installing System Plugins'),
-                self::SUCCESS => __('System Plugins installed'),
-                self::FAIL => __('There was an error installing System Plugins')
+                self::PRE => $this->__('System Plugins'),
+                self::DURING => $this->__('Installing System Plugins'),
+                self::SUCCESS => $this->__('System Plugins installed'),
+                self::FAIL => $this->__('There was an error installing System Plugins')
             ],
             26 => [
                 self::NAME => 'protect',
-                self::PRE => __('Protect configuration files'),
-                self::DURING => __('Protecting configuration files'),
-                self::SUCCESS => __('Configuration files protected'),
-                self::FAIL => __('There was an error protecting configuration files')
+                self::PRE => $this->__('Protect configuration files'),
+                self::DURING => $this->__('Protecting configuration files'),
+                self::SUCCESS => $this->__('Configuration files protected'),
+                self::FAIL => $this->__('There was an error protecting configuration files')
             ],
             27 => [
                 self::NAME => 'installassets',
-                self::PRE => __('Install assets'),
-                self::DURING => __('Installing assets to /web'),
-                self::SUCCESS => __('Assets installed'),
-                self::FAIL => __('Failed to install assets')
+                self::PRE => $this->__('Install assets'),
+                self::DURING => $this->__('Installing assets to /web'),
+                self::SUCCESS => $this->__('Assets installed'),
+                self::FAIL => $this->__('Failed to install assets')
             ],
             28 => [
                 self::NAME => 'finish',
-                self::PRE => __('Finish'),
-                self::DURING => __('Finish'),
-                self::SUCCESS => __('Finish'),
-                self::FAIL => __('Finish')
+                self::PRE => $this->__('Finish'),
+                self::DURING => $this->__('Finish'),
+                self::SUCCESS => $this->__('Finish'),
+                self::FAIL => $this->__('Finish')
             ]
         ]];
     }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/CompleteStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/CompleteStage.php
@@ -11,6 +11,7 @@
 
 namespace Zikula\Bundle\CoreInstallerBundle\Stage\Install;
 
+use Zikula\Common\Translator\TranslatorTrait;
 use Zikula\Component\Wizard\InjectContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Zikula\Component\Wizard\StageInterface;
@@ -23,11 +24,19 @@ use Zikula\ExtensionsModule\Api\VariableApi;
 
 class CompleteStage implements StageInterface, WizardCompleteInterface, InjectContainerInterface
 {
+    use TranslatorTrait;
+
     private $container;
 
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
+        $this->setTranslator($container->get('translator.default'));
+    }
+
+    public function setTranslator($translator)
+    {
+        $this->translator = $translator;
     }
 
     public function getName()
@@ -53,11 +62,11 @@ class CompleteStage implements StageInterface, WizardCompleteInterface, InjectCo
     public function getResponse(Request $request)
     {
         if ($this->sendEmailToAdmin($request)) {
-            $request->getSession()->getFlashBag()->add('success', __('Congratulations! Zikula has been successfully installed.'));
+            $request->getSession()->getFlashBag()->add('success', $this->__('Congratulations! Zikula has been successfully installed.'));
 
             return new RedirectResponse($this->container->get('router')->generate('zikulaadminmodule_admin_adminpanel', [], RouterInterface::ABSOLUTE_URL));
         } else {
-            $request->getSession()->getFlashBag()->add('warning', __('Email settings are not yet configured. Please configure them below.'));
+            $request->getSession()->getFlashBag()->add('warning', $this->__('Email settings are not yet configured. Please configure them below.'));
 
             return new RedirectResponse($this->container->get('router')->generate('zikulamailermodule_config_config', [], RouterInterface::ABSOLUTE_URL));
         }
@@ -80,7 +89,7 @@ visit <a href="http://zikula.org">zikula.org</a></p>
 </body>
 EOF;
         $message = \Swift_Message::newInstance()
-            ->setSubject(__('Zikula installation completed!'))
+            ->setSubject($this->__('Zikula installation completed!'))
             ->setFrom($fromMail)
             ->setTo($email)
             ->setBody($body)

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/CreateAdminStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/CreateAdminStage.php
@@ -45,7 +45,9 @@ class CreateAdminStage implements StageInterface, FormHandlerInterface, InjectCo
 
     public function getFormOptions()
     {
-        return [];
+        return [
+            'translator' => $this->container->get('translator.default')
+        ];
     }
 
     public function getTemplateName()

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/DbCredsStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Install/DbCredsStage.php
@@ -50,7 +50,9 @@ class DbCredsStage implements StageInterface, FormHandlerInterface, InjectContai
 
     public function getFormOptions()
     {
-        return [];
+        return [
+            'translator' => $this->container->get('translator.default')
+        ];
     }
 
     public function getTemplateName()

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/LocaleStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/LocaleStage.php
@@ -103,7 +103,7 @@ class LocaleStage implements StageInterface, FormHandlerInterface, InjectContain
         try {
             $this->yamlManager->setParameters($params);
         } catch (IOException $e) {
-            throw new AbortStageException(__f('Cannot write parameters to %s file.', 'custom_parameters.yml'));
+            throw new AbortStageException($this->container->get('translator.default')->__f('Cannot write parameters to %s file.', 'custom_parameters.yml'));
         }
         // setup multilingual
         $this->container->setParameter('language_i18n', $data['locale']);

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/LocaleStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/LocaleStage.php
@@ -106,11 +106,11 @@ class LocaleStage implements StageInterface, FormHandlerInterface, InjectContain
         }
         // setup multilingual
         $this->container->setParameter('language_i18n', $data['locale']);
+        $this->container->setParameter('locale', $data['locale']);
         $this->container->setParameter('multilingual', true);
         $this->container->setParameter('languageurl', true);
         $this->container->setParameter('language_detect', false);
-
-//        $_lang = ZLanguage::getInstance();
-//        $_lang->setup($request);
+        // clear container cache
+        $this->container->get('zikula.cache_clearer')->clear('symfony.config');
     }
 }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/LocaleStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/LocaleStage.php
@@ -65,7 +65,8 @@ class LocaleStage implements StageInterface, FormHandlerInterface, InjectContain
     {
         return [
             'choices' => \ZLanguage::getInstalledLanguageNames(),
-            'choice' => $this->matchedLocale
+            'choice' => $this->matchedLocale,
+            'translator' => $this->container->get('translator.default')
         ];
     }
 

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Upgrade/AjaxUpgraderStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Upgrade/AjaxUpgraderStage.php
@@ -11,11 +11,26 @@
 
 namespace Zikula\Bundle\CoreInstallerBundle\Stage\Upgrade;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Zikula\Common\Translator\TranslatorTrait;
+use Zikula\Component\Wizard\InjectContainerInterface;
 use Zikula\Component\Wizard\StageInterface;
 use Zikula\Bundle\CoreInstallerBundle\Stage\Install\AjaxInstallerStage;
 
-class AjaxUpgraderStage implements StageInterface
+class AjaxUpgraderStage implements StageInterface, InjectContainerInterface
 {
+    use TranslatorTrait;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->setTranslator($container->get('translator.default'));
+    }
+
+    public function setTranslator($translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function getName()
     {
         return 'ajaxupgrader';
@@ -36,87 +51,87 @@ class AjaxUpgraderStage implements StageInterface
         return ['stages' => [
             1 => [
                 AjaxInstallerStage::NAME => 'loginadmin',
-                AjaxInstallerStage::PRE => __('Login'),
-                AjaxInstallerStage::DURING => __('Logging in as admin'),
-                AjaxInstallerStage::SUCCESS => __('Logged in as admin'),
-                AjaxInstallerStage::FAIL => __('There was an error logging in as admin')
+                AjaxInstallerStage::PRE => $this->__('Login'),
+                AjaxInstallerStage::DURING => $this->__('Logging in as admin'),
+                AjaxInstallerStage::SUCCESS => $this->__('Logged in as admin'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error logging in as admin')
             ],
             2 => [
                 AjaxInstallerStage::NAME => 'upgrademodules',
-                AjaxInstallerStage::PRE => __('Upgrade modules'),
-                AjaxInstallerStage::DURING => __('Upgrading modules'),
-                AjaxInstallerStage::SUCCESS => __('Modules upgraded'),
-                AjaxInstallerStage::FAIL => __('There was an error upgrading the modules')
+                AjaxInstallerStage::PRE => $this->__('Upgrade modules'),
+                AjaxInstallerStage::DURING => $this->__('Upgrading modules'),
+                AjaxInstallerStage::SUCCESS => $this->__('Modules upgraded'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error upgrading the modules')
             ],
             3 => [
                 AjaxInstallerStage::NAME => 'installroutes',
-                AjaxInstallerStage::PRE => __('Install Zikula Routes Module'),
-                AjaxInstallerStage::DURING => __('Installing Zikula Routes Module'),
-                AjaxInstallerStage::SUCCESS => __('Zikula Routes Module installed'),
-                AjaxInstallerStage::FAIL => __('There was an error installing Zikula Routes Module')
+                AjaxInstallerStage::PRE => $this->__('Install Zikula Routes Module'),
+                AjaxInstallerStage::DURING => $this->__('Installing Zikula Routes Module'),
+                AjaxInstallerStage::SUCCESS => $this->__('Zikula Routes Module installed'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error installing Zikula Routes Module')
             ],
             4 => [
                 AjaxInstallerStage::NAME => 'reloadroutes',
-                AjaxInstallerStage::PRE => __('Reload routes'),
-                AjaxInstallerStage::DURING => __('Reloading routes (takes longer...)'),
-                AjaxInstallerStage::SUCCESS => __('Routes reloaded'),
-                AjaxInstallerStage::FAIL => __('There was an error reloading the routes')
+                AjaxInstallerStage::PRE => $this->__('Reload routes'),
+                AjaxInstallerStage::DURING => $this->__('Reloading routes (takes longer...)'),
+                AjaxInstallerStage::SUCCESS => $this->__('Routes reloaded'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error reloading the routes')
             ],
             5 => [
                 AjaxInstallerStage::NAME => 'regenthemes',
-                AjaxInstallerStage::PRE => __('Regenerate themes'),
-                AjaxInstallerStage::DURING => __('Regenerating themes'),
-                AjaxInstallerStage::SUCCESS => __('Themes regenerated'),
-                AjaxInstallerStage::FAIL => __('There was an error regenerating the themes')
+                AjaxInstallerStage::PRE => $this->__('Regenerate themes'),
+                AjaxInstallerStage::DURING => $this->__('Regenerating themes'),
+                AjaxInstallerStage::SUCCESS => $this->__('Themes regenerated'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error regenerating the themes')
             ],
             6 => [
                 AjaxInstallerStage::NAME => 'from140to141',
-                AjaxInstallerStage::PRE => __('Upgrade from Core 1.4.0 to Core 1.4.1'),
-                AjaxInstallerStage::DURING => __('Upgrading to Core 1.4.1'),
-                AjaxInstallerStage::SUCCESS => __('Upgraded to Core 1.4.1'),
-                AjaxInstallerStage::FAIL => __('There was an error upgrading to Core 1.4.1')
+                AjaxInstallerStage::PRE => $this->__('Upgrade from Core 1.4.0 to Core 1.4.1'),
+                AjaxInstallerStage::DURING => $this->__('Upgrading to Core 1.4.1'),
+                AjaxInstallerStage::SUCCESS => $this->__('Upgraded to Core 1.4.1'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error upgrading to Core 1.4.1')
             ],
             7 => [
                 AjaxInstallerStage::NAME => 'from141to142',
-                AjaxInstallerStage::PRE => __('Upgrade from Core 1.4.1 to Core 1.4.2'),
-                AjaxInstallerStage::DURING => __('Upgrading to Core 1.4.2'),
-                AjaxInstallerStage::SUCCESS => __('Upgraded to Core 1.4.2'),
-                AjaxInstallerStage::FAIL => __('There was an error upgrading to Core 1.4.2')
+                AjaxInstallerStage::PRE => $this->__('Upgrade from Core 1.4.1 to Core 1.4.2'),
+                AjaxInstallerStage::DURING => $this->__('Upgrading to Core 1.4.2'),
+                AjaxInstallerStage::SUCCESS => $this->__('Upgraded to Core 1.4.2'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error upgrading to Core 1.4.2')
             ],
             8 => [
                 AjaxInstallerStage::NAME => 'from142to143',
-                AjaxInstallerStage::PRE => __('Upgrade from Core 1.4.2 to Core 1.4.3'),
-                AjaxInstallerStage::DURING => __('Upgrading to Core 1.4.3'),
-                AjaxInstallerStage::SUCCESS => __('Upgraded to Core 1.4.3'),
-                AjaxInstallerStage::FAIL => __('There was an error upgrading to Core 1.4.3')
+                AjaxInstallerStage::PRE => $this->__('Upgrade from Core 1.4.2 to Core 1.4.3'),
+                AjaxInstallerStage::DURING => $this->__('Upgrading to Core 1.4.3'),
+                AjaxInstallerStage::SUCCESS => $this->__('Upgraded to Core 1.4.3'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error upgrading to Core 1.4.3')
             ],
             9 => [
                 AjaxInstallerStage::NAME => 'from143to144',
-                AjaxInstallerStage::PRE => __('Upgrade from Core 1.4.3 to Core 1.4.4'),
-                AjaxInstallerStage::DURING => __('Upgrading to Core 1.4.4'),
-                AjaxInstallerStage::SUCCESS => __('Upgraded to Core 1.4.4'),
-                AjaxInstallerStage::FAIL => __('There was an error upgrading to Core 1.4.4')
+                AjaxInstallerStage::PRE => $this->__('Upgrade from Core 1.4.3 to Core 1.4.4'),
+                AjaxInstallerStage::DURING => $this->__('Upgrading to Core 1.4.4'),
+                AjaxInstallerStage::SUCCESS => $this->__('Upgraded to Core 1.4.4'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error upgrading to Core 1.4.4')
             ],
             10 => [
                 AjaxInstallerStage::NAME => 'finalizeparameters',
-                AjaxInstallerStage::PRE => __('Finalize parameters'),
-                AjaxInstallerStage::DURING => __('Finalizing parameters'),
-                AjaxInstallerStage::SUCCESS => __('Parameters finalized'),
-                AjaxInstallerStage::FAIL => __('There was an error finalizing the parameters')
+                AjaxInstallerStage::PRE => $this->__('Finalize parameters'),
+                AjaxInstallerStage::DURING => $this->__('Finalizing parameters'),
+                AjaxInstallerStage::SUCCESS => $this->__('Parameters finalized'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error finalizing the parameters')
             ],
             11 => [
                 AjaxInstallerStage::NAME => 'clearcaches',
-                AjaxInstallerStage::PRE => __('Clear caches'),
-                AjaxInstallerStage::DURING => __('Clearing caches'),
-                AjaxInstallerStage::SUCCESS => __('Caches cleared'),
-                AjaxInstallerStage::FAIL => __('There was an error clearing caches')
+                AjaxInstallerStage::PRE => $this->__('Clear caches'),
+                AjaxInstallerStage::DURING => $this->__('Clearing caches'),
+                AjaxInstallerStage::SUCCESS => $this->__('Caches cleared'),
+                AjaxInstallerStage::FAIL => $this->__('There was an error clearing caches')
             ],
             12 => [
                 AjaxInstallerStage::NAME => 'finish',
-                AjaxInstallerStage::PRE => __('Finish'),
-                AjaxInstallerStage::DURING => __('Finish'),
-                AjaxInstallerStage::SUCCESS => __('Finish'),
-                AjaxInstallerStage::FAIL => __('Finish')
+                AjaxInstallerStage::PRE => $this->__('Finish'),
+                AjaxInstallerStage::DURING => $this->__('Finish'),
+                AjaxInstallerStage::SUCCESS => $this->__('Finish'),
+                AjaxInstallerStage::FAIL => $this->__('Finish')
             ]
         ]];
     }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Upgrade/CompleteStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Upgrade/CompleteStage.php
@@ -50,7 +50,7 @@ class CompleteStage implements StageInterface, WizardCompleteInterface, InjectCo
 
     public function getResponse(Request $request)
     {
-        $request->getSession()->getFlashBag()->add('success', __('Congratulations! Upgrade Complete.'));
+        $request->getSession()->getFlashBag()->add('success', $this->container->get('translator.default')->__('Congratulations! Upgrade Complete.'));
 
         return new RedirectResponse($this->container->get('router')->generate('zikulaadminmodule_admin_adminpanel', [], RouterInterface::ABSOLUTE_URL));
     }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Upgrade/LoginStage.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Stage/Upgrade/LoginStage.php
@@ -41,7 +41,9 @@ class LoginStage implements StageInterface, FormHandlerInterface, InjectContaine
 
     public function getFormOptions()
     {
-        return [];
+        return [
+            'translator' => $this->container->get('translator.default')
+        ];
     }
 
     public function getTemplateName()

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Validator/Constraints/AuthenticateAdminLoginValidator.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Validator/Constraints/AuthenticateAdminLoginValidator.php
@@ -14,10 +14,14 @@ namespace Zikula\Bundle\CoreInstallerBundle\Validator\Constraints;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Zikula\Common\Translator\TranslatorInterface;
+use Zikula\Common\Translator\TranslatorTrait;
 use Zikula\PermissionsModule\Api\PermissionApi;
 
 class AuthenticateAdminLoginValidator extends ConstraintValidator
 {
+    use TranslatorTrait;
+
     /**
      * @var PermissionApi
      */
@@ -32,11 +36,18 @@ class AuthenticateAdminLoginValidator extends ConstraintValidator
      * AuthenticateAdminLoginValidator constructor.
      * @param PermissionApi $permissionApi
      * @param Connection $connection
+     * @param TranslatorInterface $translator
      */
-    public function __construct(PermissionApi $permissionApi, Connection $connection)
+    public function __construct(PermissionApi $permissionApi, Connection $connection, TranslatorInterface $translator)
     {
         $this->permissionApi = $permissionApi;
         $this->databaseConnection = $connection;
+        $this->setTranslator($translator);
+    }
+
+    public function setTranslator($translator)
+    {
+        $this->translator = $translator;
     }
 
     public function validate($object, Constraint $constraint)
@@ -52,18 +63,18 @@ class AuthenticateAdminLoginValidator extends ConstraintValidator
                 $user = $this->databaseConnection->fetchAssoc('SELECT uid, pass FROM users WHERE uname= ?', [$object['username']]);
             }
         } catch (\Exception $e) {
-            $this->context->buildViolation(__('Error! There was a problem with the database connection.'))
+            $this->context->buildViolation($this->__('Error! There was a problem with the database connection.'))
                 ->addViolation()
             ;
         }
 
         if (empty($user) || ($user['uid'] <= 1) || (!\UserUtil::passwordsMatch($object['password'], $user['pass']))) { // @todo
-            $this->context->buildViolation(__('Error! Could not login with provided credentials. Please try again.'))
+            $this->context->buildViolation($this->__('Error! Could not login with provided credentials. Please try again.'))
                 ->addViolation();
         } else {
             $granted = $this->permissionApi->hasPermission('.*', '.*', ACCESS_ADMIN, $user['uid']);
             if (!$granted) {
-                $this->context->buildViolation(__('Error! You logged in to an account without Admin permissions'))
+                $this->context->buildViolation($this->__('Error! You logged in to an account without Admin permissions'))
                     ->addViolation();
             }
         }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Validator/Constraints/ValidPdoConnectionValidator.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Validator/Constraints/ValidPdoConnectionValidator.php
@@ -13,13 +13,27 @@ namespace Zikula\Bundle\CoreInstallerBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Zikula\Common\Translator\TranslatorInterface;
+use Zikula\Common\Translator\TranslatorTrait;
 
 class ValidPdoConnectionValidator extends ConstraintValidator
 {
+    use TranslatorTrait;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->setTranslator($translator);
+    }
+
+    public function setTranslator($translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function validate($object, Constraint $constraint)
     {
         if ($object['database_host'] == '' || $object['database_name'] == '' || $object['database_user'] == '') {
-            $this->context->buildViolation(__('Error! Please enter your database credentials.'))
+            $this->context->buildViolation($this->__('Error! Please enter your database credentials.'))
                 ->addViolation();
 
             return;
@@ -33,14 +47,14 @@ class ValidPdoConnectionValidator extends ConstraintValidator
                 "SHOW TABLES FROM $object[database_name] LIKE '%'";
             $tables = $dbh->query($sql);
             if (!is_object($tables)) {
-                $this->context->buildViolation(__('Error! Determination existing tables failed.') . ' SQL: ' . $sql)
+                $this->context->buildViolation($this->__('Error! Determination existing tables failed.') . ' SQL: ' . $sql)
                     ->addViolation();
             } elseif ($tables->rowCount() > 0) {
-                $this->context->buildViolation(__('Error! The database exists and contains tables. Please delete all tables before proceeding or select a new database.'))
+                $this->context->buildViolation($this->__('Error! The database exists and contains tables. Please delete all tables before proceeding or select a new database.'))
                     ->addViolation();
             }
         } catch (\PDOException $eb) {
-            $this->context->buildViolation(__('Error! Could not connect to the database. Please check that you have entered the correct database information and try again. ' . $eb->getMessage()))
+            $this->context->buildViolation($this->__('Error! Could not connect to the database. Please check that you have entered the correct database information and try again. ' . $eb->getMessage()))
                 ->addViolation();
         }
     }

--- a/src/lib/Zikula/Bundle/CoreInstallerBundle/Validator/Constraints/ValidPdoConnectionValidator.php
+++ b/src/lib/Zikula/Bundle/CoreInstallerBundle/Validator/Constraints/ValidPdoConnectionValidator.php
@@ -54,7 +54,7 @@ class ValidPdoConnectionValidator extends ConstraintValidator
                     ->addViolation();
             }
         } catch (\PDOException $eb) {
-            $this->context->buildViolation($this->__('Error! Could not connect to the database. Please check that you have entered the correct database information and try again. ' . $eb->getMessage()))
+            $this->context->buildViolation($this->__('Error! Could not connect to the database. Please check that you have entered the correct database information and try again. ') . $eb->getMessage())
                 ->addViolation();
         }
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #2191
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description
enable scan of locales on installation and set locale for installer based on user selection. Add translator usage to many parts of the core installer and upgrader.
closes #2191