### PR TITLE
fixes for creating ZAuth users without setting password

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -139,6 +139,8 @@
   - Fixed broken JavaScript in ZAuth user modification form (#3992).
   - Fixed "remember me" problem caused by faulty session regeneration with custom lifetime in PHP 7.2+ (#3898, #4078).
   - When updating a block, orphan properties are removed (#3892).
+  - Refactored page title handling, introducing a new `\Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface` (#3969).
+  - Fixed creating new ZAuth users as admin without setting a password.
 
 - Features:
   - Utilise autowiring and autoconfiguring functionality from Symfony (#3940).
@@ -164,6 +166,7 @@
   - Blocks can now specify default property defaults used for custom form fields (#3676).
   - Added twig-inspector for easy debugging of Twig templates (#4051).
   - Added new fields for optional comments and colours to permission rules (#914).
+  - Added ability to create dynamic site properties (e.g. titles, meta descriptions etc.) by subclassing `Zikula\Bundle\CoreBundle\Site\SiteDefinition` (#519).
 
 - Vendor updates:
   - antishov/doctrine-extensions-bundle updated from 1.2.2 to 1.4.2

--- a/src/system/ZAuthModule/AuthenticationMethod/AbstractNativeAuthenticationMethod.php
+++ b/src/system/ZAuthModule/AuthenticationMethod/AbstractNativeAuthenticationMethod.php
@@ -90,6 +90,10 @@ abstract class AbstractNativeAuthenticationMethod implements NonReEntrantAuthent
         }
 
         $mapping = $this->getMapping($field, $data[$field]);
+        if (!$mapping->getPass()) {
+            return null;
+        }
+
         if ($mapping && $this->passwordApi->passwordsMatch($data['pass'], $mapping->getPass())) {
             // is this the place to update the hash method? #2842
             return $mapping->getUid();

--- a/src/system/ZAuthModule/Entity/Repository/UserVerificationRepository.php
+++ b/src/system/ZAuthModule/Entity/Repository/UserVerificationRepository.php
@@ -131,7 +131,7 @@ class UserVerificationRepository extends ServiceEntityRepository implements User
         if (empty($hashedConfirmationCode)) {
             throw new InvalidArgumentException();
         }
-        $nowUTC = new DateTime(null, new DateTimeZone('UTC'));
+        $nowUTC = new DateTime('now', new DateTimeZone('UTC'));
 
         $query = $this->createQueryBuilder('v')
             ->delete()

--- a/src/system/ZAuthModule/Form/Type/AdminCreatedUserType.php
+++ b/src/system/ZAuthModule/Form/Type/AdminCreatedUserType.php
@@ -82,6 +82,7 @@ class AdminCreatedUserType extends AbstractType
             ->add('pass', RepeatedType::class, [
                 'type' => PasswordType::class,
                 'first_options' => [
+                    'required' => false,
                     'label' => 'Create new password',
                     'input_group' => ['left' => '<i class="fas fa-asterisk"></i>'],
                     'help' => 'Minimum password length: %amount% characters.',
@@ -90,6 +91,7 @@ class AdminCreatedUserType extends AbstractType
                     ]
                 ],
                 'second_options' => [
+                    'required' => false,
                     'label' => 'Repeat new password',
                     'input_group' => ['left' => '<i class="fas fa-asterisk"></i>']
                 ],

--- a/src/system/ZAuthModule/Resources/views/UserAdministration/create.html.twig
+++ b/src/system/ZAuthModule/Resources/views/UserAdministration/create.html.twig
@@ -66,6 +66,8 @@
                 passSecond.parents('.form-group').find('label').removeClass('required');
             };
             setPassAlert.addClass('collapse show');
+            showPasswordsOptional();
+
             // ensure wrap is shown on form re-draw
             if (setPassEle.is(':checked')) {
                 setPassWrap.collapse('show');

--- a/src/system/ZAuthModule/Validator/Constraints/ValidPasswordValidator.php
+++ b/src/system/ZAuthModule/Validator/Constraints/ValidPasswordValidator.php
@@ -42,6 +42,11 @@ class ValidPasswordValidator extends ConstraintValidator
 
     public function validate($value, Constraint $constraint)
     {
+        if (!$value) {
+            // user created without password
+            // needs to set one during verification
+            return;
+        }
         /** @var ConstraintViolationListInterface $errors */
         $errors = $this->validator->validate($value, [
             new Type('string'),


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

This PR adds several small fixes to make it possible (again?) to create new ZAuth users as admin without setting an initial password.
