### PR TITLE
Allowing audio files with the .mp3 and .wav extensions to be accessible

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -8,6 +8,7 @@ CHANGELOG - ZIKULA 1.5.x
     - Provide showRegistryLabels option in category selection form type to show a label for each single selector based on the base category assigned in the corresponding registry.
     - Corrected Category API to properly get the category by path (#3852). 
     - Disabled CSRF protection for search results (#3831).
+    - Allowing WAV files (#3858).
 
  - Vendor updates:
     - composer/ca-bundle updated from 1.0.8 to 1.0.9

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -8,7 +8,7 @@ CHANGELOG - ZIKULA 1.5.x
     - Provide showRegistryLabels option in category selection form type to show a label for each single selector based on the base category assigned in the corresponding registry.
     - Corrected Category API to properly get the category by path (#3852). 
     - Disabled CSRF protection for search results (#3831).
-    - Allowing WAV files (#3858).
+    - Allowing audio files with the .mp3 and .wav extensions to be accessible via the modules and themes folders. (#3858).
 
  - Vendor updates:
     - composer/ca-bundle updated from 1.0.8 to 1.0.9

--- a/src/modules/.htaccess
+++ b/src/modules/.htaccess
@@ -13,7 +13,7 @@
     Require all denied
 </IfModule>
 
-<FilesMatch "(?i)\.(css|css\.map|eot|flv|gif|ico|jpeg|jpg|js|map|mp4|ogv|pdf|png|svg|swf|ttf|wav|webm|woff|woff2)$">
+<FilesMatch "(?i)\.(css|css\.map|eot|flv|gif|ico|jpeg|jpg|js|map|mp3|mp4|ogv|pdf|png|svg|swf|ttf|wav|webm|woff|woff2)$">
     # Apache 2.2
     <IfModule !mod_authz_core.c>
         Order allow,deny

--- a/src/modules/.htaccess
+++ b/src/modules/.htaccess
@@ -13,7 +13,7 @@
     Require all denied
 </IfModule>
 
-<FilesMatch "(?i)\.(css|css\.map|eot|flv|gif|ico|jpeg|jpg|js|map|mp4|ogv|pdf|png|svg|swf|ttf|webm|woff|woff2)$">
+<FilesMatch "(?i)\.(css|css\.map|eot|flv|gif|ico|jpeg|jpg|js|map|mp4|ogv|pdf|png|svg|swf|ttf|wav|webm|woff|woff2)$">
     # Apache 2.2
     <IfModule !mod_authz_core.c>
         Order allow,deny

--- a/src/themes/.htaccess
+++ b/src/themes/.htaccess
@@ -13,7 +13,7 @@
     Require all denied
 </IfModule>
 
-<FilesMatch "(?i)\.(css|eot|flv|gif|ico|jpeg|jpg|js|map|mp4|ogv|pdf|png|svg|swf|ttf|webm|woff|woff2)$">
+<FilesMatch "(?i)\.(css|eot|flv|gif|ico|jpeg|jpg|js|map|mp3|mp4|ogv|pdf|png|svg|swf|ttf|wav|webm|woff|woff2)$">
     # Apache 2.2
     <IfModule !mod_authz_core.c>
         Order allow,deny


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description
Allowing audio files with the .mp3 and .wav extensions to be accessible via the modules and themes folders.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
