### PR TITLE
1.5 Fixed wrong translation domain in templates when calling helper functions form external modules

### DIFF
--- a/src/system/ZAuthModule/Helper/MailHelper.php
+++ b/src/system/ZAuthModule/Helper/MailHelper.php
@@ -103,22 +103,22 @@ class MailHelper
         $siteName = $this->variableApi->getSystemVar('sitename');
         switch ($notificationType) {
             case 'importnotify':
-                return $this->translator->__f('Welcome to %s!', ['%s' => $siteName], 'zikula');
+                return $this->translator->__f('Welcome to %s!', ['%s' => $siteName],'zikula');
                  break;
             case 'lostpassword':
-                return $this->translator->__f('Reset your password at \'%s\'', ['%s' => $siteName], 'zikula');
+                return $this->translator->__f('Reset your password at \'%s\'', ['%s' => $siteName],'zikula');
                 break;
             case 'lostuname':
-                return $this->translator->__f('\'%s\' account information', ['%s' => $siteName], 'zikula');
+                return $this->translator->__f('\'%s\' account information', ['%s' => $siteName],'zikula');
                 break;
             case 'regverifyemail':
-                return $this->translator->__f('Verify your e-mail address for %s.', ['%s' => $siteName], 'zikula');
+                return $this->translator->__f('Verify your e-mail address for %s.', ['%s' => $siteName],'zikula');
                 break;
             case 'userverifyemail':
-                return $this->translator->__f('Verify your request to change your e-mail address at \'%s\'', ['%s' => $siteName], 'zikula');
+                return $this->translator->__f('Verify your request to change your e-mail address at \'%s\'', ['%s' => $siteName],'zikula');
                 break;
             default:
-                return $this->translator->__f('A message from %s.', ['%s' => $siteName], 'zikula');
+                return $this->translator->__f('A message from %s.', ['%s' => $siteName],'zikula');
         }
     }
 }

--- a/src/system/ZAuthModule/Helper/MailHelper.php
+++ b/src/system/ZAuthModule/Helper/MailHelper.php
@@ -66,6 +66,8 @@ class MailHelper
     {
         $html = false;
 
+        //Set translation domain to avoid problems when calling sendNotification from external modules
+        $templateArgs['domain'] = 'zikula';
         $templateName = "@ZikulaZAuthModule/Email/{$notificationType}.html.twig";
         try {
             $html = true;

--- a/src/system/ZAuthModule/Helper/MailHelper.php
+++ b/src/system/ZAuthModule/Helper/MailHelper.php
@@ -103,22 +103,22 @@ class MailHelper
         $siteName = $this->variableApi->getSystemVar('sitename');
         switch ($notificationType) {
             case 'importnotify':
-                return $this->translator->__f('Welcome to %s!', ['%s' => $siteName]);
-                break;
+                return $this->translator->__f('Welcome to %s!', ['%s' => $siteName], 'zikula');
+                 break;
             case 'lostpassword':
-                return $this->translator->__f('Reset your password at \'%s\'', ['%s' => $siteName]);
+                return $this->translator->__f('Reset your password at \'%s\'', ['%s' => $siteName], 'zikula');
                 break;
             case 'lostuname':
-                return $this->translator->__f('\'%s\' account information', ['%s' => $siteName]);
+                return $this->translator->__f('\'%s\' account information', ['%s' => $siteName], 'zikula');
                 break;
             case 'regverifyemail':
-                return $this->translator->__f('Verify your e-mail address for %s.', ['%s' => $siteName]);
+                return $this->translator->__f('Verify your e-mail address for %s.', ['%s' => $siteName], 'zikula');
                 break;
             case 'userverifyemail':
-                return $this->translator->__f('Verify your request to change your e-mail address at \'%s\'', ['%s' => $siteName]);
+                return $this->translator->__f('Verify your request to change your e-mail address at \'%s\'', ['%s' => $siteName], 'zikula');
                 break;
             default:
-                return $this->translator->__f('A message from %s.', ['%s' => $siteName]);
+                return $this->translator->__f('A message from %s.', ['%s' => $siteName], 'zikula');
         }
     }
 }

--- a/src/system/ZAuthModule/Helper/MailHelper.php
+++ b/src/system/ZAuthModule/Helper/MailHelper.php
@@ -103,22 +103,22 @@ class MailHelper
         $siteName = $this->variableApi->getSystemVar('sitename');
         switch ($notificationType) {
             case 'importnotify':
-                return $this->translator->__f('Welcome to %s!', ['%s' => $siteName],'zikula');
+                return $this->translator->__f('Welcome to %s!', ['%s' => $siteName], 'zikula');
                  break;
             case 'lostpassword':
-                return $this->translator->__f('Reset your password at \'%s\'', ['%s' => $siteName],'zikula');
+                return $this->translator->__f('Reset your password at \'%s\'', ['%s' => $siteName], 'zikula');
                 break;
             case 'lostuname':
-                return $this->translator->__f('\'%s\' account information', ['%s' => $siteName],'zikula');
+                return $this->translator->__f('\'%s\' account information', ['%s' => $siteName], 'zikula');
                 break;
             case 'regverifyemail':
-                return $this->translator->__f('Verify your e-mail address for %s.', ['%s' => $siteName],'zikula');
+                return $this->translator->__f('Verify your e-mail address for %s.', ['%s' => $siteName], 'zikula');
                 break;
             case 'userverifyemail':
-                return $this->translator->__f('Verify your request to change your e-mail address at \'%s\'', ['%s' => $siteName],'zikula');
+                return $this->translator->__f('Verify your request to change your e-mail address at \'%s\'', ['%s' => $siteName], 'zikula');
                 break;
             default:
-                return $this->translator->__f('A message from %s.', ['%s' => $siteName],'zikula');
+                return $this->translator->__f('A message from %s.', ['%s' => $siteName], 'zikula');
         }
     }
 }

--- a/src/system/ZAuthModule/Helper/MailHelper.php
+++ b/src/system/ZAuthModule/Helper/MailHelper.php
@@ -104,7 +104,7 @@ class MailHelper
         switch ($notificationType) {
             case 'importnotify':
                 return $this->translator->__f('Welcome to %s!', ['%s' => $siteName], 'zikula');
-                 break;
+                break;
             case 'lostpassword':
                 return $this->translator->__f('Reset your password at \'%s\'', ['%s' => $siteName], 'zikula');
                 break;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | [yes/no]

## Description
Fixed wrong translation domain in templates when calling helper functions form external modules

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
