### PR TITLE
do not clear start controller if it is available

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -13,6 +13,7 @@ CHANGELOG - ZIKULA 2.0.x
     - Improved collecting module workflow definitions (#3767).
     - Updated field lengths in HookRuntimeEntity to facilitate longer classnames and serviceIds.
     - Introduce override of `Kernel::getProjectDir()` (#3773).
+    - Do not clear start controller if it is available (#3780, #3782).
 
  - Vendor updates:
     - jquery.mmenu updated from 6.1.3 to 6.1.4


### PR DESCRIPTION
closes #3780

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description
do not clear start controller if it is available