### PR TITLE
Get correct category by path, using the parent ID.

### DIFF
--- a/src/system/CategoriesModule/Api/CategoryApi.php
+++ b/src/system/CategoriesModule/Api/CategoryApi.php
@@ -229,6 +229,23 @@ class CategoryApi
         $values = [];
         foreach ($apath as $path) {
             $parts = explode('/', $path);
+
+            if ($pathField == 'path') {
+                $parts = array_values(array_filter($parts));
+            
+                if (!empty($parts)) {
+                    $last = count($parts) - 1;
+                
+                    foreach ($parts as $part_key => $part_value) {
+                        if ($part_key == 0) {
+                            $parent = $repo->findOneBy(['name' => $parts[$part_key]])->getID();
+                        } elseif ($part_key != $last) {
+                            $parent = $repo->findOneBy(['name' => $parts[$part_key], 'parent' => $parent])->getID();
+                        }
+                    }
+                }
+            }
+            
             $values[] = array_pop($parts);
         }
         if (count($values) > 1) {
@@ -238,6 +255,9 @@ class CategoryApi
             $values = array_pop($values);
         }
         $criteria = [$fieldMap[$pathField] => $values];
+        if ($pathField == 'path') {
+            $criteria['parent'] = $parent;
+        }
         if (!$includeLeaf) {
             $criteria['is_leaf'] = false;
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | [yes/no]

## Description

When attempting to get a category by path, it is possible that multiple categories exist with the same name (although their parents differ). Therefore, in order to get the correct category by path, then the query must include the parent ID. Without also querying with the parent ID, then you may result in getting the incorrect category by just the non-unique name.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
