### PR TITLE
Enabled httpOnly for cookies (#2716)

### DIFF
--- a/src/app/config/config.yml
+++ b/src/app/config/config.yml
@@ -29,7 +29,7 @@ framework:
         handler_id: "%zikula.session.handler_id%"
         storage_id: "%zikula.session.storage_id%"
         save_path: "%zikula.session.save_path%"
-        cookie_httponly: false # must be false for ajax tokens to work but increases chance of XSS attack
+        cookie_httponly: true
     fragments:       ~
 
 # Twig Configuration

--- a/src/javascript/helpers/Zikula.js
+++ b/src/javascript/helpers/Zikula.js
@@ -1343,14 +1343,6 @@ Object.extend(Zikula.Ajax.Request,/** @lends Zikula.Ajax.Request.prototype */{
         options = Object.extend({
             method: 'POST'
         }, options || { });
-        if (Zikula.Config.sessionName) {
-            var sessionId = Zikula.Cookie.get(Zikula.Config.sessionName, false);
-            if (sessionId) {
-                options.requestHeaders = Object.extend({
-                    'X-ZIKULA-AJAX-TOKEN': sessionId
-                }, options.requestHeaders || { });
-            }
-        }
         return options;
     }
 });

--- a/src/javascript/zikula/zikula.boot.js
+++ b/src/javascript/zikula/zikula.boot.js
@@ -73,14 +73,6 @@
                 "text json": Zikula.Ajax.Response.convertResponseText
             }
         };
-        if (Zikula.Config.sessionName) {
-            var sessionId = Zikula.Core.getService('cookie').get(Zikula.Config.sessionName, false);
-            if (sessionId) {
-                Zikula.Ajax.defaultOptions.headers = {
-                    'X-ZIKULA-AJAX-TOKEN': sessionId
-                };
-            }
-        }
         $.ajaxSetup(Zikula.Ajax.defaultOptions);
 
         // Use prefilter to extend jQuery request and response object with Zikula.Ajax.Response

--- a/src/javascript/zikula/zikula.min.js
+++ b/src/javascript/zikula/zikula.min.js
@@ -1595,14 +1595,6 @@ if (typeof jQuery !== 'undefined') {
                 "text json": Zikula.Ajax.Response.convertResponseText
             }
         };
-        if (Zikula.Config.sessionName) {
-            var sessionId = Zikula.Services.cookie.get(Zikula.Config.sessionName, false);
-            if (sessionId) {
-                Zikula.Ajax.defaultOptions.headers = {
-                    'X-ZIKULA-AJAX-TOKEN': sessionId
-                };
-            }
-        }
         $.ajaxSetup(Zikula.Ajax.defaultOptions);
 
         // Use prefilter to extend jQuery request and response object with Zikula.Ajax.Response

--- a/src/lib/Zikula/Bundle/CoreBundle/Resources/public/js/jquery_config.js
+++ b/src/lib/Zikula/Bundle/CoreBundle/Resources/public/js/jquery_config.js
@@ -27,13 +27,5 @@ if (typeof Prototype !== 'undefined' && Prototype.BrowserFeatures.ElementExtensi
         type: 'POST',
         timeout: Zikula.Config.ajaxtimeout || 5000
     };
-    if (Zikula.Config.sessionName) {
-        var sessionId = new RegExp(Zikula.Config.sessionName + '=(.*?)(;|$)').exec(document.cookie);
-        if (sessionId && sessionId[1]) {
-            defaultOptions.headers = {
-                'X-ZIKULA-AJAX-TOKEN': sessionId[1]
-            };
-        }
-    }
     $.ajaxSetup(defaultOptions);
 })(jQuery);

--- a/src/lib/Zikula/Bundle/HookBundle/Controller/HookController.php
+++ b/src/lib/Zikula/Bundle/HookBundle/Controller/HookController.php
@@ -452,11 +452,14 @@ class HookController extends Controller
         if (!$currentRequest->isXmlHttpRequest()) {
             throw new \Exception();
         }
-        // @todo how to SET the $_SERVER['HTTP_X_ZIKULA_AJAX_TOKEN'] ?
-        $headerToken = ($currentRequest->server->has('HTTP_X_ZIKULA_AJAX_TOKEN')) ? $currentRequest->server->get('HTTP_X_ZIKULA_AJAX_TOKEN') : null;
-        if ($headerToken == $currentRequest->getSession()->getId()) {
+        
+        $sessionName = $this->container->getParameter('zikula.session.name');
+        $sessionId = $this->getRequest()->cookies->get($sessionName, null);
+        
+        if ($sessionId == $currentRequest->getSession()->getId()) {
             return;
         }
+        
         $this->get('zikula_core.common.csrf_token_handler')->validate($token);
     }
 

--- a/src/lib/legacy/Zikula/Controller/AbstractAjax.php
+++ b/src/lib/legacy/Zikula/Controller/AbstractAjax.php
@@ -40,9 +40,10 @@ abstract class Zikula_Controller_AbstractAjax extends Zikula_AbstractController
     {
         @trigger_error('Old controller is deprecated, please use Symfony instead.', E_USER_DEPRECATED);
 
-        $headerToken = isset($_SERVER['HTTP_X_ZIKULA_AJAX_TOKEN']) ? $_SERVER['HTTP_X_ZIKULA_AJAX_TOKEN'] : null;
-
-        if ($headerToken == session_id()) {
+        $sessionName = $this->serviceManager->getParameter('zikula.session.name');
+        $sessionId = $this->request->cookies->get($sessionName, null);
+        
+        if ($sessionId == session_id()) {
             return;
         }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #2716
| Refs tickets      | #3454
| License           | MIT
| Changelog updated | yes

## Description
Removed legacy code to enable httpOnly setting for cookies

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog
