### PR TITLE
Revert #3277

### DIFF
--- a/src/system/ZAuthModule/Controller/AccountController.php
+++ b/src/system/ZAuthModule/Controller/AccountController.php
@@ -53,28 +53,15 @@ class AccountController extends AbstractController
         $form->handleRequest($request);
         if ($form->isSubmitted()) {
             $data = $form->getData();
-
-            $email = $data['email'];
-            $userName = '';
-
-            $mapping = $this->get('zikula_zauth_module.authentication_mapping_repository')->findBy(['email' => $email]);
+            $mapping = $this->get('zikula_zauth_module.authentication_mapping_repository')->findBy(['email' => $data['email']]);
             if (count($mapping) == 1) {
-                $userName = $mapping[0]->getUname();
-            } elseif (count($mapping) < 1) {
-                $user = $this->get('zikula_users_module.user_repository')->findBy(['email' => $email]);
-                if (count($user) == 1) {
-                    $userName = $user[0]->getUname();
-                }
-            }
-
-            if ($userName != '') {
                 // send email
-                $sent = $this->get('zikula_zauth_module.helper.mail_helper')->sendNotification($email, 'lostuname', [
-                    'uname' => $userName,
+                $sent = $this->get('zikula_zauth_module.helper.mail_helper')->sendNotification($mapping[0]->getEmail(), 'lostuname', [
+                    'uname' => $mapping[0]->getUname(),
                     'requestedByAdmin' => false,
                 ]);
                 if ($sent) {
-                    $this->addFlash('status', $this->__f('Done! The account information for %s has been sent via e-mail.', ['%s' => $email]));
+                    $this->addFlash('status', $this->__f('Done! The account information for %s has been sent via e-mail.', ['%s' => $data['email']]));
                 } else {
                     $this->addFlash('error', $this->__('Unable to send email to the requested address. Please contact the system administrator for assistance.'));
                 }
@@ -108,33 +95,20 @@ class AccountController extends AbstractController
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             $redirectToRoute = '';
-            $map = [
-                'uname' => $this->__('username'),
-                'email' => $this->__('email address')
-            ];
+            $map = ['uname' => $this->__('username'), 'email' => $this->__('email address')];
             $data = $form->getData();
             $field = empty($data['uname']) ? 'email' : 'uname';
             $inverse = $field == 'uname' ? 'email' : 'uname';
-
-            $user = null;
-
             $mapping = $this->get('zikula_zauth_module.authentication_mapping_repository')->findBy([$field => $data[$field]]);
             if (count($mapping) == 1) {
-                $user = $this->get('zikula_users_module.user_repository')->find($mapping[0]->getUid());
-            } elseif (count($mapping) < 1) {
-                $users = $this->get('zikula_users_module.user_repository')->findBy([$field => $data[$field]]);
-                if (count($users) == 1) {
-                    $user = $users[0];
-                }
-            }
-
-            if (null !== $user) {
+                $mapping = $mapping[0];
+                $user = $this->get('zikula_users_module.user_repository')->find($mapping->getUid());
                 switch ($user->getActivated()) {
                     case UsersConstant::ACTIVATED_ACTIVE:
                         $changePasswordExpireDays = $this->getVar(ZAuthConstant::MODVAR_EXPIRE_DAYS_CHANGE_PASSWORD, ZAuthConstant::DEFAULT_EXPIRE_DAYS_CHANGE_PASSWORD);
-                        $lostPasswordId = $this->get('zikula_zauth_module.helper.lost_password_verification_helper')->createLostPasswordId($user);
-                        $sent = $this->get('zikula_zauth_module.helper.mail_helper')->sendNotification($user->getEmail(), 'lostpassword', [
-                            'uname' => $user->getUname(),
+                        $lostPasswordId = $this->get('zikula_zauth_module.helper.lost_password_verification_helper')->createLostPasswordId($mapping);
+                        $sent = $this->get('zikula_zauth_module.helper.mail_helper')->sendNotification($mapping->getEmail(), 'lostpassword', [
+                            'uname' => $mapping->getUname(),
                             'validDays' => $changePasswordExpireDays,
                             'lostPasswordId' => $lostPasswordId,
                             'requestedByAdmin' => false,

--- a/src/system/ZAuthModule/Helper/LostPasswordVerificationHelper.php
+++ b/src/system/ZAuthModule/Helper/LostPasswordVerificationHelper.php
@@ -11,9 +11,7 @@
 
 namespace Zikula\ZAuthModule\Helper;
 
-use Zikula\Core\Doctrine\EntityAccess;
 use Zikula\ExtensionsModule\Api\VariableApi;
-use Zikula\UsersModule\Entity\UserEntity;
 use Zikula\ZAuthModule\Api\PasswordApi;
 use Zikula\ZAuthModule\Entity\AuthenticationMappingEntity;
 use Zikula\ZAuthModule\Entity\RepositoryInterface\UserVerificationRepositoryInterface;
@@ -64,25 +62,21 @@ class LostPasswordVerificationHelper
      * Creates an identifier for the lost password link.
      * This link carries the user's id, name and email address as well as the actual confirmation code.
      *
-     * @param EntityAccess $record instance of UserEntity or AuthenticationMappingEntity
+     * @param AuthenticationMappingEntity $mapping
      * @return string The created identifier
      */
-    public function createLostPasswordId(EntityAccess $record)
+    public function createLostPasswordId(AuthenticationMappingEntity $mapping)
     {
-        if (!($record instanceof UserEntity) && !($record instanceof AuthenticationMappingEntity)) {
-            throw new \Exception('Record must be an instance of UserEntity or AuthenticationMappingEntity.');
-        }
-
         $confirmationCode = $this->delimiter;
         while (false !== strpos($confirmationCode, $this->delimiter)) {
             $confirmationCode = $this->passwordApi->generatePassword();
         }
-        $this->userVerificationRepository->setVerificationCode($record->getUid(), ZAuthConstant::VERIFYCHGTYPE_PWD, $this->passwordApi->getHashedPassword($confirmationCode));
+        $this->userVerificationRepository->setVerificationCode($mapping->getUid(), ZAuthConstant::VERIFYCHGTYPE_PWD, $this->passwordApi->getHashedPassword($confirmationCode));
 
         $params = [
-            $record->getUid(),
-            $record->getUname(),
-            $record->getEmail(),
+            $mapping->getUid(),
+            $mapping->getUname(),
+            $mapping->getEmail(),
             $confirmationCode
         ];
 
@@ -100,6 +94,7 @@ class LostPasswordVerificationHelper
      *
      * @param string $identifier
      * @return array The extracted values
+     * @throws \Exception
      */
     public function decodeLostPasswordId($identifier = '')
     {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | #3277, #3536
| License           | MIT
| Changelog updated | no

## Description
revert 'search also for user entities during lost user name and lost password processes, fixed #3274' (reverted from commit c4761dd)

@Guite - opinions? This reverts the BC changes you made (in 1.5) and again requires an authentication mapping for each user.