### PR TITLE
notify admin on registration if admin email is not empty. closes #3725

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -15,6 +15,7 @@ CHANGELOG - ZIKULA 1.5.x
     - Updated field lengths in HookRuntimeEntity to facilitate longer classnames and serviceIds.
     - Fixed two category issues with legacy modules (#3775, News#172, News#174).
     - Corrected pdo driver name for pgsql (#3783).
+    - Notify admin on registration if admin email is not empty (#3725).
 
  - Vendor updates:
     - jquery.mmenu updated from 6.1.3 to 6.1.4

--- a/src/system/ZAuthModule/Controller/RegistrationController.php
+++ b/src/system/ZAuthModule/Controller/RegistrationController.php
@@ -98,10 +98,11 @@ class RegistrationController extends AbstractController
             $this->get('zikula_zauth_module.authentication_mapping_repository')->persistAndFlush($mapping);
             $this->get('zikula_users_module.helper.registration_helper')->registerNewUser($userEntity);
             $this->get('zikula_zauth_module.user_verification_repository')->resetVerifyChgFor($userEntity->getUid(), ZAuthConstant::VERIFYCHGTYPE_REGEMAIL);
+            $adminNotificationEmail = $this->get('zikula_extensions_module.api.variable')->get('ZikulaUsersModule', UsersConstant::MODVAR_REGISTRATION_ADMIN_NOTIFICATION_EMAIL, '');
 
             switch ($userEntity->getActivated()) {
                 case UsersConstant::ACTIVATED_PENDING_REG:
-                    $notificationErrors = $this->get('zikula_users_module.helper.mail_helper')->createAndSendRegistrationMail($userEntity, true, false);
+                    $notificationErrors = $this->get('zikula_users_module.helper.mail_helper')->createAndSendRegistrationMail($userEntity, true, !empty($adminNotificationEmail));
                     if (!empty($notificationErrors)) {
                         $this->addFlash('error', implode('<br>', $notificationErrors));
                     }
@@ -112,7 +113,7 @@ class RegistrationController extends AbstractController
                     }
                     break;
                 case UsersConstant::ACTIVATED_ACTIVE:
-                    $notificationErrors = $this->get('zikula_users_module.helper.mail_helper')->createAndSendUserMail($userEntity, true, false);
+                    $notificationErrors = $this->get('zikula_users_module.helper.mail_helper')->createAndSendUserMail($userEntity, true, !empty($adminNotificationEmail));
                     if (!empty($notificationErrors)) {
                         $this->addFlash('error', implode('<br>', $notificationErrors));
                     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #3725
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description
notify admin on registration if admin email is not empty. closes #3725