### PR TITLE
added note about password length; strength meter fixes

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -12,8 +12,10 @@ CHANGELOG - ZIKULA 1.5.x
     - Fixed fetching module url from metadata when untranslated (#3876).
     - Activated translatable fallback for proper handling of content with missing translations.
     - Added fallback for missing user real names.
-    - Avoid exposure of server pathes in JS assets merger (#3883).
+    - Avoid exposure of server pathes in JS assets merger (#3883, #3890).
     - Fixed missing routes table in CLI upgrade from 1.3.x (#3887, #3888).
+    - Added hints about minimum password length (#3884, #3891).
+    - Fixed broken password strength meter usage in ZAuth administration (#3891).
 
  - Vendor updates:
     - composer/installers updated from 1.4.0 to 1.5.0

--- a/src/system/ZAuthModule/Controller/AccountController.php
+++ b/src/system/ZAuthModule/Controller/AccountController.php
@@ -373,7 +373,8 @@ class AccountController extends AbstractController
             'login' => $login,
             'authenticationMethod' => $authenticationMethod
         ], [
-            'translator' => $this->get('translator.default')
+            'translator' => $this->get('translator.default'),
+            'minimumPasswordLength' => $this->get('zikula_extensions_module.api.variable')->get('ZikulaZAuthModule', ZAuthConstant::MODVAR_PASSWORD_MINIMUM_LENGTH, ZAuthConstant::DEFAULT_PASSWORD_MINIMUM_LENGTH)
         ]);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/system/ZAuthModule/Controller/UserAdministrationController.php
+++ b/src/system/ZAuthModule/Controller/UserAdministrationController.php
@@ -134,7 +134,10 @@ class UserAdministrationController extends AbstractController
 
         $mapping = new AuthenticationMappingEntity();
         $form = $this->createForm('Zikula\ZAuthModule\Form\Type\AdminCreatedUserType',
-            $mapping, ['translator' => $this->get('translator.default')]
+            $mapping, [
+                'translator' => $this->get('translator.default'),
+                'minimumPasswordLength' => $this->get('zikula_extensions_module.api.variable')->get('ZikulaZAuthModule', ZAuthConstant::MODVAR_PASSWORD_MINIMUM_LENGTH, ZAuthConstant::DEFAULT_PASSWORD_MINIMUM_LENGTH)
+            ]
         );
         $formEvent = new UserFormAwareEvent($form);
         $dispatcher->dispatch(UserEvents::EDIT_FORM, $formEvent);
@@ -222,7 +225,10 @@ class UserAdministrationController extends AbstractController
         $dispatcher = $this->get('event_dispatcher');
 
         $form = $this->createForm('Zikula\ZAuthModule\Form\Type\AdminModifyUserType',
-            $mapping, ['translator' => $this->get('translator.default')]
+            $mapping, [
+                'translator' => $this->get('translator.default'),
+                'minimumPasswordLength' => $this->get('zikula_extensions_module.api.variable')->get('ZikulaZAuthModule', ZAuthConstant::MODVAR_PASSWORD_MINIMUM_LENGTH, ZAuthConstant::DEFAULT_PASSWORD_MINIMUM_LENGTH)
+            ]
         );
         $originalMapping = clone $mapping;
         $formEvent = new UserFormAwareEvent($form);

--- a/src/system/ZAuthModule/Form/Type/AdminCreatedUserType.php
+++ b/src/system/ZAuthModule/Form/Type/AdminCreatedUserType.php
@@ -69,7 +69,8 @@ class AdminCreatedUserType extends AbstractType
                 'type' => PasswordType::class,
                 'first_options' => [
                     'label' => $options['translator']->__('Create new password'),
-                    'input_group' => ['left' => '<i class="fa fa-asterisk"></i>']
+                    'input_group' => ['left' => '<i class="fa fa-asterisk"></i>'],
+                    'help' => $options['translator']->__f('Minimum password length: %amount% characters.', ['%amount%' => $options['minimumPasswordLength']])
                 ],
                 'second_options' => [
                     'label' => $options['translator']->__('Repeat new password'),
@@ -134,6 +135,7 @@ class AdminCreatedUserType extends AbstractType
     {
         $resolver->setDefaults([
             'translator' => null,
+            'minimumPasswordLength' => 5,
             'constraints' => [
                 new ValidUserFields()
             ]

--- a/src/system/ZAuthModule/Form/Type/AdminModifyUserType.php
+++ b/src/system/ZAuthModule/Form/Type/AdminModifyUserType.php
@@ -57,7 +57,8 @@ class AdminModifyUserType extends AbstractType
                 'first_options' => [
                     'required' => false,
                     'label' => $options['translator']->__('Create new password'),
-                    'input_group' => ['left' => '<i class="fa fa-asterisk"></i>']
+                    'input_group' => ['left' => '<i class="fa fa-asterisk"></i>'],
+                    'help' => $options['translator']->__f('Minimum password length: %amount% characters.', ['%amount%' => $options['minimumPasswordLength']])
                 ],
                 'second_options' => [
                     'required' => false,
@@ -97,6 +98,7 @@ class AdminModifyUserType extends AbstractType
     {
         $resolver->setDefaults([
             'translator' => null,
+            'minimumPasswordLength' => 5,
             'constraints' => [
                 new ValidUserFields()
             ]

--- a/src/system/ZAuthModule/Form/Type/ChangePasswordType.php
+++ b/src/system/ZAuthModule/Form/Type/ChangePasswordType.php
@@ -40,7 +40,7 @@ class ChangePasswordType extends AbstractType
             ])
             ->add('pass', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'first_options' => ['label' => $options['translator']->__('New password')],
+                'first_options' => ['label' => $options['translator']->__('New password'), 'help' => $options['translator']->__f('Minimum password length: %amount% characters.', ['%amount%' => $options['minimumPasswordLength']])],
                 'second_options' => ['label' => $options['translator']->__('Repeat new password')],
                 'invalid_message' => $options['translator']->__('The passwords must match!'),
                 'constraints' => [
@@ -76,6 +76,7 @@ class ChangePasswordType extends AbstractType
     {
         $resolver->setDefaults([
             'translator' => null,
+            'minimumPasswordLength' => 5,
             'constraints' => [
                 new ValidPasswordChange()
             ]

--- a/src/system/ZAuthModule/Form/Type/RegistrationType.php
+++ b/src/system/ZAuthModule/Form/Type/RegistrationType.php
@@ -77,7 +77,7 @@ class RegistrationType extends AbstractType
             ])
             ->add('pass', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'first_options' => ['label' => $this->translator->__('Password')],
+                'first_options' => ['label' => $this->translator->__('Password'), 'help' => $this->translator->__f('Minimum password length: %amount% characters.', ['%amount%' => $options['minimumPasswordLength']])],
                 'second_options' => ['label' => $this->translator->__('Repeat Password')],
                 'invalid_message' => $this->translator->__('The passwords must match!'),
                 'constraints' => [
@@ -125,6 +125,7 @@ class RegistrationType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
+            'minimumPasswordLength' => $this->zAuthModVars[ZAuthConstant::MODVAR_PASSWORD_MINIMUM_LENGTH],
             'antiSpamQuestion' => $this->zAuthModVars[ZAuthConstant::MODVAR_REGISTRATION_ANTISPAM_QUESTION]
         ]);
     }

--- a/src/system/ZAuthModule/Resources/views/UserAdministration/create.html.twig
+++ b/src/system/ZAuthModule/Resources/views/UserAdministration/create.html.twig
@@ -99,7 +99,7 @@
     <script type="text/javascript">
         (function($) {
             $(document).ready(function() {
-                ZikulaZAuthPassMeter.init(passFirst.attr('id'), '{{ form.vars.id }}_passmeter', {
+                ZikulaZAuthPassMeter.init('{{ form.pass.vars.id }}_first', '{{ form.vars.id }}_passmeter', {
                     username: '{{ form.uname.vars.id }}',
                     minLength: '{{ getModVar('ZikulaZAuthModule', constant('Zikula\\ZAuthModule\\ZAuthConstant::MODVAR_PASSWORD_MINIMUM_LENGTH')) }}'
                 });

--- a/src/system/ZAuthModule/Resources/views/UserAdministration/modify.html.twig
+++ b/src/system/ZAuthModule/Resources/views/UserAdministration/modify.html.twig
@@ -96,7 +96,7 @@
     <script type="text/javascript">
         (function($) {
             $(document).ready(function() {
-                ZikulaZAuthPassMeter.init(passFirst.attr('id'), '{{ form.vars.id }}_passmeter', {
+                ZikulaZAuthPassMeter.init('{{ form.pass.vars.id }}_first', '{{ form.vars.id }}_passmeter', {
                     username: '{{ form.uname.vars.id }}',
                     minLength: '{{ getModVar('ZikulaZAuthModule', constant('Zikula\\ZAuthModule\\ZAuthConstant::MODVAR_PASSWORD_MINIMUM_LENGTH')) }}'
                 });


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #3884 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description
This PR adds a help text regarding the minimum length to all password input fields (user creation, user modification, new account registration, password change).
Also a problem is fixed which breaks the password strength meter usage in user creation and modification forms in the ZAuth admin area.
