### PR TITLE
ability to specify comments and colours for permission rules

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -46,7 +46,7 @@
     - `Zikula\Bundle\HookBundle\HookProviderInterface` has dropped `setServiceId` and `getServiceId` methods.
     - `Zikula\Bundle\HookBundle\Collector\HookCollectorInterface` has changed signature of `addProvider()` and `addSubscriber()` methods.
     - `Zikula\Common\Content\ContentTypeInterface` requires a new method `getBundleName()` to be implemented.
-    - `Zikula\PermissionsModule\Entity\RepositoryInterface\PermissionRepositoryInterface` requires a new method `deleteGroupPermissions` to be implemented.
+    - `Zikula\PermissionsModule\Entity\RepositoryInterface\PermissionRepositoryInterface` requires new methods `getAllColours()` and `deleteGroupPermissions()` to be implemented.
     - `Zikula\ŞearchModule\SearchableInterface` requires a new method `getBundleName()` to be implemented.
     - `Zikula\ŞearchModule\SearchableInterface` has changed signature of `getResults()` method.        
     - `Zikula\UsersModule\MessageModule\MessageModuleInterface` requires a new method `getBundleName()` to be implemented.
@@ -54,7 +54,7 @@
   - `Zikula\BlocksModule\AbstractBlockHandler` is not container aware anymore.
   - Entity changes
     - `Zikula\ExtensionsModule\Entity\ExtensionEntity` has renamed `core_min` to `coreCompatibility` and removed `core_max` property (#3649).
-    - `Zikula\PermissionsModule\Entity\PermissionEntity` removed the `bond` property.
+    - `Zikula\PermissionsModule\Entity\PermissionEntity` removed the `realm` and `bond` properties.
     - `Zikula\ThemeModule\Entity\ThemeEntity` removed the `xhtml` property.
     - `Zikula\SearchModule\Entity\SearchResultEntity` has changed the `extra` field from `text` to `array`. The `setExtra()` method takes care of that though.
   - Removed `Zikula\Core\Response\Ajax\*Response` classes (#3772). Use Symfony's `JsonResponse` with appropriate status codes instead.
@@ -163,6 +163,7 @@
   - Added possibility to specify custom database port in installer.
   - Blocks can now specify default property defaults used for custom form fields (#3676).
   - Added twig-inspector for easy debugging of Twig templates (#4051).
+  - Added new fields for optional comments and colours to permission rules (#914).
 
 - Vendor updates:
   - antishov/doctrine-extensions-bundle updated from 1.2.2 to 1.4.2

--- a/src/system/PermissionsModule/Controller/PermissionController.php
+++ b/src/system/PermissionsModule/Controller/PermissionController.php
@@ -54,13 +54,14 @@ class PermissionController extends AbstractController
         }
         $groups = $groupsRepository->getGroupNamesById();
         $permissions = $permissionRepository->getFilteredPermissions();
-        $components = $permissionRepository->getAllComponents();
-        $components = [$this->trans('All components') => '-1'] + $components;
+        $components = [$this->trans('All components') => '-1'] + $permissionRepository->getAllComponents();
+        $colours = [$this->trans('All colours') => '-1'] + $permissionRepository->getAllColours();
         $permissionLevels = $permissionApi->accessLevelNames();
 
         $filterForm = $this->createForm(FilterListType::class, [], [
             'groupChoices' => $groups,
-            'componentChoices' => $components
+            'componentChoices' => $components,
+            'colourChoices' => $colours
         ]);
         $permissionCheckForm = $this->createForm(PermissionCheckType::class, [], [
             'permissionLevels' => $permissionLevels

--- a/src/system/PermissionsModule/Entity/PermissionEntity.php
+++ b/src/system/PermissionsModule/Entity/PermissionEntity.php
@@ -52,14 +52,6 @@ class PermissionEntity extends EntityAccess
     private $sequence;
 
     /**
-     * the realm assoiciated with this rule
-     *
-     * @ORM\Column(type="integer")
-     * @var int
-     */
-    private $realm;
-
-    /**
      * the component part of the rule
      *
      * @ORM\Column(type="string", length=255)
@@ -85,14 +77,33 @@ class PermissionEntity extends EntityAccess
      */
     private $level;
 
+    /**
+     * optional comment
+     *
+     * @ORM\Column(type="string", length=255)
+     * @Assert\Length(min="0", max="255", allowEmptyString="true")
+     * @var string
+     */
+    private $comment;
+
+    /**
+     * optional colour (Bootstrap contextual class)
+     *
+     * @ORM\Column(type="string", length=10)
+     * @Assert\Length(min="0", max="10", allowEmptyString="true")
+     * @var string
+     */
+    private $colour;
+
     public function __construct()
     {
         $this->gid = 0;
         $this->sequence = 0;
-        $this->realm = 0;
         $this->component = '';
         $this->instance = '';
         $this->level = 0;
+        $this->comment = '';
+        $this->colour = '';
     }
 
     public function getPid(): ?int
@@ -125,16 +136,6 @@ class PermissionEntity extends EntityAccess
         $this->sequence = $sequence;
     }
 
-    public function getRealm(): int
-    {
-        return $this->realm;
-    }
-
-    public function setRealm(int $realm): void
-    {
-        $this->realm = $realm;
-    }
-
     public function getComponent(): string
     {
         return $this->component;
@@ -163,5 +164,25 @@ class PermissionEntity extends EntityAccess
     public function setLevel(int $level): void
     {
         $this->level = $level;
+    }
+
+    public function getComment(): string
+    {
+        return $this->comment;
+    }
+
+    public function setComment(string $comment): void
+    {
+        $this->comment = $comment;
+    }
+
+    public function getColour(): string
+    {
+        return $this->colour;
+    }
+
+    public function setColour(string $colour): void
+    {
+        $this->colour = $colour;
     }
 }

--- a/src/system/PermissionsModule/Entity/Repository/PermissionRepository.php
+++ b/src/system/PermissionsModule/Entity/Repository/PermissionRepository.php
@@ -68,6 +68,18 @@ class PermissionRepository extends ServiceEntityRepository implements Permission
         return $components;
     }
 
+    public function getAllColours(): array
+    {
+        $all = $this->findBy([], ['sequence' => 'ASC']);
+        $colours = [];
+        foreach ($all as $perm) {
+            $colour = $perm->getColour() ?: 'default';
+            $colours[ucfirst($colour)] = $colour;
+        }
+
+        return $colours;
+    }
+
     public function persistAndFlush(PermissionEntity $entity): void
     {
         $this->_em->persist($entity);

--- a/src/system/PermissionsModule/Entity/RepositoryInterface/PermissionRepositoryInterface.php
+++ b/src/system/PermissionsModule/Entity/RepositoryInterface/PermissionRepositoryInterface.php
@@ -27,6 +27,8 @@ interface PermissionRepositoryInterface
 
     public function getAllComponents(): array;
 
+    public function getAllColours(): array;
+
     public function persistAndFlush(PermissionEntity $entity): void;
 
     /**

--- a/src/system/PermissionsModule/Form/Type/FilterListType.php
+++ b/src/system/PermissionsModule/Form/Type/FilterListType.php
@@ -39,11 +39,18 @@ class FilterListType extends AbstractType
                     'class' => 'form-control-sm'
                 ]
             ])
+            ->add('filterColour', ChoiceType::class, [
+                'label' => 'Filter colour',
+                'choices' => /** @Ignore */$options['colourChoices'],
+                'attr' => [
+                    'class' => 'form-control-sm'
+                ]
+            ])
             ->add('reset', ButtonType::class, [
                 'label' => 'Reset',
                 'icon' => 'fa-times',
                 'attr' => [
-                    'class' => 'btn-default btn-sm'
+                    'class' => 'btn-secondary btn-sm'
                 ]
             ])
         ;
@@ -61,7 +68,8 @@ class FilterListType extends AbstractType
                 'class' => 'form-inline'
             ],
             'groupChoices' => [],
-            'componentChoices' => []
+            'componentChoices' => [],
+            'colourChoices' => []
         ]);
     }
 }

--- a/src/system/PermissionsModule/Form/Type/PermissionType.php
+++ b/src/system/PermissionsModule/Form/Type/PermissionType.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Translation\Extractor\Annotation\Ignore;
+use Zikula\Bundle\FormExtensionBundle\Form\DataTransformer\NullToEmptyTransformer;
 use Zikula\PermissionsModule\Entity\PermissionEntity;
 
 class PermissionType extends AbstractType
@@ -43,6 +44,26 @@ class PermissionType extends AbstractType
                 'label' => 'Level',
                 'choices' => /** @Ignore */array_flip($options['permissionLevels'])
             ])
+            ->add($builder->create('comment', TextType::class, [
+                'label' => 'Comment',
+                'required' => false
+            ])->addModelTransformer(new NullToEmptyTransformer()))
+            ->add($builder->create('colour', ChoiceType::class, [
+                'label' => 'Colour',
+                'choices' => [
+                    'Default' => 'default',
+                    'Active' => 'active',
+                    'Primary' => 'primary',
+                    'Secondary' => 'secondary',
+                    'Success' => 'success',
+                    'Danger' => 'danger',
+                    'Warning' => 'warning',
+                    'Info' => 'info',
+                    'Light' => 'light',
+                    'Dark' => 'dark'
+                ],
+                'required' => false
+            ])->addModelTransformer(new NullToEmptyTransformer()))
         ;
     }
 

--- a/src/system/PermissionsModule/Listener/Core3UpgradeListener.php
+++ b/src/system/PermissionsModule/Listener/Core3UpgradeListener.php
@@ -34,8 +34,20 @@ class Core3UpgradeListener implements EventSubscriberInterface
         if (!version_compare($event->getArgument('currentVersion'), '3.0.0', '<')) {
             return;
         }
+        if ($this->columnExists('group_perms', 'realm')) {
+            $sql = 'ALTER TABLE `group_perms` DROP COLUMN `realm`;';
+            $this->conn->executeQuery($sql);
+        }
         if ($this->columnExists('group_perms', 'bond')) {
-            $sql = 'ALTER TABLE `group_perms` DROP COLUMN `bond`';
+            $sql = 'ALTER TABLE `group_perms` DROP COLUMN `bond`;';
+            $this->conn->executeQuery($sql);
+        }
+        if ($this->columnExists('group_perms', 'comment')) {
+            $sql = '
+                ALTER TABLE `group_perms`
+                ADD `comment` VARCHAR(255) NOT NULL AFTER `level`,
+                ADD `colour` VARCHAR(10) NOT NULL AFTER `comment`;;
+            ';
             $this->conn->executeQuery($sql);
         }
     }

--- a/src/system/PermissionsModule/Listener/Core3UpgradeListener.php
+++ b/src/system/PermissionsModule/Listener/Core3UpgradeListener.php
@@ -42,7 +42,7 @@ class Core3UpgradeListener implements EventSubscriberInterface
             $sql = 'ALTER TABLE `group_perms` DROP COLUMN `bond`;';
             $this->conn->executeQuery($sql);
         }
-        if ($this->columnExists('group_perms', 'comment')) {
+        if (!$this->columnExists('group_perms', 'comment')) {
             $sql = '
                 ALTER TABLE `group_perms`
                 ADD `comment` VARCHAR(255) NOT NULL AFTER `level`,

--- a/src/system/PermissionsModule/PermissionsModuleInstaller.php
+++ b/src/system/PermissionsModule/PermissionsModuleInstaller.php
@@ -51,7 +51,6 @@ class PermissionsModuleInstaller extends AbstractExtensionInstaller
                 $record = new PermissionEntity();
                 $record['gid']       = -1;
                 $record['sequence']  = $lastPerm->getSequence();
-                $record['realm']     = 0;
                 $record['component'] = 'ZikulaThemeModule::ThemeChange';
                 $record['instance']  = ':(ZikulaRssTheme|ZikulaPrinterTheme|ZikulaAtomTheme):';
                 $record['level']     = ACCESS_COMMENT; // 300
@@ -88,7 +87,6 @@ class PermissionsModuleInstaller extends AbstractExtensionInstaller
         $record = new PermissionEntity();
         $record['gid']       = 2;
         $record['sequence']  = 1;
-        $record['realm']     = 0;
         $record['component'] = '.*';
         $record['instance']  = '.*';
         $record['level']     = ACCESS_ADMIN; // 800
@@ -98,7 +96,6 @@ class PermissionsModuleInstaller extends AbstractExtensionInstaller
         $record = new PermissionEntity();
         $record['gid']       = -1;
         $record['sequence']  = 2;
-        $record['realm']     = 0;
         $record['component'] = 'ZikulaThemeModule::ThemeChange';
         $record['instance']  = ':(ZikulaRssTheme|ZikulaPrinterTheme|ZikulaAtomTheme):';
         $record['level']     = ACCESS_COMMENT; // 300
@@ -108,7 +105,6 @@ class PermissionsModuleInstaller extends AbstractExtensionInstaller
         $record = new PermissionEntity();
         $record['gid']       = 1;
         $record['sequence']  = 2;
-        $record['realm']     = 0;
         $record['component'] = '.*';
         $record['instance']  = '.*';
         $record['level']     = ACCESS_COMMENT; // 300
@@ -118,7 +114,6 @@ class PermissionsModuleInstaller extends AbstractExtensionInstaller
         $record = new PermissionEntity();
         $record['gid']       = 0;
         $record['sequence']  = 3;
-        $record['realm']     = 0;
         $record['component'] = '.*';
         $record['instance']  = '.*';
         $record['level']     = ACCESS_READ; // 200

--- a/src/system/PermissionsModule/Resources/public/js/Zikula.Permission.Admin.View.js
+++ b/src/system/PermissionsModule/Resources/public/js/Zikula.Permission.Admin.View.js
@@ -8,6 +8,7 @@ var currentDelete;
         $('.create-new-permission').unbind('click').on('click', {action: 'new'}, editPermissionHandler);
         $('.delete-permission').unbind('click').click(startDeletePermission);
         $('.test-permission').unbind('click').click(startTestPermission);
+        $('[data-toggle="tooltip"]').tooltip();
     }
 
     /* --- edit or create permission ---------------------------------------------------------------------------------------------- */
@@ -36,9 +37,9 @@ var currentDelete;
 
     function savePermission() {
         var pid = $('#zikulapermissionsmodule_permission_pid').val();
-        if (pid === '') {
+        if ('' === pid) {
             pid = '-1';
-        } else if (pid === adminpermission && lockadmin === 1) {
+        } else if (pid === adminPermission && 1 === lockAdmin) {
             return;
         }
         // fetch each input and hidden field and store the value to POST
@@ -59,6 +60,13 @@ var currentDelete;
             } else {
                 if (pid !== '-1') {
                     // update existing row
+                    $('#permission-row-' + pid).removeClass().addClass('table-' + (data.permission.colour ? data.permission.colour : 'default'));
+                    $('#permission-row-' + pid)
+                        .attr('title', data.permission.comment)
+                        .attr('data-original-title', data.permission.comment)
+                        .tooltip('update')
+                        .tooltip('show')
+                    ;
                     $('#permission-component-' + pid).text(data.permission.component);
                     $('#permission-instance-' + pid).text(data.permission.instance);
                     $('#permission-group-' + pid).data('id', data.permission.gid);
@@ -123,6 +131,7 @@ var currentDelete;
             ui.children().each(function () {
                 jQuery(this).css({width: jQuery(this).width()});
             });
+
             return ui;
         };
         $sortable.sortable({
@@ -188,9 +197,10 @@ var currentDelete;
         });
 
         /* --- Filter permissions ------------------------------------------------------------------------------------------- */
-        $('#zikulapermissionsmodule_filterlist_filterGroup, #zikulapermissionsmodule_filterlist_filterComponent').change(function () {
+        $('#zikulapermissionsmodule_filterlist_filterGroup, #zikulapermissionsmodule_filterlist_filterComponent, #zikulapermissionsmodule_filterlist_filterColour').change(function () {
             var group = $('#zikulapermissionsmodule_filterlist_filterGroup').val();
             var component = $('#zikulapermissionsmodule_filterlist_filterComponent').val();
+            var colour = $('#zikulapermissionsmodule_filterlist_filterColour').val();
 
             // toggle warnings
             $('#filter-warning-group').toggleClass('d-none', group == '-1');
@@ -206,6 +216,9 @@ var currentDelete;
                 if (component != '-1' && $('#permission-component-' + pid).text().indexOf(component) == -1) {
                     show = false;
                 }
+                if (colour != '-1' && !$('#permission-row-' + pid).hasClass('table-' + colour)) {
+                    show = false;
+                }
                 $this.toggleClass('d-none', !show);
             });
         });
@@ -213,6 +226,7 @@ var currentDelete;
         $('#zikulapermissionsmodule_filterlist_reset').click(function () {
             $('#zikulapermissionsmodule_filterlist_filterComponent').val(-1);
             $('#zikulapermissionsmodule_filterlist_filterGroup').val(-1).trigger('change');
+            $('#zikulapermissionsmodule_filterlist_filterColour').val(-1);
         });
 
         // on modal close, stop all spinning icons

--- a/src/system/PermissionsModule/Resources/views/Permission/list.html.twig
+++ b/src/system/PermissionsModule/Resources/views/Permission/list.html.twig
@@ -1,8 +1,8 @@
 {% set scriptInit %}
     <script>
         // some defines
-        var adminpermission = {{ adminId }};
-        var lockadmin = {{ lockadmin }};
+        var adminPermission = {{ adminId }};
+        var lockAdmin = {{ lockadmin }};
     </script>
 {% endset %}
 {{ pageAddAsset('header', scriptInit) }}
@@ -25,6 +25,7 @@
         <legend class="mb-0">{% trans %}Filter{% endtrans %}</legend>
         {{ form_widget(filterForm.filterGroup) }}
         {{ form_widget(filterForm.filterComponent) }}
+        {{ form_widget(filterForm.filterColour) }}
         {{ form_widget(filterForm.reset) }}
     </fieldset>
     {{ form_end(filterForm) }}

--- a/src/system/PermissionsModule/Resources/views/Permission/permissionTableRow.html.twig
+++ b/src/system/PermissionsModule/Resources/views/Permission/permissionTableRow.html.twig
@@ -1,4 +1,4 @@
-<tr{% if lockadmin and adminId == permission.pid %} class="warning"{% endif %} data-id="{{ permission.pid }}">
+<tr id="permission-row-{{ permission.pid }}" class="table-{% if lockadmin and adminId == permission.pid %}warning locked{% else %}{{ permission.colour|default('default') }}{% endif %}" data-id="{{ permission.pid }}" data-toggle="tooltip" title="{{ permission.comment|default('')|e('html_attr') }}">
     <td headers="hPosition" style="width: 1px; white-space: nowrap">
         {% if lockadmin and adminId == permission.pid %}
             <i class="fas fa-lock" title="{% trans %}This permission rule has been locked. If you need to unlock it, go to the Permission rules manager Settings page.{% endtrans %}"></i>

--- a/src/system/PermissionsModule/Tests/Api/Fixtures/StubPermissionRepository.php
+++ b/src/system/PermissionsModule/Tests/Api/Fixtures/StubPermissionRepository.php
@@ -31,7 +31,6 @@ class StubPermissionRepository implements PermissionRepositoryInterface
             [
                 'gid' => Constant::GROUP_ID_ADMIN, // 2
                 'sequence' => 1,
-                'realm' => 0,
                 'component' => '.*',
                 'instance' => '.*',
                 'level' => ACCESS_ADMIN
@@ -39,7 +38,6 @@ class StubPermissionRepository implements PermissionRepositoryInterface
             [
                 'gid' => PermissionApi::ALL_GROUPS, // -1
                 'sequence' => 2,
-                'realm' => 0,
                 'component' => 'ExtendedMenublock::',
                 'instance' => '1:1:',
                 'level' => ACCESS_NONE
@@ -47,7 +45,6 @@ class StubPermissionRepository implements PermissionRepositoryInterface
             [
                 'gid' => Constant::GROUP_ID_USERS, // 1
                 'sequence' => 3,
-                'realm' => 0,
                 'component' => '.*',
                 'instance' => '.*',
                 'level' => ACCESS_COMMENT
@@ -55,7 +52,6 @@ class StubPermissionRepository implements PermissionRepositoryInterface
             [
                 'gid' => PermissionApi::UNREGISTERED_USER_GROUP, // 0
                 'sequence' => 4,
-                'realm' => 0,
                 'component' => 'ExtendedMenublock::',
                 'instance' => '1:(1|2|3):',
                 'level' => ACCESS_NONE
@@ -63,7 +59,6 @@ class StubPermissionRepository implements PermissionRepositoryInterface
             [
                 'gid' => PermissionApi::UNREGISTERED_USER_GROUP, // 0
                 'sequence' => 5,
-                'realm' => 0,
                 'component' => '.*',
                 'instance' => '.*',
                 'level' => ACCESS_READ

--- a/src/system/PermissionsModule/Tests/Api/Fixtures/StubPermissionRepository.php
+++ b/src/system/PermissionsModule/Tests/Api/Fixtures/StubPermissionRepository.php
@@ -95,6 +95,12 @@ class StubPermissionRepository implements PermissionRepositoryInterface
         return [];
     }
 
+    public function getAllColours(): array
+    {
+        // TODO: Implement getAllColours() method.
+        return [];
+    }
+
     public function persistAndFlush(PermissionEntity $entity): void
     {
         // TODO: Implement persistAndFlush() method.

--- a/src/system/PermissionsModule/Tests/Api/Fixtures/StubPermissionRepository.php
+++ b/src/system/PermissionsModule/Tests/Api/Fixtures/StubPermissionRepository.php
@@ -85,45 +85,41 @@ class StubPermissionRepository implements PermissionRepositoryInterface
 
     public function getFilteredPermissions(int $group = PermissionApi::ALL_GROUPS, string $component = null): array
     {
-        // TODO: Implement getFilteredPermissions() method.
         return [];
     }
 
     public function getAllComponents(): array
     {
-        // TODO: Implement getAllComponents() method.
         return [];
     }
 
     public function getAllColours(): array
     {
-        // TODO: Implement getAllColours() method.
         return [];
     }
 
     public function persistAndFlush(PermissionEntity $entity): void
     {
-        // TODO: Implement persistAndFlush() method.
+        // nothing
     }
 
     public function getMaxSequence(): int
     {
-        // TODO: Implement getMaxSequence() method.
         return 999;
     }
 
     public function updateSequencesFrom(int $value, int $amount = 1): void
     {
-        // TODO: Implement updateSequencesFrom() method.
+        // nothing
     }
 
     public function reSequence(): void
     {
-        // TODO: Implement reSequence() method.
+        // nothing
     }
 
     public function deleteGroupPermissions(int $groupId = 0): void
     {
-        // TODO: Implement deleteGroupPermissions() method.
+        // nothing
     }
 }

--- a/src/system/ThemeModule/EventListener/Core3UpgradeListener.php
+++ b/src/system/ThemeModule/EventListener/Core3UpgradeListener.php
@@ -35,7 +35,7 @@ class Core3UpgradeListener implements EventSubscriberInterface
             return;
         }
         if ($this->columnExists('themes', 'xhtml')) {
-            $sql = 'ALTER TABLE `themes` DROP COLUMN `xhtml`;';
+            $sql = 'ALTER TABLE `themes` DROP COLUMN `xhtml`';
             $this->conn->executeQuery($sql);
         }
     }

--- a/src/system/ThemeModule/EventListener/Core3UpgradeListener.php
+++ b/src/system/ThemeModule/EventListener/Core3UpgradeListener.php
@@ -35,7 +35,7 @@ class Core3UpgradeListener implements EventSubscriberInterface
             return;
         }
         if ($this->columnExists('themes', 'xhtml')) {
-            $sql = 'ALTER TABLE `themes` DROP COLUMN `xhtml`';
+            $sql = 'ALTER TABLE `themes` DROP COLUMN `xhtml`;';
             $this->conn->executeQuery($sql);
         }
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #914 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

This PR introduces two new fields for permission rules:

- an optional comment which is shown as tooltip of the corresponding table row
- an optional colour which corresponds to a Bootstrap context class (info, danger, etc.)

It is also possible to filter by colour in the same way as you can filter by group and/or component.

While the two new fields are added to the permission entity the old `realm` field is removed in the same step.
