### PR TITLE
submit data as strings

### DIFF
--- a/src/system/CategoriesModule/Tests/Form/Type/CategoriesTypeTest.php
+++ b/src/system/CategoriesModule/Tests/Form/Type/CategoriesTypeTest.php
@@ -106,7 +106,7 @@ class CategoriesTypeTest extends TypeTestCase
     public function testSubmitValidData()
     {
         $formData = [
-            'categoryAssignments' => ['registry_1' => 2],
+            'categoryAssignments' => ['registry_1' => '2'],
         ];
 
         $form = $this->factory->create('Zikula\CategoriesModule\Tests\Fixtures\CategorizableType', new CategorizableEntity(), ['em' => $this->em]);
@@ -134,7 +134,7 @@ class CategoriesTypeTest extends TypeTestCase
     public function testSubmitMultipleValidData()
     {
         $formData = [
-            'categoryAssignments' => ['registry_1' => [2, 3]],
+            'categoryAssignments' => ['registry_1' => ['2', '3']],
         ];
 
         $form = $this->factory->create('Zikula\CategoriesModule\Tests\Fixtures\CategorizableType', new CategorizableEntity(), [
@@ -158,7 +158,7 @@ class CategoriesTypeTest extends TypeTestCase
     public function testSubmitWithExistingData()
     {
         $formData = [
-            'categoryAssignments' => ['registry_1' => 2],
+            'categoryAssignments' => ['registry_1' => '2'],
         ];
         $existingObject = new CategorizableEntity();
         $categoryAssignments = new ArrayCollection();
@@ -191,7 +191,7 @@ class CategoriesTypeTest extends TypeTestCase
     public function testSubmitMultipleWithExistingData()
     {
         $formData = [
-            'categoryAssignments' => ['registry_1' => [2, 3]],
+            'categoryAssignments' => ['registry_1' => ['2', '3']],
         ];
         $existingObject = new CategorizableEntity();
         $categoryAssignments = new ArrayCollection();
@@ -229,7 +229,7 @@ class CategoriesTypeTest extends TypeTestCase
     public function testSubmitSingleWithMultipleExistingData()
     {
         $formData = [
-            'categoryAssignments' => ['registry_1' => 2],
+            'categoryAssignments' => ['registry_1' => '2'],
         ];
         $existingObject = new CategorizableEntity();
         $categoryAssignments = new ArrayCollection();


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | symfony/symfony#21949
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description
Submit strings instead of integers when testing form types.

## Todos
- [X] Tests
- [x] Documentation
- [x] Changelog
