### PR TITLE
Fixed paths for adding autoloaders

### DIFF
--- a/src/Zikula/CoreBundle/Helper/PersistedBundleHelper.php
+++ b/src/Zikula/CoreBundle/Helper/PersistedBundleHelper.php
@@ -120,14 +120,15 @@ class PersistedBundleHelper
      */
     public function addAutoloaders(ZikulaHttpKernelInterface $kernel, array $autoload = []): void
     {
+        $srcDir = dirname(dirname(dirname(__DIR__))) . '/';
         if (isset($autoload['psr-0'])) {
             foreach ($autoload['psr-0'] as $prefix => $path) {
-                $kernel->getAutoloader()->add($prefix, $path);
+                $kernel->getAutoloader()->add($prefix, $srcDir . $path);
             }
         }
         if (isset($autoload['psr-4'])) {
             foreach ($autoload['psr-4'] as $prefix => $path) {
-                $kernel->getAutoloader()->addPsr4($prefix, $path);
+                $kernel->getAutoloader()->addPsr4($prefix, $srcDir . $path);
             }
         }
         if (isset($autoload['classmap'])) {

--- a/src/Zikula/CoreBundle/Helper/PersistedBundleHelper.php
+++ b/src/Zikula/CoreBundle/Helper/PersistedBundleHelper.php
@@ -120,7 +120,7 @@ class PersistedBundleHelper
      */
     public function addAutoloaders(ZikulaHttpKernelInterface $kernel, array $autoload = []): void
     {
-        $srcDir = dirname(dirname(dirname(__DIR__))) . '/';
+        $srcDir = $kernel->getProjectDir() . '/src/';
         if (isset($autoload['psr-0'])) {
             foreach ($autoload['psr-0'] as $prefix => $path) {
                 $kernel->getAutoloader()->add($prefix, $srcDir . $path);

--- a/src/system/ExtensionsModule/Helper/BundleSyncHelper.php
+++ b/src/system/ExtensionsModule/Helper/BundleSyncHelper.php
@@ -140,7 +140,7 @@ class BundleSyncHelper
         $newModules = $scanner->getModulesMetaData();
 
         $bundles = [];
-        $srcDir = dirname(dirname(dirname(__DIR__))) . '/';
+        $srcDir = $this->kernel->getProjectDir() . '/src/';
         /** @var MetaData $bundleMetaData */
         foreach ($newModules as $name => $bundleMetaData) {
             foreach ($bundleMetaData->getPsr4() as $ns => $path) {

--- a/src/system/ExtensionsModule/Helper/BundleSyncHelper.php
+++ b/src/system/ExtensionsModule/Helper/BundleSyncHelper.php
@@ -129,15 +129,22 @@ class BundleSyncHelper
         $scanner->setTranslator($this->translator);
         $scanner->scan($directories, 5);
         foreach ($scanner->getInvalid() as $invalidName) {
-            $this->session->getFlashBag()->add('warning', $this->translator->trans('WARNING: %extension% has an invalid composer.json file which could not be decoded.', ['%extension%' => $invalidName]));
+            $this->session->getFlashBag()->add(
+                'warning',
+                $this->translator->trans(
+                    'WARNING: %extension% has an invalid composer.json file which could not be decoded.',
+                    ['%extension%' => $invalidName]
+                )
+            );
         }
         $newModules = $scanner->getModulesMetaData();
 
         $bundles = [];
+        $srcDir = dirname(dirname(dirname(__DIR__))) . '/';
         /** @var MetaData $bundleMetaData */
         foreach ($newModules as $name => $bundleMetaData) {
             foreach ($bundleMetaData->getPsr4() as $ns => $path) {
-                $this->kernel->getAutoloader()->addPsr4($ns, $path);
+                $this->kernel->getAutoloader()->addPsr4($ns, $srcDir . $path);
             }
 
             $bundleClass = $bundleMetaData->getClass();
@@ -159,7 +166,13 @@ class BundleSyncHelper
                     $bundles[$bundle->getName()] = $bundleVersionArray;
                     $bundles[$bundle->getName()]['oldnames'] = $bundleVersionArray['oldnames'] ?? '';
                 } else {
-                    $this->session->getFlashBag()->add('error', $this->translator->trans('Cannot load %extension% because the composer file is invalid.', ['%extension%' => $bundle->getName()]));
+                    $this->session->getFlashBag()->add(
+                        'error',
+                        $this->translator->trans(
+                            'Cannot load %extension% because the composer file is invalid.',
+                            ['%extension%' => $bundle->getName()]
+                        )
+                    );
                     foreach ($this->composerValidationHelper->getErrors() as $error) {
                         $this->session->getFlashBag()->add('error', $error);
                     }

--- a/src/system/ThemeModule/Helper/BundleSyncHelper.php
+++ b/src/system/ThemeModule/Helper/BundleSyncHelper.php
@@ -95,7 +95,7 @@ class BundleSyncHelper
         $scanner->scan([$this->kernel->getProjectDir() . '/src/themes']);
         $newThemes = $scanner->getThemesMetaData();
 
-        $srcDir = dirname(dirname(dirname(__DIR__))) . '/';
+        $srcDir = $this->kernel->getProjectDir() . '/src/';
         /** @var MetaData $themeMetaData */
         foreach ($newThemes as $name => $themeMetaData) {
             foreach ($themeMetaData->getPsr4() as $ns => $path) {

--- a/src/system/ThemeModule/Helper/BundleSyncHelper.php
+++ b/src/system/ThemeModule/Helper/BundleSyncHelper.php
@@ -95,10 +95,11 @@ class BundleSyncHelper
         $scanner->scan([$this->kernel->getProjectDir() . '/src/themes']);
         $newThemes = $scanner->getThemesMetaData();
 
+        $srcDir = dirname(dirname(dirname(__DIR__))) . '/';
         /** @var MetaData $themeMetaData */
         foreach ($newThemes as $name => $themeMetaData) {
             foreach ($themeMetaData->getPsr4() as $ns => $path) {
-                $this->kernel->getAutoloader()->addPsr4($ns, $path);
+                $this->kernel->getAutoloader()->addPsr4($ns, $srcDir . $path);
             }
 
             $bundleClass = $themeMetaData->getClass();
@@ -121,7 +122,13 @@ class BundleSyncHelper
                 if ($this->composerValidationHelper->isValid()) {
                     $bundleThemes[$bundle->getName()] = $themeVersionArray;
                 } else {
-                    $this->session->getFlashBag()->add('error', $this->translator->trans('Cannot load %extension because the composer file is invalid.', ['%extension' => $bundle->getName()]));
+                    $this->session->getFlashBag()->add(
+                        'error',
+                        $this->translator->trans(
+                            'Cannot load %extension because the composer file is invalid.',
+                            ['%extension' => $bundle->getName()]
+                        )
+                    );
                     foreach ($this->composerValidationHelper->getErrors() as $error) {
                         $this->session->getFlashBag()->add('error', $error);
                     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR ensures that PSR4 namespaces are added with the correct path.

Background is that from the class loader's point of view classes are now not in `modules|themes/...` anymore, but `src/(modules|themes)/`.
