### PR TITLE
avoid server path exposure in JS asset merger

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -12,6 +12,7 @@ CHANGELOG - ZIKULA 1.5.x
     - Fixed fetching module url from metadata when untranslated (#3876).
     - Activated translatable fallback for proper handling of content with missing translations.
     - Added fallback for missing user real names.
+    - Avoid exposure of server pathes in JS assets merger (#3883).
 
  - Vendor updates:
     - composer/installers updated from 1.4.0 to 1.5.0


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #3883 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes


Successfully tested.