### PR TITLE
ensure that the kernel is initialized

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/Console/Application.php
+++ b/src/lib/Zikula/Bundle/CoreBundle/Console/Application.php
@@ -31,9 +31,9 @@ class Application extends BaseApplication
      */
     public function __construct(ZikulaHttpKernelInterface $kernel)
     {
-        parent::__construct($kernel);
-
         $this->kernel = $kernel;
+
+        parent::__construct($kernel);
 
         $this->setName('Zikula');
         $this->setVersion(ZikulaKernel::VERSION.' - '.$kernel->getName().'/'.$kernel->getEnvironment().($kernel->isDebug() ? '/debug' : ''));


### PR DESCRIPTION
Before delegating to the parent application's constructor make sure to
set the `$kernel` property as the parent class will call the
`registerCommands()` method in its constructor.

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | 
| Refs tickets      | symfony/symfony#23053
| License           | MIT
| Changelog updated | no