### PR TITLE
allow template overrides also for sub requests

### DIFF
--- a/src/system/ThemeModule/EventListener/TemplatePathOverrideListener.php
+++ b/src/system/ThemeModule/EventListener/TemplatePathOverrideListener.php
@@ -44,9 +44,9 @@ class TemplatePathOverrideListener implements EventSubscriberInterface
      */
     public function setUpThemePathOverrides(FilterControllerEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
+//         if (!$event->isMasterRequest()) {
+//             return;
+//         }
         // add theme path to template locator
         $controller = $event->getController()[0];
         if ($controller instanceof AbstractController) {

--- a/src/system/ThemeModule/EventListener/TemplatePathOverrideListener.php
+++ b/src/system/ThemeModule/EventListener/TemplatePathOverrideListener.php
@@ -44,9 +44,9 @@ class TemplatePathOverrideListener implements EventSubscriberInterface
      */
     public function setUpThemePathOverrides(FilterControllerEvent $event)
     {
-//         if (!$event->isMasterRequest()) {
-//             return;
-//         }
+        /*if (!$event->isMasterRequest()) {
+            return;
+        }*/
         // add theme path to template locator
         $controller = $event->getController()[0];
         if ($controller instanceof AbstractController) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description
This PR allows template overrides being considered also for sub requests. This becomes important for use cases like content types. My specific example use case is a Formicula form embedded using the content type.
Scheduled for 1.4.5 to avoid unexpected side effects for 1.4.4.

cc @MrMontesa