### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6


### PR DESCRIPTION
builds on `php 5.5.` failing. see https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | [yes/no]

## Description
fixes travis build for 5.5