### PR TITLE
Allowing the .swf extension, since webshim attempts to load a file

### DIFF
--- a/src/web/.htaccess
+++ b/src/web/.htaccess
@@ -13,7 +13,7 @@
     Require all denied
 </IfModule>
 
-<FilesMatch "(?i)\.(css|map|eot|js|jpg|jpeg|gif|png|svg|ttf|woff|woff2)$">
+<FilesMatch "(?i)\.(css|map|eot|js|jpg|jpeg|gif|png|svg|swf|ttf|woff|woff2)$">
     # Apache 2.2
     <IfModule !mod_authz_core.c>
         Order allow,deny


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

Allowing the .swf extension, since webshim attempts to load a file at "/web/webshim/js-webshim/minified/shims/swf/JarisFLVPlayer.swf".

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog