### PR TITLE
introduce site definition

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -139,6 +139,7 @@
   - Fixed broken JavaScript in ZAuth user modification form (#3992).
   - Fixed "remember me" problem caused by faulty session regeneration with custom lifetime in PHP 7.2+ (#3898, #4078).
   - When updating a block, orphan properties are removed (#3892).
+  - Refactored page title handling, introducing a new `\Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface` (#3969).
 
 - Features:
   - Utilise autowiring and autoconfiguring functionality from Symfony (#3940).
@@ -164,6 +165,7 @@
   - Blocks can now specify default property defaults used for custom form fields (#3676).
   - Added twig-inspector for easy debugging of Twig templates (#4051).
   - Added new fields for optional comments and colours to permission rules (#914).
+  - Added ability to create dynamic site titles and meta descriptions by subclassing `Zikula\Bundle\CoreBundle\Site\SiteDefinition` (#519).
 
 - Vendor updates:
   - antishov/doctrine-extensions-bundle updated from 1.2.2 to 1.4.2

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -165,7 +165,7 @@
   - Blocks can now specify default property defaults used for custom form fields (#3676).
   - Added twig-inspector for easy debugging of Twig templates (#4051).
   - Added new fields for optional comments and colours to permission rules (#914).
-  - Added ability to create dynamic site titles and meta descriptions by subclassing `Zikula\Bundle\CoreBundle\Site\SiteDefinition` (#519).
+  - Added ability to create dynamic site properties (e.g. titles, meta descriptions etc.) by subclassing `Zikula\Bundle\CoreBundle\Site\SiteDefinition` (#519).
 
 - Vendor updates:
   - antishov/doctrine-extensions-bundle updated from 1.2.2 to 1.4.2

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -44,6 +44,8 @@ services:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
 
+    zikula.site_definition: '@Zikula\Bundle\CoreBundle\Site\SiteDefinition'
+
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     #App\:

--- a/docs/Developer/SiteDefinition.md
+++ b/docs/Developer/SiteDefinition.md
@@ -1,0 +1,33 @@
+# Site Definition
+
+The Core bundle provides a site definition which can be used for adding additional logic for computing site titles, site meta descriptions as well as logos and icon files.
+
+The basic interface for this is defined in `\Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface` as follows:
+
+```php
+interface SiteDefinitionInterface
+{
+    public function getTitle(): string;
+
+    public function getDescription(): string;
+
+    public function getLogoPath(): ?string;
+
+    public function getMobileLogoPath(): ?string;
+
+    public function getIconPath(): ?string;
+}
+```
+
+## How to add custom logic
+
+A default implementation is provided by `\Zikula\Bundle\CoreBundle\Site\SiteDefinition`.
+
+You can subclass this and tell the dependency injection system that it should use your custom subclass whenever the interface is expected.
+
+For this add something like the following to `/config/services_custom.yaml`:
+
+```yaml
+services:
+    zikula.site_definition: '@Acme\FooTheme\Site\AcmeCustomSiteDefinition'
+```

--- a/src/Zikula/CoreBundle/Site/SiteDefinition.php
+++ b/src/Zikula/CoreBundle/Site/SiteDefinition.php
@@ -91,16 +91,16 @@ class SiteDefinition implements SiteDefinitionInterface
 
     public function getLogoPath(): ?string
     {
-        return null;
+        return '@CoreBundle:images/logo_with_title.png';
     }
 
     public function getMobileLogoPath(): ?string
     {
-        return null;
+        return '@CoreBundle:images/zk-power.png';
     }
 
     public function getIconPath(): ?string
     {
-        return null;
+        return '@CoreBundle:images/logo.gif';
     }
 }

--- a/src/Zikula/CoreBundle/Site/SiteDefinition.php
+++ b/src/Zikula/CoreBundle/Site/SiteDefinition.php
@@ -52,12 +52,7 @@ class SiteDefinition implements SiteDefinitionInterface
 
     public function getTitle(): string
     {
-        $pageTitle = $this->variableApi->getSystemVar('defaultpagetitle');
-        if (!is_string($pageTitle)) {
-            return $pageTitle;
-        }
-
-        $title = $pageTitle;
+        $title = $this->variableApi->getSystemVar('defaultpagetitle');
         $titleScheme = $this->variableApi->getSystemVar('pagetitle', '');
         if (!empty($titleScheme) && '%pagetitle%' !== $titleScheme) {
             $title = str_replace(

--- a/src/Zikula/CoreBundle/Site/SiteDefinition.php
+++ b/src/Zikula/CoreBundle/Site/SiteDefinition.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\Bundle\CoreBundle\Site;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Zikula\Bundle\CoreBundle\Translation\TranslatorTrait;
+use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
+use Zikula\ExtensionsModule\Entity\RepositoryInterface\ExtensionRepositoryInterface;
+
+class SiteDefinition implements SiteDefinitionInterface
+{
+    use TranslatorTrait;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var VariableApiInterface
+     */
+    private $variableApi;
+
+    /**
+     * @var ExtensionRepositoryInterface
+     */
+    private $extensionRepository;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        RequestStack $requestStack,
+        VariableApiInterface $variableApi,
+        ExtensionRepositoryInterface $extensionRepository
+    ) {
+        $this->setTranslator($translator);
+        $this->requestStack = $requestStack;
+        $this->variableApi = $variableApi;
+        $this->extensionRepository = $extensionRepository;
+    }
+
+    public function getTitle(): string
+    {
+        $pageTitle = $this->variableApi->getSystemVar('defaultpagetitle');
+        if (!is_string($pageTitle)) {
+            return $pageTitle;
+        }
+
+        $title = $pageTitle;
+        $titleScheme = $this->variableApi->getSystemVar('pagetitle', '');
+        if (!empty($titleScheme) && '%pagetitle%' !== $titleScheme) {
+            $title = str_replace(
+                ['%pagetitle%', '%sitename%'],
+                [$title, $this->variableApi->getSystemVar('sitename', '')],
+                $titleScheme
+            );
+
+            $moduleDisplayName = '';
+            $request = $this->requestStack->getCurrentRequest();
+            if (null !== $request && null !== $request->attributes->get('_controller')) {
+                $controllerNameParts = explode('\\', $request->attributes->get('_controller'));
+                $bundleName = count($controllerNameParts) > 1 ? $controllerNameParts[0] . $controllerNameParts[1] : '';
+                if ('Module' === mb_substr($bundleName, -6)) {
+                    $module = $this->extensionRepository->get($bundleName);
+                    if (null !== $module) {
+                        $moduleDisplayName = $module->getDisplayName();
+                    }
+                }
+            }
+            $title = str_replace('%modulename%', $moduleDisplayName, $title);
+        }
+
+        return $title;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->variableApi->getSystemVar('defaultmetadescription');
+    }
+
+    public function getLogoPath(): ?string
+    {
+        return null;
+    }
+
+    public function getMobileLogoPath(): ?string
+    {
+        return null;
+    }
+
+    public function getIconPath(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Zikula/CoreBundle/Site/SiteDefinitionInterface.php
+++ b/src/Zikula/CoreBundle/Site/SiteDefinitionInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\Bundle\CoreBundle\Site;
+
+interface SiteDefinitionInterface
+{
+    public function getTitle(): string;
+
+    public function getDescription(): string;
+
+    public function getLogoPath(): ?string;
+
+    public function getMobileLogoPath(): ?string;
+
+    public function getIconPath(): ?string;
+}

--- a/src/system/ThemeModule/EventListener/DefaultPageVarSetterListener.php
+++ b/src/system/ThemeModule/EventListener/DefaultPageVarSetterListener.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaKernel;
-use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\ThemeModule\Engine\ParameterBag;
 
 /**
@@ -27,6 +27,11 @@ use Zikula\ThemeModule\Engine\ParameterBag;
  */
 class DefaultPageVarSetterListener implements EventSubscriberInterface
 {
+    /**
+     * @var SiteDefinitionInterface
+     */
+    private $site;
+
     /**
      * @var ParameterBag
      */
@@ -36,11 +41,6 @@ class DefaultPageVarSetterListener implements EventSubscriberInterface
      * @var RouterInterface
      */
     private $router;
-
-    /**
-     * @var VariableApiInterface
-     */
-    private $variableApi;
 
     /**
      * @var ZikulaHttpKernelInterface
@@ -53,15 +53,15 @@ class DefaultPageVarSetterListener implements EventSubscriberInterface
     private $installed;
 
     public function __construct(
+        SiteDefinitionInterface $site,
         ParameterBag $pageVars,
         RouterInterface $routerInterface,
-        VariableApiInterface $variableApi,
         ZikulaHttpKernelInterface $kernel,
         bool $installed
     ) {
+        $this->site = $site;
         $this->pageVars = $pageVars;
         $this->router = $routerInterface;
-        $this->variableApi = $variableApi;
         $this->kernel = $kernel;
         $this->installed = $installed;
     }
@@ -88,9 +88,9 @@ class DefaultPageVarSetterListener implements EventSubscriberInterface
         }
 
         // set some defaults
-        $this->pageVars->set('title', $this->variableApi->getSystemVar('defaultpagetitle'));
+        $this->pageVars->set('title', $this->site->getTitle());
         $this->pageVars->set('meta.charset', $this->kernel->getCharset());
-        $this->pageVars->set('meta.description', $this->variableApi->getSystemVar('defaultmetadescription'));
+        $this->pageVars->set('meta.description', $this->site->getDescription());
         $this->pageVars->set('homepath', $this->router->generate('home'));
         $this->pageVars->set('coredata', [
             'version' => ZikulaKernel::VERSION,

--- a/src/system/ThemeModule/Resources/config/services.yaml
+++ b/src/system/ThemeModule/Resources/config/services.yaml
@@ -6,6 +6,7 @@ services:
         bind:
             $bundle: '@Zikula\ThemeModule\ZikulaThemeModule'
             $installed: '%installed%'
+            Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface: '@zikula.site_definition'
 
     Zikula\ThemeModule\:
         resource: '../../*'

--- a/src/system/ThemeModule/Tests/Engine/ParameterBagTest.php
+++ b/src/system/ThemeModule/Tests/Engine/ParameterBagTest.php
@@ -14,9 +14,6 @@ declare(strict_types=1);
 namespace Zikula\ThemeModule\Tests\Engine;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
-use Zikula\ExtensionsModule\Entity\RepositoryInterface\ExtensionRepositoryInterface;
 use Zikula\ThemeModule\Engine\ParameterBag;
 
 class ParameterBagTest extends TestCase
@@ -28,23 +25,7 @@ class ParameterBagTest extends TestCase
 
     protected function setUp(): void
     {
-        $requestStack = $this
-            ->getMockBuilder(RequestStack::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-        $variableApi = $this
-            ->getMockBuilder(VariableApiInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-        $extensionRepository = $this
-            ->getMockBuilder(ExtensionRepositoryInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $this->bag = new ParameterBag($requestStack, $variableApi, $extensionRepository, ['foo' => 10]);
+        $this->bag = new ParameterBag(['foo' => 10]);
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #3969, #519 
| Refs tickets      | #3972
| License           | MIT
| Changelog updated | yes

## Description

This PR introduces a `SiteDefinitionInterface` together with a default implementation (`SiteDefinition`) to encapsulate site specific properties.

It makes the theme engine's `ParameterBag` clean again (fixes #3969), allows for subclassing in order to use additional logic for dynamical determination of site properties (fixes #519) and lays the foundation for branding support (refs #3972).
