### PR TITLE
No attr error

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -7,6 +7,7 @@ CHANGELOG - ZIKULA 1.5.x
     - ?
 
  - Fixes:
+    - Fixed getAttributeValue error in case attribute does not exist.
     - Added missing action icons to admin menu sub entries and admin panel module links.
     - Fixed locale determination in legacy url creation.
     - Fixed locale determination in legacy (Smarty) view class.

--- a/src/system/UsersModule/Entity/UserEntity.php
+++ b/src/system/UsersModule/Entity/UserEntity.php
@@ -490,7 +490,7 @@ class UserEntity extends EntityAccess
 
     public function getAttributeValue($name)
     {
-        return $this->getAttributes()->get($name)->getValue();
+        return $this->getAttributes()->offsetExists($name) ? $this->getAttributes()->get($name)->getValue() : null;
     }
 
     /**

--- a/src/system/UsersModule/Entity/UserEntity.php
+++ b/src/system/UsersModule/Entity/UserEntity.php
@@ -490,7 +490,7 @@ class UserEntity extends EntityAccess
 
     public function getAttributeValue($name)
     {
-        return $this->getAttributes()->offsetExists($name) ? $this->getAttributes()->get($name)->getValue() : null;
+        return $this->getAttributes()->offsetExists($name) ? $this->getAttributes()->get($name)->getValue() : '';
     }
 
     /**


### PR DESCRIPTION
In case of an attribute with a $name does not exist return empty string.

| Q                 | A
| ----------------- | ---
| Bug fix?          | [yes]
| New feature?      | [no]
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | [no]

## Description
Fix error that will occur in case of not existing attr.

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog
