### PR TITLE
Fixed pixel display bug in the Bootstrap theme when the admin panel i…

### DIFF
--- a/src/system/AdminModule/Resources/public/css/mmenu-hiddenpanel-customwidth.css
+++ b/src/system/AdminModule/Resources/public/css/mmenu-hiddenpanel-customwidth.css
@@ -1,7 +1,6 @@
 .mm-menu.mm-hiddenpanel-customwidth {
   width: 80%;
-  min-width: 325px;
-  max-width: 325px; }
+  min-width: 325px; }
 
 html.mm-opening.mm-hiddenpanel-customwidth .mm-slideout {
   -webkit-transform: translate(80%, 0);
@@ -10,14 +9,14 @@ html.mm-opening.mm-hiddenpanel-customwidth .mm-slideout {
   -o-transform: translate(80%, 0);
   transform: translate(80%, 0); }
 
-@media all and (max-width: 406.25px) {
+@media all and (max-width: 325px) {
   html.mm-opening.mm-hiddenpanel-customwidth .mm-slideout {
-    -webkit-transform: translate(325px, 0);
+    -webkit-transform: translate(325px, -50px);
     -moz-transform: translate(325px, 0);
     -ms-transform: translate(325px, 0);
     -o-transform: translate(325px, 0);
     transform: translate(325px, 0); } }
-@media all and (min-width: 406.25px) {
+@media all and (min-width: 325px) {
   html.mm-opening.mm-hiddenpanel-customwidth .mm-slideout {
     -webkit-transform: translate(325px, 0);
     -moz-transform: translate(325px, 0);

--- a/src/themes/BootstrapTheme/Resources/public/css/style.css
+++ b/src/themes/BootstrapTheme/Resources/public/css/style.css
@@ -1,3 +1,0 @@
-body {
-    padding-top: 70px;
-}


### PR DESCRIPTION
…s pulled out.

| Q                 | A
| ----------------- | ---
| Bug fix?          | [yes]
| New feature?      | [no]
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | 3449
| Refs tickets      | -
| License           | MIT
| Changelog updated | [yes?]

## Description
Found the css bug that was making the Bootstrap theme display poorly when the Admin Interface was pulled out.
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
