### PR TITLE
correct visibility of properties

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -10,6 +10,7 @@ CHANGELOG - ZIKULA 1.5.x
     - Corrected conditional statement for searchable modules (#3752).
     - Corrected path to recent search results in pager (#3654, #3760).
     - Corrected access to category properties on edit (#3763, #3762).
+    - Corrected visibility of properties in \Zikula\Core\Doctrine\Entity\AbstractEntityAttribute (#3765).
 
  - Vendor updates:
     - jquery.mmenu updated from 6.1.3 to 6.1.4

--- a/src/lib/Zikula/Core/Doctrine/Entity/AbstractEntityAttribute.php
+++ b/src/lib/Zikula/Core/Doctrine/Entity/AbstractEntityAttribute.php
@@ -27,19 +27,19 @@ abstract class AbstractEntityAttribute extends EntityAccess
      * @ORM\GeneratedValue
      * @var integer
      */
-    private $id;
+    protected $id;
 
     /**
      * @ORM\Column(type="string", length=255)
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @ORM\Column(type="array")
      * @var string
      */
-    private $value;
+    protected $value;
 
     abstract public function getEntity();
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description
correct visibility of properties 

refs Guite/MostGenerator#1103  

When extending the class, the `id` property was not visible to the subclass, preventing usage, making the resultant child an invalid entity.

/cc @Guite 
