### PR TITLE
add listener to clear asset cache on module state change

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/CacheClearer.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/CacheClearer.php
@@ -47,7 +47,7 @@ class CacheClearer
 
         $this->cacheTypes = [
             'symfony.annotations' => [
-                $cacheFolder . '/annotations'
+                $cacheFolder . 'annotations'
             ],
             'symfony.routing.generator' => [
                 $cacheFolder . $cachePrefix . 'UrlGenerator.php',
@@ -73,6 +73,9 @@ class CacheClearer
             ],
             'purifier' => [
                 $cacheFolder . 'purifier'
+            ],
+            'assets' => [
+                $cacheFolder . 'assets'
             ]
         ];
         if (isset($legacyCacheDir)) {

--- a/src/system/ThemeModule/DependencyInjection/ZikulaThemeExtension.php
+++ b/src/system/ThemeModule/DependencyInjection/ZikulaThemeExtension.php
@@ -30,6 +30,8 @@ class ZikulaThemeExtension extends Extension
 
         $loader->load('services.xml');
         $loader->load('theme_engine.xml');
+        $loader->load('theme_engine_event_listeners.xml');
+        $loader->load('deprecated_aliases.xml');
         $loader->load('legacy.xml');
     }
 }

--- a/src/system/ThemeModule/Engine/Asset/MergerInterface.php
+++ b/src/system/ThemeModule/Engine/Asset/MergerInterface.php
@@ -15,7 +15,7 @@ interface MergerInterface
 {
     /**
      * Merge the assets and publish.
-     * @param \Traversable $assets
+     * @param array $assets
      * @param string $type
      * @return $this
      */

--- a/src/system/ThemeModule/EventListener/ExtensionInstallationListener.php
+++ b/src/system/ThemeModule/EventListener/ExtensionInstallationListener.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - http://zikula.org/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\ThemeModule\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Zikula\Bundle\CoreBundle\CacheClearer;
+use Zikula\Core\CoreEvents;
+
+/**
+ * Clear the combined asset cache when a module or theme state is changed
+ */
+class ExtensionInstallationListener implements EventSubscriberInterface
+{
+    private $cacheClearer;
+
+    public function __construct(CacheClearer $cacheClearer)
+    {
+        $this->cacheClearer = $cacheClearer;
+    }
+
+    public function clearCombinedAssetCache()
+    {
+        $this->cacheClearer->clear('assets');
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            CoreEvents::MODULE_INSTALL => ['clearCombinedAssetCache'],
+            CoreEvents::MODULE_UPGRADE => ['clearCombinedAssetCache'],
+            CoreEvents::MODULE_ENABLE => ['clearCombinedAssetCache'],
+            CoreEvents::MODULE_DISABLE => ['clearCombinedAssetCache'],
+            CoreEvents::MODULE_REMOVE => ['clearCombinedAssetCache'],
+            // @todo create theme events for same and add here
+        ];
+    }
+}

--- a/src/system/ThemeModule/Resources/config/deprecated_aliases.xml
+++ b/src/system/ThemeModule/Resources/config/deprecated_aliases.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Alias for services. These service names are @deprecated and will be removed in Core-2.0 -->
+        <service id="theme.theme_listener" alias="zikula_core.internal.theme.create_themed_response_listener" />
+        <service id="theme.asset_helper" alias="zikula_core.common.theme.asset_helper" />
+        <service id="theme.pagevars" alias="zikula_core.common.theme.pagevars" />
+        <service id="theme.assets_js" alias="zikula_core.common.theme.assets_js" />
+        <service id="theme.assets_css" alias="zikula_core.common.theme.assets_css" />
+        <service id="theme.js_resolver" alias="zikula_core.internal.theme.js_resolver" />
+        <service id="theme.css_resolver" alias="zikula_core.internal.theme.css_resolver" />
+        <service id="theme.themevars" alias="zikula_core.common.theme.themevars" />
+        <!-- end alias definitions -->
+    </services>
+</container>

--- a/src/system/ThemeModule/Resources/config/theme_engine.xml
+++ b/src/system/ThemeModule/Resources/config/theme_engine.xml
@@ -5,14 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="zikula_core.internal.theme.create_themed_response_listener.class">Zikula\ThemeModule\EventListener\CreateThemedResponseListener</parameter>
-        <parameter key="zikula_core.internal.theme.default_page_asset_setter_listener.class">Zikula\ThemeModule\EventListener\DefaultPageAssetSetterListener</parameter>
-        <parameter key="zikula_core.internal.theme.default_page_var_setter_listener.class">Zikula\ThemeModule\EventListener\DefaultPageVarSetterListener</parameter>
-        <parameter key="zikula_core.internal.theme.controller_annotation_reader_listener.class">Zikula\ThemeModule\EventListener\ControllerAnnotationReaderListener</parameter>
-        <parameter key="zikula_core.internal.theme.template_path_override_listener.class">Zikula\ThemeModule\EventListener\TemplatePathOverrideListener</parameter>
-        <parameter key="zikula_core.internal.theme.module_stylesheet_insert_listener.class">Zikula\ThemeModule\EventListener\ModuleStylesheetInsertListener</parameter>
-        <parameter key="zikula_core.internal.theme.add_jsconfig_listener.class">Zikula\ThemeModule\EventListener\AddJSConfigListener</parameter>
-        <parameter key="zikula_core.internal.theme.template_name_expose_listener.class">Zikula\ThemeModule\EventListener\TemplateNameExposeListener</parameter>
         <parameter key="zikula_core.common.theme_engine.class">Zikula\ThemeModule\Engine\Engine</parameter>
         <parameter key="zikula_core.internal.theme.merger.class">Zikula\ThemeModule\Engine\Asset\Merger</parameter>
         <parameter key="zikula_core.common.theme.assets.js.class">Zikula\ThemeModule\Engine\AssetBag</parameter>
@@ -29,74 +21,6 @@
     </parameters>
 
     <services>
-        <service id="zikula_core.internal.theme.create_themed_response_listener" class="%zikula_core.internal.theme.create_themed_response_listener.class%">
-            <argument>%installed%</argument>
-            <tag name="kernel.event_subscriber" />
-            <tag name="monolog.logger" channel="request" />
-            <argument type="service" id="zikula_core.common.theme_engine" />
-            <argument type="service" id="zikula_extensions_module.api.variable" />
-        </service>
-
-        <service id="zikula_core.internal.theme.default_page_asset_setter_listener" class="%zikula_core.internal.theme.default_page_asset_setter_listener.class%">
-            <tag name="kernel.event_subscriber" />
-            <tag name="monolog.logger" channel="request" />
-            <argument type="service" id="zikula_core.common.theme.assets_js" />
-            <argument type="service" id="zikula_core.common.theme.assets_css" />
-            <argument type="service" id="router" />
-            <argument type="service" id="zikula_core.common.theme_engine" />
-            <argument>%kernel.root_dir%</argument>
-            <argument>%compat_layer%</argument>
-            <call method="setParameters">
-                <argument type="service" id="service_container" />
-            </call>
-        </service>
-
-        <service id="zikula_core.internal.theme.default_page_var_setter_listener" class="%zikula_core.internal.theme.default_page_var_setter_listener.class%">
-            <tag name="kernel.event_subscriber" />
-            <!--<tag name="monolog.logger" channel="request" />-->
-            <argument type="service" id="zikula_core.common.theme.pagevars" />
-            <argument type="service" id="router" />
-            <argument type="service" id="zikula_extensions_module.api.variable" />
-            <argument type="service" id="kernel" />
-            <argument type="service" id="zikula_settings_module.locale_api" />
-            <argument>%installed%</argument>
-        </service>
-
-        <service id="zikula_core.internal.theme.controller_annotation_reader_listener" class="%zikula_core.internal.theme.controller_annotation_reader_listener.class%">
-            <tag name="kernel.event_subscriber" />
-            <tag name="monolog.logger" channel="request" />
-            <argument type="service" id="zikula_core.common.theme_engine" />
-        </service>
-
-        <service id="zikula_core.internal.theme.template_path_override_listener" class="%zikula_core.internal.theme.template_path_override_listener.class%">
-            <tag name="kernel.event_subscriber" />
-            <tag name="monolog.logger" channel="request" />
-            <argument type="service" id="twig.loader" />
-            <argument type="service" id="zikula_core.common.theme_engine" />
-        </service>
-
-        <service id="zikula_core.internal.theme.module_stylesheet_insert_listener" class="%zikula_core.internal.theme.module_stylesheet_insert_listener.class%">
-            <argument id="kernel" type="service"/>
-            <tag name="kernel.event_subscriber"/>
-        </service>
-
-        <service id="zikula_core.internal.theme.add_jsconfig_listener" class="%zikula_core.internal.theme.add_jsconfig_listener.class%">
-            <argument>%installed%</argument>
-            <argument type="service" id="zikula_extensions_module.api.variable" />
-            <argument type="service" id="zikula_users_module.current_user" />
-            <argument type="service" id="templating.engine.twig" />
-            <argument type="service" id="zikula_core.common.theme.themevars" />
-            <argument type="service" id="zikula_core.common.theme.assets_header" />
-            <argument>%zikula.session.name%</argument>
-            <argument>%compat_layer%</argument>
-            <tag name="kernel.event_subscriber"/>
-        </service>
-
-        <service id="zikula_core.internal.theme.template_name_expose_listener" class="%zikula_core.internal.theme.template_name_expose_listener.class%">
-            <argument>%env%</argument>
-            <tag name="kernel.event_subscriber"/>
-        </service>
-
         <service id="zikula_core.common.theme_engine" class="%zikula_core.common.theme_engine.class%">
             <argument type="service" id="request_stack" strict="false" />
             <argument type="service" id="annotation_reader" />

--- a/src/system/ThemeModule/Resources/config/theme_engine_event_listeners.xml
+++ b/src/system/ThemeModule/Resources/config/theme_engine_event_listeners.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="zikula_core.internal.theme.create_themed_response_listener.class">Zikula\ThemeModule\EventListener\CreateThemedResponseListener</parameter>
+        <parameter key="zikula_core.internal.theme.default_page_asset_setter_listener.class">Zikula\ThemeModule\EventListener\DefaultPageAssetSetterListener</parameter>
+        <parameter key="zikula_core.internal.theme.default_page_var_setter_listener.class">Zikula\ThemeModule\EventListener\DefaultPageVarSetterListener</parameter>
+        <parameter key="zikula_core.internal.theme.controller_annotation_reader_listener.class">Zikula\ThemeModule\EventListener\ControllerAnnotationReaderListener</parameter>
+        <parameter key="zikula_core.internal.theme.template_path_override_listener.class">Zikula\ThemeModule\EventListener\TemplatePathOverrideListener</parameter>
+        <parameter key="zikula_core.internal.theme.module_stylesheet_insert_listener.class">Zikula\ThemeModule\EventListener\ModuleStylesheetInsertListener</parameter>
+        <parameter key="zikula_core.internal.theme.add_jsconfig_listener.class">Zikula\ThemeModule\EventListener\AddJSConfigListener</parameter>
+        <parameter key="zikula_core.internal.theme.template_name_expose_listener.class">Zikula\ThemeModule\EventListener\TemplateNameExposeListener</parameter>
+        <parameter key="zikula_core.internal.theme.extension_installation_listener.class">Zikula\ThemeModule\EventListener\ExtensionInstallationListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="zikula_core.internal.theme.create_themed_response_listener" class="%zikula_core.internal.theme.create_themed_response_listener.class%">
+            <argument>%installed%</argument>
+            <tag name="kernel.event_subscriber" />
+            <tag name="monolog.logger" channel="request" />
+            <argument type="service" id="zikula_core.common.theme_engine" />
+            <argument type="service" id="zikula_extensions_module.api.variable" />
+        </service>
+
+        <service id="zikula_core.internal.theme.default_page_asset_setter_listener" class="%zikula_core.internal.theme.default_page_asset_setter_listener.class%">
+            <tag name="kernel.event_subscriber" />
+            <tag name="monolog.logger" channel="request" />
+            <argument type="service" id="zikula_core.common.theme.assets_js" />
+            <argument type="service" id="zikula_core.common.theme.assets_css" />
+            <argument type="service" id="router" />
+            <argument type="service" id="zikula_core.common.theme_engine" />
+            <argument>%kernel.root_dir%</argument>
+            <argument>%compat_layer%</argument>
+            <call method="setParameters">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+
+        <service id="zikula_core.internal.theme.default_page_var_setter_listener" class="%zikula_core.internal.theme.default_page_var_setter_listener.class%">
+            <tag name="kernel.event_subscriber" />
+            <!--<tag name="monolog.logger" channel="request" />-->
+            <argument type="service" id="zikula_core.common.theme.pagevars" />
+            <argument type="service" id="router" />
+            <argument type="service" id="zikula_extensions_module.api.variable" />
+            <argument type="service" id="kernel" />
+            <argument type="service" id="zikula_settings_module.locale_api" />
+            <argument>%installed%</argument>
+        </service>
+
+        <service id="zikula_core.internal.theme.controller_annotation_reader_listener" class="%zikula_core.internal.theme.controller_annotation_reader_listener.class%">
+            <tag name="kernel.event_subscriber" />
+            <tag name="monolog.logger" channel="request" />
+            <argument type="service" id="zikula_core.common.theme_engine" />
+        </service>
+
+        <service id="zikula_core.internal.theme.template_path_override_listener" class="%zikula_core.internal.theme.template_path_override_listener.class%">
+            <tag name="kernel.event_subscriber" />
+            <tag name="monolog.logger" channel="request" />
+            <argument type="service" id="twig.loader" />
+            <argument type="service" id="zikula_core.common.theme_engine" />
+        </service>
+
+        <service id="zikula_core.internal.theme.module_stylesheet_insert_listener" class="%zikula_core.internal.theme.module_stylesheet_insert_listener.class%">
+            <argument id="kernel" type="service"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="zikula_core.internal.theme.add_jsconfig_listener" class="%zikula_core.internal.theme.add_jsconfig_listener.class%">
+            <argument>%installed%</argument>
+            <argument type="service" id="zikula_extensions_module.api.variable" />
+            <argument type="service" id="zikula_users_module.current_user" />
+            <argument type="service" id="templating.engine.twig" />
+            <argument type="service" id="zikula_core.common.theme.themevars" />
+            <argument type="service" id="zikula_core.common.theme.assets_header" />
+            <argument>%zikula.session.name%</argument>
+            <argument>%compat_layer%</argument>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="zikula_core.internal.theme.template_name_expose_listener" class="%zikula_core.internal.theme.template_name_expose_listener.class%">
+            <argument>%env%</argument>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="zikula_core.internal.theme.extension_installation_listener" class="%zikula_core.internal.theme.extension_installation_listener.class%">
+            <argument type="service" id="zikula.cache_clearer" />
+            <tag name="kernel.event_subscriber"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description
add listener to clear asset cache on module state change
refs #3200
also reorganize some of the theme engine DI definitions