### PR TITLE
asset combination fixes

### DIFF
--- a/src/system/ThemeModule/Engine/Asset/Merger.php
+++ b/src/system/ThemeModule/Engine/Asset/Merger.php
@@ -51,12 +51,18 @@ class Merger implements MergerInterface
      */
     private $compress;
 
+    /**
+     * @var string[]
+     */
+    private $skipFiles;
+
     public function __construct(
         RouterInterface $router,
         ZikulaHttpKernelInterface $kernel,
         string $lifetime = '1 day',
         bool $minify = false,
-        bool $compress = false
+        bool $compress = false,
+        array $skipFiles = []
     ) {
         $this->router = $router;
         $this->kernel = $kernel;
@@ -65,6 +71,11 @@ class Merger implements MergerInterface
         $this->lifetime = abs((new DateTime($lifetime))->getTimestamp() - (new DateTime())->getTimestamp());
         $this->minify = $minify;
         $this->compress = $compress;
+
+        $this->skipFiles = [];
+        foreach ($skipFiles as $path) {
+            $this->skipFiles[] = '/public' . $path;
+        }
     }
 
     public function merge(array $assets, $type = 'js'): array
@@ -76,13 +87,21 @@ class Merger implements MergerInterface
         $preCachedFiles = [];
         $cachedFiles = [];
         $outputFiles = [];
-        // skip remote files from combining
+        $postCachedFiles = [];
         foreach ($assets as $asset => $weight) {
             $path = realpath($this->rootDir . $asset);
-            if (false !== $path && is_file($path)) {
+            // skip remote files and specific unwanted ones from combining
+            if (
+                false !== $path
+                && is_file($path)
+                && !in_array($asset, $this->skipFiles)
+                && false === strpos($asset, '/public/bootswatch')
+            ) {
                 $cachedFiles[] = $path;
             } elseif ($weight < 0) {
                 $preCachedFiles[$asset] = $weight;
+            } elseif ($weight > AssetBag::WEIGHT_DEFAULT) {
+                $postCachedFiles[$asset] = $weight;
             } else {
                 $outputFiles[$asset] = $weight;
             }
@@ -115,7 +134,7 @@ class Merger implements MergerInterface
         $route = $this->router->generate('zikulathememodule_combinedasset_asset', ['type' => $type, 'key' => $key]);
         $outputFiles[$route] = AssetBag::WEIGHT_DEFAULT;
 
-        $outputFiles = array_merge($preCachedFiles, $outputFiles);
+        $outputFiles = array_merge($preCachedFiles, $outputFiles, $postCachedFiles);
 
         return $outputFiles;
     }
@@ -139,7 +158,7 @@ class Merger implements MergerInterface
         $relativePath = end($pathParts);
         $contents[] = "/* --- Source file: {$relativePath} */\n\n";
         $inMultilineComment = false;
-        $importsAllowd = true;
+        $importsAllowed = true;
         $wasCommentHack = false;
         while (!feof($source)) {
             if ('css' === $ext) {
@@ -167,7 +186,7 @@ class Merger implements MergerInterface
                             $newLine .= '/*/'; // fix hack comment because we lost some chars with $i += 3
                         }
                         $i++;
-                    } elseif ($importsAllowd && '@' === $char && '@import' === mb_substr($lineParse, $i, 7)) {
+                    } elseif ($importsAllowed && '@' === $char && '@import' === mb_substr($lineParse, $i, 7)) {
                         // an @import starts here
                         $lineParseRest = trim(mb_substr($lineParse, $i + 7));
                         if (0 === mb_stripos($lineParseRest, 'url')) {
@@ -179,19 +198,23 @@ class Merger implements MergerInterface
                                 $start = mb_strpos($lineParseRest, '(') + 1;
                                 $end = mb_strpos($lineParseRest, ')');
                                 $url = mb_substr($lineParseRest, $start, $end - $start);
-                                if (0 === mb_strpos($url, '"') | 0 === mb_strpos($url, "'")) {
+                                if (0 === mb_strpos($url, '"')) {
                                     $url = mb_substr($url, 1, -1);
                                 }
                                 // fix url
-                                $url = dirname($file) . '/' . $url;
-                                if (!$wasCommentHack) {
-                                    // clear buffer
-                                    $contents[] = $newLine;
-                                    $newLine = '';
-                                    // process include
-                                    $this->readFile($contents, $url, $ext);
-                                } else {
+                                if ('http' === mb_substr($url, 0, 4)) {
                                     $newLine .= '@import url("' . $url . '");';
+                                } else {
+                                    $url = dirname($file) . '/' . $url;
+                                    if (!$wasCommentHack) {
+                                        // clear buffer
+                                        $contents[] = $newLine;
+                                        $newLine = '';
+                                        // process include
+                                        $this->readFile($contents, $url, $ext);
+                                    } else {
+                                        $newLine .= '@import url("' . $url . '");';
+                                    }
                                 }
                                 // skip @import statement
                                 $i += $posEnd - $i;
@@ -232,14 +255,14 @@ class Merger implements MergerInterface
                         }
                     } elseif (!$inMultilineComment && ' ' !== $char && "\n" !== $char && "\r\n" !== $char && "\r" !== $char) {
                         // css rule found -> stop processing of @import statements
-                        $importsAllowd = false;
+                        $importsAllowed = false;
                         $newLine .= $char;
                     } else {
                         $newLine .= $char;
                     }
                 }
                 // fix other paths after @import processing
-                if (!$importsAllowd) {
+                if (!$importsAllowed) {
                     $relativePath = str_replace(realpath($this->rootDir), '', $file);
                     $newLine = $this->cssFixPath($newLine, explode('/', dirname($relativePath)));
                 }

--- a/src/system/ThemeModule/Engine/Asset/Merger.php
+++ b/src/system/ThemeModule/Engine/Asset/Merger.php
@@ -268,7 +268,11 @@ class Merger implements MergerInterface
                 }
                 $contents[] = $newLine;
             } else {
-                $contents[] = fgets($source, 4096);
+                $line = fgets($source, 4096);
+                if (false === $line || 0 === mb_strpos($line, '//# sourceMappingURL=')) {
+                    continue;
+                }
+                $contents[] = $line;
             }
         }
         fclose($source);

--- a/src/system/ThemeModule/Engine/Asset/Merger.php
+++ b/src/system/ThemeModule/Engine/Asset/Merger.php
@@ -95,7 +95,7 @@ class Merger implements MergerInterface
                 false !== $path
                 && is_file($path)
                 && !in_array($asset, $this->skipFiles)
-                && false === strpos($asset, '/public/bootswatch')
+                && false === mb_strpos($asset, '/public/bootswatch')
             ) {
                 $cachedFiles[] = $path;
             } elseif ($weight < 0) {

--- a/src/system/ThemeModule/Engine/AssetBag.php
+++ b/src/system/ThemeModule/Engine/AssetBag.php
@@ -46,9 +46,9 @@ class AssetBag implements IteratorAggregate, Countable
 
     public const WEIGHT_JS_TRANSLATOR = 26;
 
-    public const WEIGHT_JS_TRANSLATIONS = 28;
-
     public const WEIGHT_DEFAULT = 100;
+
+    public const WEIGHT_JS_TRANSLATIONS = 110;
 
     public const WEIGHT_THEME_STYLESHEET = 120;
 

--- a/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
+++ b/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
@@ -161,7 +161,7 @@ class DefaultPageAssetSetterListener implements EventSubscriberInterface
         // consider option of dumping the translations to /public
         // add bundle translations? need domain name e.g. zikulapagesmodule
         // #3650
-        $jsScript = $this->router->generate('bazinga_jstranslation_js', ['domain' => 'zikula_javascript'], RouterInterface::ABSOLUTE_URL);
+        $jsScript = $this->router->generate('bazinga_jstranslation_js', ['domain' => 'zikula_javascript']/*, RouterInterface::ABSOLUTE_URL*/);
         $this->jsAssetBag->add([
             $this->assetHelper->resolve('bundles/bazingajstranslation/js/translator.min.js') => AssetBag::WEIGHT_JS_TRANSLATOR,
             $jsScript => AssetBag::WEIGHT_JS_TRANSLATIONS,

--- a/src/system/ThemeModule/Resources/config/services.yaml
+++ b/src/system/ThemeModule/Resources/config/services.yaml
@@ -78,6 +78,12 @@ services:
           $lifetime: '%zikula_asset_manager.lifetime%'
           $minify: '%zikula_asset_manager.minify%'
           $compress: '%zikula_asset_manager.compress%'
+          $skipFiles:
+            - '/jquery/jquery.min.js'
+            - '%zikula.stylesheet.bootstrap.min.path%'
+            - '%zikula.stylesheet.fontawesome.min.path%'
+            - '/mmenu/css/mmenu.css'
+            - '/mmenu/js/mmenu.js'
 
     Zikula\ThemeModule\Engine\Asset\JsResolver:
         arguments:


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #4082 
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR fixes the following problems in asset combination:

- Ensures that `public/translations/zikula_javascript` is loaded after combined JS so that `Translator` object is defined.
- Excludes the following ones:
  - FontAwesome CSS to keep relative pathes to webfonts
  - Bootstrap CSS as some Bootswatch designs reference external fonts
  - jQuery JS which should be loaded first always
  - mmenu (both CSS and JS) which is reluctant to work when being combined
- Fixes a minor problem in CSS import resolver so that `@import("http...")` are kept instead of omitted
- Skips JS source map references (refs 2nd problem in #4082)
