### PR TITLE
modify how bootstrap override paths are used

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -21,9 +21,11 @@ CHANGELOG - ZIKULA 1.5.x
     - All contents of `src/javascript`, `src/style`, and `src/images` are deprecated.
         - Core Assets that will be maintained are copied to `CoreBundle/Resources/public/*`.
     - zikula/jquery-minicolors-bundle (which includes https://github.com/claviska/jquery-minicolors) is deprecated.
-    - metakeywords are deprecated as they are no longer considered 'good practice' for SEO (#3187).
+    - Metakeywords are deprecated as they are no longer considered 'good practice' for SEO (#3187).
     - Gedmo Doctrine extensions should be used by the stof listeners. The old listener names are deprecated.
     - Modernizr javascript library is deprecated and will not be included in Core-2.0.
+    - Deprecate full path for footstrap overrides and use zasset-style notation (#3357).
+        - e.g. @AcmeFooModule:css/mybootstrap.css
 
  - Fixes:
     - Corrected path to legacy module's admin icons.

--- a/src/app/config/config.yml
+++ b/src/app/config/config.yml
@@ -166,8 +166,9 @@ bazinga_js_translation:
     active_locales: "%jms_i18n_routing.locales%"
 
 parameters:
+    # all paths below are resolved as assets (in /web)
     # zikula core stylesheet and javascript component locations
-    zikula.stylesheet.bootstrap-font-awesome.path: web/bootstrap-font-awesome.css
-    zikula.javascript.bootstrap.min.path: web/bootstrap/js/bootstrap.min.js
+    zikula.stylesheet.bootstrap-font-awesome.path: "/bootstrap-font-awesome.css"
+    zikula.javascript.bootstrap.min.path: "/bootstrap/js/bootstrap.min.js"
     # this is needed if an external bootstrap path is used
-    zikula.stylesheet.fontawesome.min.path: web/font-awesome/css/font-awesome.min.css
+    zikula.stylesheet.fontawesome.min.path: "/font-awesome/css/font-awesome.min.css"

--- a/src/docs/Admin/CustomBootstrapCss.md
+++ b/src/docs/Admin/CustomBootstrapCss.md
@@ -7,7 +7,7 @@ Theme
 A **theme** can force the core to use a customized build of Bootstrap css file by setting the 
 `bootstrapPath` parameter value in its `theme.yml` file:
 
-    bootstrapPath: themes/BootstrapTheme/Resources/public/css/cerulean.min.css
+    bootstrapPath: "@ZikulaBootstrapTheme:css/cerulean.min.css"
 
 
 Full Site
@@ -16,10 +16,10 @@ Full Site
 A **site administrator** can force the core to use a customized build of Bootstrap css file by setting a parameter
 value in `app/config/custom_parameters.yml`:
 
-    zikula.stylesheet.bootstrap.min.path: /path/to/my/bootstrap.min.css
+    zikula.stylesheet.bootstrap.min.path: "@AcmeFooModule:css/bootstrap.min.css"
 
 The recommended location is in `/web`
 
-    zikula.stylesheet.bootstrap.min.path: /web/bootstrap.min.css
+    zikula.stylesheet.bootstrap.min.path: "/bootstrap.min.css"
 
 WARNING: setting the value in `custom_parameters.yml` will affect *every* theme on the site.

--- a/src/docs/Core-2.0/Cookbook/CustomizeBoostrap.md
+++ b/src/docs/Core-2.0/Cookbook/CustomizeBoostrap.md
@@ -10,7 +10,7 @@ Changing the look of bootstrap is quite simple.
 * Rename it to your needs (if you want) e.g. `paula.min.js`
 * Copy the file into the css folder of your theme
 * Now you have to make an adjustment within the file `theme.yml`. The line 
-  `bootstrapPath: themes/BootstrapTheme/Resources/public/css/cerulean.min.css` must be adjusted to the path where you
+  `bootstrapPath: "@ZikulaBootstrapTheme:css/cerulean.min.css"` must be adjusted to the path where you
   have placed your new css file.
 * It is wise to store the `config.json` which is delivered within the zip file somewhere in your theme. That makes it
   much easier to update the configuration again later.

--- a/src/docs/Core-2.0/Cookbook/ThemeExample.md
+++ b/src/docs/Core-2.0/Cookbook/ThemeExample.md
@@ -64,7 +64,7 @@ to `@CompanyPaulaTheme`. They are located in `theme/Company/Paula/Resources/view
 * There is a file named `AdminMenu` in the `/Menu` directory. Inside this file you will find the namespace. You have to adjust
   this accordingly: `namespace Company\PaulaTheme\Menu;`
 * at the end you have to adjust the bootstrap css file. It is located inside `config/theme.yml`. Normally it looks 
-like `bootstrapPath: themes/BootstrapTheme/Resources/public/css/cerulean.min.css`. It should get the right path:
-`bootstrapPath: themes/Company/PaulaTheme/Resources/public/css/cerulean.min.css`
+like `bootstrapPath: "@ZikulaBootstrapTheme:css/cerulean.min.css"`. It should get the right path:
+`bootstrapPath: "@CompanyPaulaTheme:css/cerulean.min.css`
 
 Now you should be able to activate your theme.

--- a/src/docs/Core-2.0/Themes/Config.md
+++ b/src/docs/Core-2.0/Themes/Config.md
@@ -24,8 +24,9 @@ Optional Values
 ---------------
 
  - bootstrapPath
-    set a full path from the site root to override the core bootstrap.css
-    - e.g.: `bootstrapPath: themes/BootstrapTheme/Resources/public/css/cerulean.min.css`
+    set a zasset-type path to override the core bootstrap.css - the file is then stored in your Theme's
+    `Resources/public/css/` directory
+    - e.g.: `bootstrapPath: "@ZikulaBootstrapTheme:css/cerulean.min.css"`
  - blockWrapping
     set a boolean value to indicate whether ALL blocks will be wrapped with a unique container `<div>`
      - e.g. `blockWrapping: false`

--- a/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
+++ b/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
@@ -11,11 +11,11 @@
 
 namespace Zikula\ThemeModule\EventListener;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
+use Zikula\ThemeModule\Engine\Asset;
 use Zikula\ThemeModule\Engine\AssetBag;
 use Zikula\ThemeModule\Engine\Engine;
 
@@ -43,11 +43,17 @@ class DefaultPageAssetSetterListener implements EventSubscriberInterface
     private $router;
 
     /**
+     * @var Asset
+     */
+    private $assetHelper;
+
+    /**
      * @var Engine
      */
     private $themeEngine;
 
     /**
+     * @deprecated
      * @var string
      */
     private $rootdir;
@@ -67,36 +73,47 @@ class DefaultPageAssetSetterListener implements EventSubscriberInterface
      * @param AssetBag $jsAssetBag
      * @param AssetBag $cssAssetBag
      * @param RouterInterface $router
+     * @param Asset $assetHelper
      * @param Engine $themeEngine
-     * @param string $rootdir
-     * @param bool $compatLayer
+     * @param string $rootdir @deprecated
+     * @param bool $compatLayer @deprecated
+     * @param string $env
+     * @param bool $installed
+     * @param string $bootstrapJavascriptPath
+     * @param string $bootstrapFontAwesomeStylesheetPath
+     * @param string $fontAwesomePath
+     * @param string $bootstrapStylesheetPath
      */
     public function __construct(
         AssetBag $jsAssetBag,
         AssetBag $cssAssetBag,
         RouterInterface $router,
+        Asset $assetHelper,
         Engine $themeEngine,
         $rootdir,
-        $compatLayer
+        $compatLayer,
+        $env,
+        $installed,
+        $bootstrapJavascriptPath,
+        $bootstrapFontAwesomeStylesheetPath,
+        $fontAwesomePath,
+        $bootstrapStylesheetPath
     ) {
         $this->jsAssetBag = $jsAssetBag;
         $this->cssAssetBag = $cssAssetBag;
         $this->router = $router;
+        $this->assetHelper = $assetHelper;
         $this->themeEngine = $themeEngine;
-        $this->rootdir = $rootdir;
-        $this->compatLayer = $compatLayer;
-    }
-
-    public function setParameters(ContainerInterface $container)
-    {
+        $this->rootdir = $rootdir; // @deprecated
+        $this->compatLayer = $compatLayer; // @deprecated
         $this->params = [
-            'env' => $container->getParameter('env'),
-            'installed' => $container->getParameter('installed'),
-            'zikula.javascript.bootstrap.min.path' => $container->getParameter('zikula.javascript.bootstrap.min.path'),
-            'zikula.stylesheet.bootstrap-font-awesome.path' => $container->getParameter('zikula.stylesheet.bootstrap-font-awesome.path'),
-            'zikula.stylesheet.fontawesome.min.path' => $container->getParameter('zikula.stylesheet.fontawesome.min.path'),
+            'env' => $env,
+            'installed' => $installed,
+            'zikula.javascript.bootstrap.min.path' => $bootstrapJavascriptPath,
+            'zikula.stylesheet.bootstrap-font-awesome.path' => $bootstrapFontAwesomeStylesheetPath,
+            'zikula.stylesheet.fontawesome.min.path' => $fontAwesomePath,
+            'zikula.stylesheet.bootstrap.min.path' => $bootstrapStylesheetPath
         ];
-        $this->params['zikula.stylesheet.bootstrap.min.path'] = $container->hasParameter('zikula.stylesheet.bootstrap.min.path') ? $container->getParameter('zikula.stylesheet.bootstrap.min.path') : '';
     }
 
     /**
@@ -108,32 +125,31 @@ class DefaultPageAssetSetterListener implements EventSubscriberInterface
         if (!$event->isMasterRequest()) {
             return;
         }
-        $basePath = $event->getRequest()->getBasePath();
 
         // add default javascripts to jsAssetBag
-        $this->addJquery($basePath);
+        $this->addJquery();
         $this->jsAssetBag->add(
             [
-                $basePath . '/' . $this->params['zikula.javascript.bootstrap.min.path'] => AssetBag::WEIGHT_BOOTSTRAP_JS,
-                $basePath . '/web/bundles/core/js/bootstrap-zikula.js' => AssetBag::WEIGHT_BOOTSTRAP_ZIKULA,
-                $basePath . '/web/html5shiv/dist/html5shiv.js' => AssetBag::WEIGHT_HTML5SHIV,
+                $this->assetHelper->resolve($this->params['zikula.javascript.bootstrap.min.path']) => AssetBag::WEIGHT_BOOTSTRAP_JS,
+                $this->assetHelper->resolve('/bundles/core/js/bootstrap-zikula.js') => AssetBag::WEIGHT_BOOTSTRAP_ZIKULA,
+                $this->assetHelper->resolve('/html5shiv/dist/html5shiv.js') => AssetBag::WEIGHT_HTML5SHIV,
             ]
         );
-        $this->addFosJsRouting($basePath);
-        $this->addJsTranslation($basePath);
+        $this->addFosJsRouting();
+        $this->addJsTranslation();
 
         // add default stylesheets to cssAssetBag
-        $this->addBootstrapCss($basePath);
+        $this->addBootstrapCss($event->getRequest()->getBasePath()); // @deprecated argument - remove arg only at Core-2.0
         $this->cssAssetBag->add(
             [
-                $basePath . '/web/bundles/core/css/core.css' => 1,
+                $this->assetHelper->resolve('/bundles/core/css/core.css') => 1,
             ]
         );
-        // Add legacy stylesheet
+        // Add legacy stylesheet @deprecated
         if ((is_bool($this->compatLayer) && $this->compatLayer) || (!is_bool($this->compatLayer) && version_compare($this->compatLayer, '1.4.0', '<='))) {
             $this->cssAssetBag->add(
                 [
-                    $basePath . '/style/legacy.css' => 2,
+                    $event->getRequest()->getBasePath() . '/style/legacy.css' => 2,
                 ]
             );
         }
@@ -148,41 +164,44 @@ class DefaultPageAssetSetterListener implements EventSubscriberInterface
         ];
     }
 
-    private function addJquery($basePath)
+    private function addJquery()
     {
         $jquery = $this->params['env'] != 'dev' ? 'jquery.min.js' : 'jquery.js';
-        $this->jsAssetBag->add([$basePath . "/web/jquery/$jquery" => AssetBag::WEIGHT_JQUERY]);
-        $this->jsAssetBag->add([$basePath . '/web/bundles/core/js/jquery_config.js' => AssetBag::WEIGHT_JQUERY + 1]);
+        $this->jsAssetBag->add([$this->assetHelper->resolve("/jquery/$jquery") => AssetBag::WEIGHT_JQUERY]);
+        $this->jsAssetBag->add([$this->assetHelper->resolve('/bundles/core/js/jquery_config.js') => AssetBag::WEIGHT_JQUERY + 1]);
     }
 
-    private function addFosJsRouting($basePath)
+    private function addFosJsRouting()
     {
         if ($this->params['env'] != 'dev' && file_exists(realpath('web/js/fos_js_routes.js'))) {
             $this->jsAssetBag->add([
-                $basePath . '/web/bundles/fosjsrouting/js/router.js' => AssetBag::WEIGHT_ROUTER_JS,
-                $basePath . '/web/js/fos_js_routes.js' => AssetBag::WEIGHT_ROUTES_JS
+                $this->assetHelper->resolve('/bundles/fosjsrouting/js/router.js') => AssetBag::WEIGHT_ROUTER_JS,
+                $this->assetHelper->resolve('/js/fos_js_routes.js') => AssetBag::WEIGHT_ROUTES_JS
             ]);
         } else {
             $routeScript = $this->router->generate('fos_js_routing_js', ['callback' => 'fos.Router.setData']);
             $this->jsAssetBag->add([
-                $basePath . '/web/bundles/fosjsrouting/js/router.js' => AssetBag::WEIGHT_ROUTER_JS,
+                $this->assetHelper->resolve('/bundles/fosjsrouting/js/router.js') => AssetBag::WEIGHT_ROUTER_JS,
                 $routeScript => AssetBag::WEIGHT_ROUTES_JS
             ]);
         }
     }
 
-    private function addJsTranslation($basePath)
+    private function addJsTranslation()
     {
         // @todo consider option of dumping the translations to /web
         // @todo add bundle translations? need domain name e.g. zikulapagesmodule
         $jsScript = $this->router->generate('bazinga_jstranslation_js', ['domain' => 'zikula_javascript'], RouterInterface::ABSOLUTE_URL);
         $this->jsAssetBag->add([
-            $basePath . '/web/bundles/bazingajstranslation/js/translator.min.js' => AssetBag::WEIGHT_JS_TRANSLATOR,
-            $basePath . '/web/bundles/core/js/Zikula.Translator.js' => AssetBag::WEIGHT_ZIKULA_JS_TRANSLATOR,
+            $this->assetHelper->resolve('/bundles/bazingajstranslation/js/translator.min.js') => AssetBag::WEIGHT_JS_TRANSLATOR,
+            $this->assetHelper->resolve('/bundles/core/js/Zikula.Translator.js') => AssetBag::WEIGHT_ZIKULA_JS_TRANSLATOR,
             $jsScript => AssetBag::WEIGHT_JS_TRANSLATIONS,
         ]);
     }
 
+    /**
+     * @param $basePath @deprecated argument - remove arg only at Core-2.0
+     */
     private function addBootstrapCss($basePath)
     {
         $overrideBootstrapPath = '';
@@ -202,18 +221,20 @@ class DefaultPageAssetSetterListener implements EventSubscriberInterface
                 }
             }
         }
-        $path = realpath($this->rootdir . '/../') . "/$overrideBootstrapPath";
-        $overrideBootstrapPath = !empty($overrideBootstrapPath) && is_readable($path) ? $overrideBootstrapPath : '';
+        if ($overrideBootstrapPath[0] == '@') {
+            $overrideBootstrapPath = $this->assetHelper->resolve($overrideBootstrapPath); // throws exception if asset not found
+        } else {
+            // @deprecated method - remove at Core-2.0
+            $path = realpath($this->rootdir . '/../') . "/$overrideBootstrapPath";
+            $overrideBootstrapPath = !empty($overrideBootstrapPath) && is_readable($path) ? "$basePath/$overrideBootstrapPath" : '';
+        }
 
         if (empty($overrideBootstrapPath)) {
-            $bootstrapFontAwesomePath = $this->params['zikula.stylesheet.bootstrap-font-awesome.path'];
-            $this->cssAssetBag->add(["$basePath/$bootstrapFontAwesomePath" => 0]);
-        }
-        if (!empty($overrideBootstrapPath)) {
-            $fontAwesomePath = $this->params['zikula.stylesheet.fontawesome.min.path'];
+            $this->cssAssetBag->add([$this->assetHelper->resolve($this->params['zikula.stylesheet.bootstrap-font-awesome.path']) => 0]);
+        } else {
             $this->cssAssetBag->add([
-                "$basePath/$overrideBootstrapPath" => 0,
-                "$basePath/$fontAwesomePath" => 1,
+                $overrideBootstrapPath => 0,
+                $this->assetHelper->resolve($this->params['zikula.stylesheet.fontawesome.min.path']) => 1,
             ]);
         }
     }

--- a/src/system/ThemeModule/Resources/config/theme_engine_event_listeners.yml
+++ b/src/system/ThemeModule/Resources/config/theme_engine_event_listeners.yml
@@ -12,11 +12,16 @@ services:
           - "@zikula_core.common.theme.assets_js"
           - "@zikula_core.common.theme.assets_css"
           - "@router"
+          - "@zikula_core.common.theme.asset_helper"
           - "@zikula_core.common.theme_engine"
           - "%kernel.root_dir%"
           - "%compat_layer%"
-        calls:
-            - [setParameters, ["@service_container"]]
+          - "%env%"
+          - "%installed%"
+          - "%zikula.javascript.bootstrap.min.path%"
+          - "%zikula.stylesheet.bootstrap-font-awesome.path%"
+          - "%zikula.stylesheet.fontawesome.min.path%"
+          - "@=container.hasParameter('zikula.stylesheet.bootstrap.min.path') ? parameter('zikula.stylesheet.bootstrap.min.path') : ''"
         tags:
             - { name: kernel.event_subscriber }
             - { name: monolog.logger, channel: request }

--- a/src/themes/BootstrapTheme/Resources/config/theme.yml
+++ b/src/themes/BootstrapTheme/Resources/config/theme.yml
@@ -24,5 +24,5 @@ master:
       right: "Block:block.html.twig"
       center: "Block:block.html.twig"
       topnav: "Block:topnavblock.html.twig"
-bootstrapPath: themes/BootstrapTheme/Resources/public/css/cerulean.min.css
+bootstrapPath: "@ZikulaBootstrapTheme:css/cerulean.min.css"
 #blockWrapping: false


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | yes
| Fixed tickets     | -
| Refs tickets      | #3357 
| License           | MIT
| Changelog updated | yes

## Description
modify how bootstrap override paths are used (method is BC with old full path)