### PR TITLE
clear published assets when extension is upgraded or removed

### DIFF
--- a/src/system/ExtensionsModule/Event/ModuleStateEvent.php
+++ b/src/system/ExtensionsModule/Event/ModuleStateEvent.php
@@ -22,16 +22,16 @@ use Zikula\ExtensionsModule\AbstractModule;
 class ModuleStateEvent extends Event
 {
     /**
+     * @var null|AbstractModule The module instance. Null when Module object is not available
+     */
+    private $module;
+
+    /**
      * An array of info for the module. Possibly a result of calling $extensionEntity->toArray().
      *
      * @var null|array
      */
     private $modInfo;
-
-    /**
-     * @var null|AbstractModule The module instance. Null when Module object is not available
-     */
-    private $module;
 
     public function __construct(AbstractModule $module = null, array $modInfo = null)
     {

--- a/src/system/ThemeModule/Engine/Asset.php
+++ b/src/system/ThemeModule/Engine/Asset.php
@@ -83,8 +83,7 @@ class Asset
      */
     public function resolve(string $path): string
     {
-        $projectDir = $this->kernel->getProjectDir();
-        $publicDir = $projectDir . '/public';
+        $publicDir = $this->kernel->getProjectDir() . '/public';
         $basePath = $this->router->getContext()->getBaseUrl();
         $httpRootDir = str_replace($basePath, '', $publicDir);
 

--- a/src/system/ThemeModule/EventListener/ExtensionInstallationListener.php
+++ b/src/system/ThemeModule/EventListener/ExtensionInstallationListener.php
@@ -20,8 +20,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Zikula\Bundle\CoreBundle\CacheClearer;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
-use Zikula\ExtensionsModule\ExtensionEvents;
 use Zikula\ExtensionsModule\Event\ModuleStateEvent;
+use Zikula\ExtensionsModule\ExtensionEvents;
 
 /**
  * Clear the combined asset cache when a module or theme state is changed

--- a/src/system/ThemeModule/EventListener/ExtensionInstallationListener.php
+++ b/src/system/ThemeModule/EventListener/ExtensionInstallationListener.php
@@ -14,8 +14,14 @@ declare(strict_types=1);
 namespace Zikula\ThemeModule\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Zikula\Bundle\CoreBundle\CacheClearer;
+use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\ExtensionsModule\ExtensionEvents;
+use Zikula\ExtensionsModule\Event\ModuleStateEvent;
 
 /**
  * Clear the combined asset cache when a module or theme state is changed
@@ -23,29 +29,52 @@ use Zikula\ExtensionsModule\ExtensionEvents;
 class ExtensionInstallationListener implements EventSubscriberInterface
 {
     /**
-     * @var bool
+     * @var ZikulaHttpKernelInterface
      */
-    private $mergerActive;
+    private $kernel;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
 
     /**
      * @var CacheClearer
      */
     private $cacheClearer;
 
-    public function __construct(bool $active, CacheClearer $cacheClearer)
-    {
-        $this->mergerActive = $active;
+    /**
+     * @var bool
+     */
+    private $mergerActive;
+
+    public function __construct(
+        ZikulaHttpKernelInterface $kernel,
+        RequestStack $requestStack,
+        TranslatorInterface $translator,
+        CacheClearer $cacheClearer,
+        bool $mergerActive
+    ) {
+        $this->kernel = $kernel;
+        $this->requestStack = $requestStack;
+        $this->translator = $translator;
         $this->cacheClearer = $cacheClearer;
+        $this->mergerActive = $mergerActive;
     }
 
     public static function getSubscribedEvents()
     {
         return [
             ExtensionEvents::MODULE_INSTALL => ['clearCombinedAssetCache'],
-            ExtensionEvents::MODULE_UPGRADE => ['clearCombinedAssetCache'],
+            ExtensionEvents::MODULE_UPGRADE => ['clearPublishedAssets'],
             ExtensionEvents::MODULE_ENABLE => ['clearCombinedAssetCache'],
             ExtensionEvents::MODULE_DISABLE => ['clearCombinedAssetCache'],
-            ExtensionEvents::MODULE_REMOVE => ['clearCombinedAssetCache']
+            ExtensionEvents::MODULE_REMOVE => ['clearPublishedAssets']
         ];
     }
 
@@ -53,6 +82,43 @@ class ExtensionInstallationListener implements EventSubscriberInterface
     {
         if ($this->mergerActive) {
             $this->cacheClearer->clear('assets');
+        }
+    }
+
+    public function clearPublishedAssets(ModuleStateEvent $event): void
+    {
+        $this->clearCombinedAssetCache();
+
+        $extension = $event->getModule();
+        if (null === $extension) {
+            return;
+        }
+
+        $publicDir = realpath($this->kernel->getProjectDir() . '/public');
+        $extensionName = $extension->getName();
+        $assetDirectory = $publicDir . '/' . $extension->getRelativeAssetPath() . '/';
+
+        $fileSystem = new Filesystem();
+        if (!$fileSystem->exists($assetDirectory)) {
+            return;
+        }
+
+        try {
+            $fileSystem->remove($assetDirectory);
+        } catch (IOExceptionInterface $exception) {
+            $request = $this->requestStack->getCurrentRequest();
+            if (null !== $request && $request->hasSession() && $session = $request->getSession()) {
+                $session->getFlashBag()->add(
+                    'warning',
+                    $this->translator->trans(
+                        'The directory %directory% could not be removed. Please remove it manually. Error message: %message%',
+                        [
+                            '%directory%' => $assetDirectory,
+                            '%message%' => $exception->getMessage()
+                        ]
+                    )
+                );
+            }
         }
     }
 }

--- a/src/system/ThemeModule/Resources/config/services.yaml
+++ b/src/system/ThemeModule/Resources/config/services.yaml
@@ -158,4 +158,4 @@ services:
 
     Zikula\ThemeModule\EventListener\ExtensionInstallationListener:
         arguments:
-          $active: '%zikula_asset_manager.combine%'
+          $mergerActive: '%zikula_asset_manager.combine%'

--- a/src/system/UsersModule/Listener/PendingContentListener.php
+++ b/src/system/UsersModule/Listener/PendingContentListener.php
@@ -39,8 +39,11 @@ class PendingContentListener implements EventSubscriberInterface
      */
     private $translator;
 
-    public function __construct(PermissionApiInterface $permissionApi, UserRepositoryInterface $userRepository, TranslatorInterface $translator)
-    {
+    public function __construct(
+        PermissionApiInterface $permissionApi,
+        UserRepositoryInterface $userRepository,
+        TranslatorInterface $translator
+    ) {
         $this->permissionApi = $permissionApi;
         $this->userRepository = $userRepository;
         $this->translator = $translator;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #3273
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR adds a functionality which removes `public/modules/acmefoo` recursively after `AcmeFooModule` has been upgraded or removed.
