### PR TITLE
Correcting the setting of a module's translated display name

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/Bundle/MetaData.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/Bundle/MetaData.php
@@ -168,7 +168,7 @@ class MetaData implements \ArrayAccess
     public function getDisplayName()
     {
         $this->confirmTranslator();
-        
+
         $display_name = $this->__(/** @Ignore */$this->displayName);
 
         return (empty($display_name)) ? $this->displayName : $display_name;

--- a/src/lib/Zikula/Bundle/CoreBundle/Bundle/MetaData.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/Bundle/MetaData.php
@@ -150,7 +150,9 @@ class MetaData implements \ArrayAccess
     {
         $this->confirmTranslator();
 
-        return $this->__(/** @Ignore */$this->description);
+        $description = $this->__(/** @Ignore */$this->description);
+
+        return (empty($description)) ? $this->description : $description;
     }
 
     public function setDescription($description)
@@ -166,8 +168,10 @@ class MetaData implements \ArrayAccess
     public function getDisplayName()
     {
         $this->confirmTranslator();
+        
+        $display_name = $this->__(/** @Ignore */$this->displayName);
 
-        return $this->__(/** @Ignore */$this->displayName);
+        return (empty($display_name)) ? $this->displayName : $display_name;
     }
 
     public function setDisplayName($name)
@@ -179,7 +183,9 @@ class MetaData implements \ArrayAccess
     {
         $this->confirmTranslator();
 
-        return $translated ? $this->__(/** @Ignore */$this->url) : $this->url;
+        $url = $this->__(/** @Ignore */$this->url);
+
+        return $translated ? ((empty($url)) ? $this->$url : $url) : $this->url;
     }
 
     public function setUrl($url)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | https://github.com/zikula-modules/Profile/issues/76
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

Correcting the setting of a module’s translated display name, description, and url.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog