### PR TITLE
Remove dependency on vanputten's fork for BazingaJS

### DIFF
--- a/src/lib/Zikula/Bundle/CoreBundle/composer.json
+++ b/src/lib/Zikula/Bundle/CoreBundle/composer.json
@@ -35,7 +35,7 @@
         "symfony/polyfill-intl-messageformatter": "1.*",
         "php-translation/symfony-bundle": "0.*",
         "nikic/php-parser": "4.*",
-        "willdurand/js-translation-bundle": "4.4.x-dev",
+        "willdurand/js-translation-bundle": "3.*",
 
         "doctrine/orm": "2.*",
         "doctrine/doctrine-bundle": "2.*",
@@ -67,10 +67,6 @@
         {
             "type": "vcs",
             "url": "https://github.com/php-translation/symfony-bundle"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/vanputten/BazingaJsTranslationBundle"
         },
         {
             "type": "vcs",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | [no]
| New feature?      | [no]
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | [no]

## Description
Just a quick PR since you rely on my custom fork for BazingaJs.
My PR (https://github.com/willdurand/BazingaJsTranslationBundle/pull/271) has been merged in master and released in version 3.0.0. As far as I can tell, you should be able to switch to 3.0.0 without a problem. 

Note: I did not run composer update (my machine kept running out of memory somehow). 

## Todos
- [ ] Documentation
- [ ] Changelog
- [ ] Update composer.lock
