### PR TITLE
fixed fixing css pathes in asset merger if core is not installed in a subdirectory, fixed #3280

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -12,6 +12,7 @@ CHANGELOG - ZIKULA 1.4.x
  - Fixes:
     - Improved handling calls to inactive legacy modules (#3275, #1869).
     - Avoid breaking site if capability route is invalid (#3276, #2905).
+    - Fixed css pathes in asset merger if the core is not installed in a subdirectory (#3280, #3294).
 
  - Features:
     - ?

--- a/src/system/ThemeModule/Engine/Asset/Merger.php
+++ b/src/system/ThemeModule/Engine/Asset/Merger.php
@@ -274,7 +274,7 @@ class Merger implements MergerInterface
                 $depth = substr_count($match[1], '../') * -1;
                 $path = $depth < 0 ? array_slice($relativeFilePath, 0, $depth) : $relativeFilePath;
                 $path = implode('/', $path);
-                $path = !empty($path) ? $path . '/' : '';
+                $path = !empty($path) ? $path . '/' : '/';
                 $line = str_replace($match[0], "url('{$path}{$match[2]}')", $line);
             }
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #3280 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Todos
- [ ] Tests
