### PR TITLE
Remove hardcoded styles in upgrade info

### DIFF
--- a/src/system/AdminModule/Resources/views/AdminInterface/updateCheck.html.twig
+++ b/src/system/AdminModule/Resources/views/AdminInterface/updateCheck.html.twig
@@ -1,5 +1,5 @@
 {% if hasPermission('ZikulaAdminModule::', '::', 'ACCESS_ADMIN') and updateCheckHelper.enabled %}
-    <div id="updatecheck" class="alert" style="background-color: #F7F7F7">
+    <div id="updatecheck" class="alert alert-success">
         <div class="row">
             <div class="col-sm-12">
                 <i class="close" data-dismiss="alert">&times;</i>


### PR DESCRIPTION
This was a bad idea from the beginning to add hard coded styles here. A problem occurs when you want to use a different bootstrap theme.

| Q                 | A
| ----------------- | ---
| Bug fix?          | [yes]
| New feature?      | [no]
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | [no]

## Description
Remove hard coded styles in upgrade info.