### PR TITLE
composer cleanup; moved icon out of capabilities, fixed #4116

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -116,8 +116,8 @@
     - Default translation domain is now always `messages`. Use specific other domains (e.g. `mail`, `config`, `hooks` etc.) where appropriate.
   - Replaced `LinkContainer` with `ExtensionMenu` for collecting module menus (admin, user, account). See companion docs.
   - Changes to `composer.json`
-    - Removed use of `admin.png` and replaced by adding icon class >> `extra/zikula/capabilities/admin/icon: "fas fa-user"`.
-      - Themes can now also include an icon path.
+    - Removed use of `admin.png` and replaced by adding icon class >> `extra/zikula/icon: "fas fa-user"`.
+      - Themes now also need to include an icon.
     - Setting >> `extra/zikula/capabilities/admin/url` is no longer supported. Use `extra/zikula/capabilities/admin/route`.
     - Change how themes define user and admin capabilities.
       - old: e.g. `capabilities/admin:true`

--- a/composer.lock
+++ b/composer.lock
@@ -6781,16 +6781,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zikula-modules/Legal.git",
-                "reference": "108bb77796ab0bc35fe4aff8136672a16efa1cac"
+                "reference": "35cf93e93e5d0add06d15e2288622cb93784ab46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zikula-modules/Legal/zipball/108bb77796ab0bc35fe4aff8136672a16efa1cac",
-                "reference": "108bb77796ab0bc35fe4aff8136672a16efa1cac",
+                "url": "https://api.github.com/repos/zikula-modules/Legal/zipball/35cf93e93e5d0add06d15e2288622cb93784ab46",
+                "reference": "35cf93e93e5d0add06d15e2288622cb93784ab46",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.2.5"
             },
             "type": "zikula-module",
             "extra": {
@@ -6802,10 +6802,10 @@
                     "oldnames": [
                         "Legal"
                     ],
+                    "icon": "fas fa-gavel",
                     "capabilities": {
                         "admin": {
-                            "route": "zikulalegalmodule_config_config",
-                            "icon": "fas fa-gavel"
+                            "route": "zikulalegalmodule_config_config"
                         },
                         "user": {
                             "route": "zikulalegalmodule_user_termsofuse"
@@ -6839,7 +6839,7 @@
                 }
             ],
             "description": "Provides an interface for managing the site's legal documents.",
-            "time": "2020-02-19T07:11:04+00:00"
+            "time": "2020-02-22T14:38:39+00:00"
         },
         {
             "name": "zikula/oauth-module",
@@ -6847,12 +6847,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zikula/OAuth.git",
-                "reference": "9bc1ab469b178e1dfde906f6ac7c27cb32a83ce2"
+                "reference": "1e2a0e7204983259d433a9f20b3a0b415d56a16b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zikula/OAuth/zipball/9bc1ab469b178e1dfde906f6ac7c27cb32a83ce2",
-                "reference": "9bc1ab469b178e1dfde906f6ac7c27cb32a83ce2",
+                "url": "https://api.github.com/repos/zikula/OAuth/zipball/1e2a0e7204983259d433a9f20b3a0b415d56a16b",
+                "reference": "1e2a0e7204983259d433a9f20b3a0b415d56a16b",
                 "shasum": ""
             },
             "require": {
@@ -6861,7 +6861,7 @@
                 "league/oauth2-google": "3.*",
                 "league/oauth2-instagram": "2.*",
                 "league/oauth2-linkedin": "4.*",
-                "php": ">=7.2.0"
+                "php": ">=7.2.5"
             },
             "type": "zikula-module",
             "extra": {
@@ -6869,14 +6869,13 @@
                     "core-compatibility": ">=3.0.0",
                     "class": "Zikula\\OAuthModule\\ZikulaOAuthModule",
                     "displayname": "OAuthModule",
+                    "url": "oauth",
+                    "icon": "fas fa-network-wired",
                     "capabilities": {
                         "admin": {
-                            "route": "zikulaoauthmodule_config_settings",
-                            "icon": "fas fa-network-wired"
+                            "route": "zikulaoauthmodule_config_settings"
                         }
                     },
-                    "url": "oauth",
-                    "oldnames": [],
                     "securityschema": {
                         "ZikulaOAuthModule::": "::"
                     }
@@ -6898,7 +6897,7 @@
                 }
             ],
             "description": "Integrates league/oauth2-client and various providers.",
-            "time": "2020-02-19T07:11:59+00:00"
+            "time": "2020-02-22T14:37:39+00:00"
         },
         {
             "name": "zikula/pagelock-module",
@@ -6906,12 +6905,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zikula-modules/PageLock.git",
-                "reference": "3d17aa1cdd822561b9c41822eacdea59728efaab"
+                "reference": "72b6d33b8c554e671940b9ec9588849e4245ff1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zikula-modules/PageLock/zipball/3d17aa1cdd822561b9c41822eacdea59728efaab",
-                "reference": "3d17aa1cdd822561b9c41822eacdea59728efaab",
+                "url": "https://api.github.com/repos/zikula-modules/PageLock/zipball/72b6d33b8c554e671940b9ec9588849e4245ff1f",
+                "reference": "72b6d33b8c554e671940b9ec9588849e4245ff1f",
                 "shasum": ""
             },
             "require": {
@@ -6924,11 +6923,8 @@
                     "core-compatibility": ">=3.0.0",
                     "displayname": "Page lock",
                     "url": "pagelock",
-                    "capabilities": {
-                        "admin": {
-                            "icon": "fas fa-lock"
-                        }
-                    },
+                    "icon": "fas fa-lock",
+                    "capabilities": [],
                     "securityschema": {
                         "ZikulaPageLockModule::": "::"
                     }
@@ -6950,7 +6946,7 @@
                 }
             ],
             "description": "Page locking support",
-            "time": "2020-02-19T07:14:59+00:00"
+            "time": "2020-02-22T14:38:06+00:00"
         },
         {
             "name": "zikula/profile-module",
@@ -6958,16 +6954,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zikula-modules/Profile.git",
-                "reference": "394cafeab738fc651bfd00dcc2621c2337170245"
+                "reference": "3219764cdde05ee1641641626698aa93b29c8339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zikula-modules/Profile/zipball/394cafeab738fc651bfd00dcc2621c2337170245",
-                "reference": "394cafeab738fc651bfd00dcc2621c2337170245",
+                "url": "https://api.github.com/repos/zikula-modules/Profile/zipball/3219764cdde05ee1641641626698aa93b29c8339",
+                "reference": "3219764cdde05ee1641641626698aa93b29c8339",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.2.5"
             },
             "type": "zikula-module",
             "extra": {
@@ -6979,10 +6975,10 @@
                     "oldnames": [
                         "Profile"
                     ],
+                    "icon": "fas fa-id-card",
                     "capabilities": {
                         "admin": {
-                            "route": "zikulaprofilemodule_property_list",
-                            "icon": "fas fa-id-card"
+                            "route": "zikulaprofilemodule_property_list"
                         },
                         "user": {
                             "route": "zikulaprofilemodule_profile_display"
@@ -7019,7 +7015,7 @@
                 }
             ],
             "description": "User profiles and member list",
-            "time": "2020-02-21T11:08:15+00:00"
+            "time": "2020-02-22T14:38:24+00:00"
         },
         {
             "name": "zikula/sortable-columns",

--- a/src/Zikula/CoreBundle/Composer/MetaData.php
+++ b/src/Zikula/CoreBundle/Composer/MetaData.php
@@ -65,6 +65,8 @@ class MetaData implements ArrayAccess
 
     private $oldNames;
 
+    private $icon;
+
     private $capabilities;
 
     private $securitySchema;

--- a/src/Zikula/CoreBundle/Composer/MetaData.php
+++ b/src/Zikula/CoreBundle/Composer/MetaData.php
@@ -87,6 +87,7 @@ class MetaData implements ArrayAccess
         $this->displayName = $json['extra']['zikula']['displayname'] ?? '';
         $this->url = $json['extra']['zikula']['url'] ?? '';
         $this->oldNames = $json['extra']['zikula']['oldnames'] ?? [];
+        $this->icon = $json['extra']['zikula']['icon'] ?? '';
         $this->capabilities = $json['extra']['zikula']['capabilities'] ?? [];
         $this->securitySchema = $json['extra']['zikula']['securityschema'] ?? [];
         $this->extensionType = $json['extensionType'] ?? self::TYPE_MODULE;
@@ -191,6 +192,16 @@ class MetaData implements ArrayAccess
     public function getOldNames(): array
     {
         return $this->oldNames;
+    }
+
+    public function getIcon(): string
+    {
+        return $this->icon;
+    }
+
+    public function setIcon(string $icon): void
+    {
+        $this->icon = $icon;
     }
 
     public function getCapabilities(): array

--- a/src/Zikula/FormExtensionBundle/composer.json
+++ b/src/Zikula/FormExtensionBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.2.5",
         "symfony/framework-bundle": "5.*"
     },
     "autoload": {

--- a/src/Zikula/HookBundle/composer.json
+++ b/src/Zikula/HookBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.2.5",
         "symfony/framework-bundle": "5.*"
     },
     "autoload": {

--- a/src/Zikula/WorkflowBundle/composer.json
+++ b/src/Zikula/WorkflowBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "autoload": {
         "psr-4": { "Zikula\\Bundle\\WorkflowBundle\\": "" }

--- a/src/system/AdminModule/composer.json
+++ b/src/system/AdminModule/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Zikula\\AdminModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.2.5",
         "mmenu.js": "8.*"
     },
     "repositories": [
@@ -29,10 +29,10 @@
             "core-compatibility": ">=3.0.0",
             "displayname": "Administration panel",
             "url": "adminpanel",
+            "icon": "fas fa-object-group",
             "capabilities": {
                 "admin": {
-                    "route": "zikulaadminmodule_admin_view",
-                    "icon": "fas fa-object-group"
+                    "route": "zikulaadminmodule_admin_view"
                 }
             },
             "securityschema": {

--- a/src/system/AtomTheme/composer.json
+++ b/src/system/AtomTheme/composer.json
@@ -14,20 +14,20 @@
         "psr-4": { "Zikula\\AtomTheme\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "extra": {
         "zikula" : {
             "core-compatibility": ">=3.0.0",
             "class": "Zikula\\AtomTheme\\ZikulaAtomTheme",
             "displayname": "Atom Theme",
+            "icon": "fas fa-atom",
             "capabilities": {
                 "user": {
                     "theme": true
                 },
                 "admin": {
-                    "theme": false,
-                    "icon": "fas fa-atom"
+                    "theme": false
                 }
             }
         }

--- a/src/system/BlocksModule/composer.json
+++ b/src/system/BlocksModule/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Zikula\\BlocksModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "suggest": {
         "Scribite:>=6.0.2": "To allow WYSIWYG HTML block editing."
@@ -25,23 +25,18 @@
             "core-compatibility": ">=3.0.0",
             "displayname": "Blocks Module",
             "url": "blocks",
-            "oldnames": [],
+            "icon": "fas fa-table",
             "capabilities": {
                 "admin": {
-                    "route": "zikulablocksmodule_admin_view",
-                    "icon": "fas fa-table"
+                    "route": "zikulablocksmodule_admin_view"
                 }
             },
             "securityschema": {
                 "ZikulaBlocksModule::": "Block key:Block title:Block ID",
                 "ZikulaBlocksModule::position": "Position name::Position ID",
-                "ExtendedMenublock::": "Block ID:Link ID:",
                 "fincludeblock::": "Block title::",
                 "HTMLblock::": "Block title::",
                 "HTMLblock::bid": "::bid",
-                "Languageblock::": "Block title::",
-                "Menublock::": "Block title:Link name:",
-                "Menutree:menutreeblock:": "Block ID:Link Name:Link ID",
                 "PendingContent::": "Block title::",
                 "Textblock::": "Block title::",
                 "Textblock::bid": "::bid",

--- a/src/system/BootstrapTheme/composer.json
+++ b/src/system/BootstrapTheme/composer.json
@@ -22,13 +22,13 @@
             "core-compatibility": ">=3.0.0",
             "class": "Zikula\\BootstrapTheme\\ZikulaBootstrapTheme",
             "displayname": "Bootstrap Theme",
+            "icon": "fab fa-bootstrap",
             "capabilities": {
                 "user": {
                     "theme": true
                 },
                 "admin": {
-                    "theme": true,
-                    "icon": "fab fa-bootstrap"
+                    "theme": true
                 }
             }
         }

--- a/src/system/CategoriesModule/composer.json
+++ b/src/system/CategoriesModule/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Zikula\\CategoriesModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "extra": {
         "zikula": {
@@ -22,10 +22,10 @@
             "core-compatibility": ">=3.0.0",
             "displayname": "Categories",
             "url": "categories",
+            "icon": "fas fa-sitemap",
             "capabilities": {
                 "admin": {
-                    "route": "zikulacategoriesmodule_category_list",
-                    "icon": "fas fa-sitemap"
+                    "route": "zikulacategoriesmodule_category_list"
                 }
             },
             "securityschema": {

--- a/src/system/ExtensionsModule/Entity/ExtensionEntity.php
+++ b/src/system/ExtensionsModule/Entity/ExtensionEntity.php
@@ -175,7 +175,7 @@ class ExtensionEntity extends EntityAccess
 
     public function getIcon(): string
     {
-        return $this->icon ?? $this['capabilities']['admin']['icon'] ?? '';
+        return $this->icon ?? '';
     }
 
     public function setIcon(string $icon): void

--- a/src/system/ExtensionsModule/Helper/BundleSyncHelper.php
+++ b/src/system/ExtensionsModule/Helper/BundleSyncHelper.php
@@ -290,9 +290,6 @@ class BundleSyncHelper
                 /** @var ExtensionEntity $extension */
                 $extension = $this->extensionRepository->find($extensionFromFile['id']);
                 $extension->merge($extensionFromFile);
-                if (empty($extension->getIcon())) {
-                    $extension->setIcon($extensionFromFile['capabilities']['admin']['icon']);
-                }
                 $this->extensionRepository->persistAndFlush($extension);
             }
 
@@ -377,9 +374,6 @@ class BundleSyncHelper
                 // insert new extension to db
                 $newExtension = new ExtensionEntity();
                 $newExtension->merge($extensionFromFile);
-                if (empty($newExtension->getIcon())) {
-                    $newExtension->setIcon($extensionFromFile['capabilities']['admin']['icon']);
-                }
                 $vetoEvent = new GenericEvent($newExtension);
                 $this->dispatcher->dispatch($vetoEvent, ExtensionEvents::INSERT_VETO);
                 if (!$vetoEvent->isPropagationStopped()) {

--- a/src/system/ExtensionsModule/Helper/ComposerValidationHelper.php
+++ b/src/system/ExtensionsModule/Helper/ComposerValidationHelper.php
@@ -111,11 +111,14 @@ class ComposerValidationHelper
         $this->content = json_decode($this->rawContent); // returns null on failure
         if (empty($this->content)) {
             $error = $this->jsonErrorCodes[json_last_error()];
-            $this->errors[] = $this->translator->trans('Unable to decode composer file of %component% (%filePath%): %error%. Ensure the composer.json file has a valid syntax.', [
-                '%component%' => $this->bundleName,
-                '%filePath%' => $this->filePath,
-                '%error%' => $error
-            ]);
+            $this->errors[] = $this->translator->trans(
+                'Unable to decode composer file of %component% (%filePath%): %error%. Ensure the composer.json file has a valid syntax.',
+                [
+                    '%component%' => $this->bundleName,
+                    '%filePath%' => $this->filePath,
+                    '%error%' => $error
+                ]
+            );
 
             return false;
         }
@@ -140,12 +143,15 @@ class ComposerValidationHelper
 
         if (!$validator->isValid()) {
             foreach ($validator->getErrors() as $errorDetails) {
-                $this->errors[] = $this->translator->trans('Error found in composer file of %component% (%filePath%) in property "%property%": %error%.', [
-                    '%component%' => $this->bundleName,
-                    '%filePath%' => $this->filePath,
-                    '%property%' => $errorDetails['property'],
-                    '%error%' => $errorDetails['message']
-                ]);
+                $this->errors[] = $this->translator->trans(
+                    'Error found in composer file of %component% (%filePath%) in property "%property%": %error%.',
+                    [
+                        '%component%' => $this->bundleName,
+                        '%filePath%' => $this->filePath,
+                        '%property%' => $errorDetails['property'],
+                        '%error%' => $errorDetails['message']
+                    ]
+                );
             }
         }
     }

--- a/src/system/ExtensionsModule/Schema/schema.composer.json
+++ b/src/system/ExtensionsModule/Schema/schema.composer.json
@@ -84,7 +84,7 @@
                             "additionalProperties": true
                         }
                     },
-                    "required": ["core-compatibility", "class"],
+                    "required": ["core-compatibility", "class", "icon"],
                     "additionalProperties": false
                 }
             },

--- a/src/system/ExtensionsModule/Schema/schema.composer.json
+++ b/src/system/ExtensionsModule/Schema/schema.composer.json
@@ -73,6 +73,7 @@
                         "class": {"type": "string"},
                         "displayname": {"type": "string"},
                         "url": {"type": "string"},
+                        "icon": {"type": "string"},
                         "oldnames": {"type": "array"},
                         "capabilities": {
                             "type": "object",

--- a/src/system/ExtensionsModule/Tests/Fixtures/maximum_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/maximum_composer.json
@@ -22,7 +22,7 @@
     "psr-4": { "Zikula\\FooModule\\": "" }
   },
   "require": {
-    "php": ">=5.5.9"
+    "php": ">=7.2.5"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.5"
@@ -38,9 +38,12 @@
       "url": "foo",
       "oldnames": ["food"],
       "capabilities": {
-        "hook_subscriber": {"class": "Zikula\\FooModule\\Container\\HookContainer"},
-        "user": {"route": "zikulafoomodule_foo_index"},
-        "admin": {"route": "zikulafoomodule_bar_index"}
+        "admin": {
+            "route": "zikulafoomodule_bar_index"
+        },
+        "user": {
+            "route": "zikulafoomodule_foo_index"
+        }
       },
       "securityschema": {
         "ZikulaFooModule::": "::"

--- a/src/system/ExtensionsModule/Tests/Fixtures/maximum_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/maximum_composer.json
@@ -37,6 +37,7 @@
       "displayname": "FooModule",
       "url": "foo",
       "oldnames": ["food"],
+      "icon": "fas fa-database",
       "capabilities": {
         "admin": {
             "route": "zikulafoomodule_bar_index"

--- a/src/system/ExtensionsModule/Tests/Fixtures/minimum_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/minimum_composer.json
@@ -12,7 +12,7 @@
     "psr-4": { "Zikula\\FooModule\\": "" }
   },
   "require": {
-    "php": ">=5.5.9"
+    "php": ">=7.2.5"
   },
   "extra": {
     "zikula": {

--- a/src/system/ExtensionsModule/Tests/Fixtures/minimum_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/minimum_composer.json
@@ -17,7 +17,8 @@
   "extra": {
     "zikula": {
       "class": "Zikula\\SpecModule\\ZikulaFooModule",
-      "core-compatibility": ">=1.4.2"
+      "core-compatibility": ">=1.4.2",
+      "icon": "fas fa-database"
     }
   }
 }

--- a/src/system/ExtensionsModule/Tests/Fixtures/minimum_error1_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/minimum_error1_composer.json
@@ -16,7 +16,8 @@
   "extra": {
     "zikula": {
       "class": "Zikula\\SpecModule\\ZikulaFooModule",
-      "core-compatibility": ">=1.4.2"
+      "core-compatibility": ">=1.4.2",
+      "icon": "fas fa-database"
     }
   }
 }

--- a/src/system/ExtensionsModule/Tests/Fixtures/minimum_error1_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/minimum_error1_composer.json
@@ -11,7 +11,7 @@
     "psr-4": { "Zikula\\FooModule\\": "" }
   },
   "require": {
-    "php": ">=5.5.9"
+    "php": ">=7.2.5"
   },
   "extra": {
     "zikula": {

--- a/src/system/ExtensionsModule/Tests/Fixtures/minimum_error2_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/minimum_error2_composer.json
@@ -17,7 +17,8 @@
   "extra": {
     "zikula": {
       "class": "Zikula\\SpecModule\\ZikulaFooModule",
-      "core-compatibility": ">=1.4.2"
+      "core-compatibility": ">=1.4.2",
+      "icon": "fas fa-database"
     }
   }
 }

--- a/src/system/ExtensionsModule/Tests/Fixtures/minimum_error2_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/minimum_error2_composer.json
@@ -12,7 +12,7 @@
     "psr-0": { "Zikula\\Module\\FooModule\\": "" }
   },
   "require": {
-    "php": ">=5.5.9"
+    "php": ">=7.2.5"
   },
   "extra": {
     "zikula": {

--- a/src/system/ExtensionsModule/Tests/Fixtures/minimum_error3_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/minimum_error3_composer.json
@@ -1,0 +1,23 @@
+{
+  "name": "zikula/foo-module",
+  "description": "A foo module.",
+  "type": "zikula-module",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Zikula Team"
+    }
+  ],
+  "autoload": {
+    "psr-4": { "Zikula\\FooModule\\": "" }
+  },
+  "require": {
+    "php": ">=7.2.5"
+  },
+  "extra": {
+    "zikula": {
+      "class": "Zikula\\SpecModule\\ZikulaFooModule",
+      "core-compatibility": ">=1.4.2"
+    }
+  }
+}

--- a/src/system/ExtensionsModule/Tests/Fixtures/minimum_syntax_error_composer.json
+++ b/src/system/ExtensionsModule/Tests/Fixtures/minimum_syntax_error_composer.json
@@ -12,7 +12,7 @@
     "psr-4": { "Zikula\\FooModule\\": "" }
   },
   "require": {
-    "php": ">=5.5.9"
+    "php": ">=7.2.5"
   },
   "extra": {
     "zikula": {

--- a/src/system/ExtensionsModule/Tests/Helper/ComposerValidationHelperTest.php
+++ b/src/system/ExtensionsModule/Tests/Helper/ComposerValidationHelperTest.php
@@ -65,6 +65,7 @@ class ComposerValidationHelperTest extends TestCase
             ['maximum_composer.json', true, []],
             ['minimum_error1_composer.json', false, ['Error found in composer file of Fixtures (/../Fixtures) in property "description": The property description is required.']],
             ['minimum_error2_composer.json', false, ['Error found in composer file of Fixtures (/../Fixtures) in property "autoload.psr-4": The property psr-4 is required.']],
+            ['minimum_error3_composer.json', false, ['Error found in composer file of Fixtures (/../Fixtures) in property "extra.zikula.icon": The property icon is required.']],
             ['minimum_syntax_error_composer.json', false, ['Unable to decode composer file of Fixtures (/../Fixtures): Syntax error. Ensure the composer.json file has a valid syntax.']],
             ['empty_composer.json', false, [
                 'Error found in composer file of Fixtures (/../Fixtures) in property "name": The property name is required.',

--- a/src/system/ExtensionsModule/composer.json
+++ b/src/system/ExtensionsModule/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Zikula\\ExtensionsModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.2.5",
         "composer/semver": "1.*",
         "justinrainbow/json-schema": "5.*"
     },
@@ -24,11 +24,10 @@
             "class": "Zikula\\ExtensionsModule\\ZikulaExtensionsModule",
             "core-compatibility": ">=3.0.0",
             "displayname": "Extensions",
-            "oldnames": [],
+            "icon": "fas fa-plug",
             "capabilities": {
                 "admin": {
-                    "route": "zikulaextensionsmodule_extension_list",
-                    "icon": "fas fa-plug"
+                    "route": "zikulaextensionsmodule_extension_list"
                 }
             },
             "securityschema": {

--- a/src/system/GroupsModule/composer.json
+++ b/src/system/GroupsModule/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Zikula\\GroupsModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "extra": {
         "zikula": {
@@ -22,12 +22,14 @@
             "core-compatibility": ">=3.0.0",
             "displayname": "Groups",
             "url": "groups",
+            "icon": "fas fa-users",
             "capabilities": {
                 "admin": {
-                    "route": "zikulagroupsmodule_group_adminlist",
-                    "icon": "fas fa-users"
+                    "route": "zikulagroupsmodule_group_adminlist"
                 },
-                "user": {"route": "zikulagroupsmodule_group_list"}
+                "user": {
+                    "route": "zikulagroupsmodule_group_list"
+                }
             },
             "securityschema": {
                 "ZikulaGroupsModule::": "Group ID::",

--- a/src/system/MailerModule/composer.json
+++ b/src/system/MailerModule/composer.json
@@ -14,8 +14,8 @@
         "psr-4": { "Zikula\\MailerModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0",
-        "symfony/swiftmailer-bundle": ">=3.2.5"
+        "php": ">=7.2.5",
+        "symfony/swiftmailer-bundle": ">=3.4.0"
     },
     "extra": {
         "zikula": {
@@ -23,10 +23,10 @@
             "core-compatibility": ">=3.0.0",
             "displayname": "Mailer Module",
             "url": "mailer",
+            "icon": "fas fa-envelope",
             "capabilities": {
                 "admin": {
-                    "route": "zikulamailermodule_config_config",
-                    "icon": "fas fa-envelope"
+                    "route": "zikulamailermodule_config_config"
                 }
             },
             "securityschema": {

--- a/src/system/MenuModule/composer.json
+++ b/src/system/MenuModule/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Zikula\\MenuModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.2.5",
         "knplabs/knp-menu-bundle": ">=2.2.1"
     },
     "extra": {
@@ -22,13 +22,13 @@
             "class": "Zikula\\MenuModule\\ZikulaMenuModule",
             "core-compatibility": ">=3.0.0",
             "displayname": "Menu Module",
+            "url": "menu",
+            "icon": "fas fa-compass",
             "capabilities": {
                 "admin": {
-                    "route": "zikulamenumodule_menu_list",
-                    "icon": "fas fa-compass"
+                    "route": "zikulamenumodule_menu_list"
                 }
             },
-            "url": "menu",
             "securityschema": {
                 "ZikulaMenuModule::": "::",
                 "ZikulaMenuModule::id": "::id"

--- a/src/system/PermissionsModule/composer.json
+++ b/src/system/PermissionsModule/composer.json
@@ -14,20 +14,20 @@
         "psr-4": { "Zikula\\PermissionsModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "extra": {
         "zikula": {
             "class": "Zikula\\PermissionsModule\\ZikulaPermissionsModule",
             "core-compatibility": ">=3.0.0",
-            "capabilities": {
-                "admin": {
-                    "route": "zikulapermissionsmodule_permission_list",
-                    "icon": "fas fa-key"
-                }
-            },
             "displayname": "Permissions",
             "url": "permissions",
+            "icon": "fas fa-key",
+            "capabilities": {
+                "admin": {
+                    "route": "zikulapermissionsmodule_permission_list"
+                }
+            },
             "securityschema": {
                 "ZikulaPermissionsModule::": "::"
             }

--- a/src/system/PrinterTheme/composer.json
+++ b/src/system/PrinterTheme/composer.json
@@ -14,20 +14,20 @@
         "psr-4": { "Zikula\\PrinterTheme\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "extra": {
         "zikula" : {
             "core-compatibility": ">=3.0.0",
             "class": "Zikula\\PrinterTheme\\ZikulaPrinterTheme",
             "displayname": "Printer Theme",
+            "icon": "fas fa-print",
             "capabilities": {
                 "user": {
                     "theme": true
                 },
                 "admin": {
-                    "theme": false,
-                    "icon": "fas fa-print"
+                    "theme": false
                 }
             }
         }

--- a/src/system/RoutesModule/composer.json
+++ b/src/system/RoutesModule/composer.json
@@ -32,13 +32,13 @@
             "class": "Zikula\\RoutesModule\\ZikulaRoutesModule",
             "displayname": "Routes",
             "url": "routes",
+            "icon": "fas fa-map-marked-alt",
             "capabilities": {
                 "user": {
                     "route": "zikularoutesmodule_route_index"
                 },
                 "admin": {
-                    "route": "zikularoutesmodule_route_adminindex",
-                    "icon": "fas fa-map-marked-alt"
+                    "route": "zikularoutesmodule_route_adminindex"
                 }
             },
             "securityschema": {

--- a/src/system/RssTheme/composer.json
+++ b/src/system/RssTheme/composer.json
@@ -14,20 +14,20 @@
         "psr-4": { "Zikula\\RssTheme\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "extra": {
         "zikula" : {
             "core-compatibility": ">=3.0.0",
             "class": "Zikula\\RssTheme\\ZikulaRssTheme",
             "displayname": "Rss Theme",
+            "icon": "fas fa-rss",
             "capabilities": {
                 "user": {
                     "theme": true
                 },
                 "admin": {
-                    "theme": false,
-                    "icon": "fas fa-rss"
+                    "theme": false
                 }
             }
         }

--- a/src/system/SearchModule/composer.json
+++ b/src/system/SearchModule/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Zikula\\SearchModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "extra": {
         "zikula": {
@@ -22,12 +22,14 @@
             "core-compatibility": ">=3.0.0",
             "displayname": "Site search",
             "url": "search",
+            "icon": "fas fa-search",
             "capabilities": {
                 "admin": {
-                    "route": "zikulasearchmodule_config_config",
-                    "icon": "fas fa-search"
+                    "route": "zikulasearchmodule_config_config"
                 },
-                "user": {"route": "zikulasearchmodule_search_execute"}
+                "user": {
+                    "route": "zikulasearchmodule_search_execute"
+                }
             },
             "securityschema": {
                 "ZikulaSearchModule::": "Module name::",

--- a/src/system/SecurityCenterModule/composer.json
+++ b/src/system/SecurityCenterModule/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Zikula\\SecurityCenterModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.2.5",
         "phpids/phpids": "dev-master"
     },
     "extra": {
@@ -23,10 +23,10 @@
             "core-compatibility": ">=3.0.0",
             "displayname": "Security Center",
             "url": "securitycenter",
+            "icon": "fas fa-shield-alt",
             "capabilities": {
                 "admin": {
-                    "route": "zikulasecuritycentermodule_config_config",
-                    "icon": "fas fa-shield-alt"
+                    "route": "zikulasecuritycentermodule_config_config"
                 }
             },
             "securityschema": {

--- a/src/system/SettingsModule/composer.json
+++ b/src/system/SettingsModule/composer.json
@@ -14,19 +14,18 @@
         "psr-4": { "Zikula\\SettingsModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "extra": {
         "zikula": {
-            "url": "settings",
             "class": "Zikula\\SettingsModule\\ZikulaSettingsModule",
             "core-compatibility": ">=3.0.0",
             "displayname": "General settings",
-            "oldnames": [],
+            "url": "settings",
+            "icon": "fas fa-tools",
             "capabilities": {
                 "admin": {
-                    "route": "zikulasettingsmodule_settings_main",
-                    "icon": "fas fa-tools"
+                    "route": "zikulasettingsmodule_settings_main"
                 }
             },
             "securityschema": {

--- a/src/system/ThemeModule/composer.json
+++ b/src/system/ThemeModule/composer.json
@@ -42,17 +42,15 @@
     },
     "extra": {
         "zikula": {
-            "url": "theme",
             "class": "Zikula\\ThemeModule\\ZikulaThemeModule",
             "core-compatibility": ">=3.0.0",
             "displayname": "Theme Module",
-            "oldnames": [],
+            "url": "theme",
+            "icon": "fas fa-palette",
             "capabilities": {
                 "admin": {
-                    "route": "zikulathememodule_config_config",
-                    "icon": "fas fa-palette"
-                },
-                "user": {"route": "zikulathememodule_user_index"}
+                    "route": "zikulathememodule_config_config"
+                }
             },
             "securityschema": {
                 "ZikulaThemeModule::": "ThemeName::",

--- a/src/system/UsersModule/composer.json
+++ b/src/system/UsersModule/composer.json
@@ -14,21 +14,22 @@
         "psr-4": { "Zikula\\UsersModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.2.5"
     },
     "extra": {
         "zikula": {
-            "url": "users",
             "class": "Zikula\\UsersModule\\ZikulaUsersModule",
             "core-compatibility": ">=3.0.0",
             "displayname": "Users Module",
-            "oldnames": [],
+            "url": "users",
+            "icon": "fas fa-users-cog",
             "capabilities": {
                 "admin": {
-                    "route": "zikulausersmodule_useradministration_list",
-                    "icon": "fas fa-users-cog"
+                    "route": "zikulausersmodule_useradministration_list"
                 },
-                "user": {"route": "zikulausersmodule_account_menu"}
+                "user": {
+                    "route": "zikulausersmodule_account_menu"
+                }
             },
             "securityschema": {
                 "ZikulaUsersModule::": "Uname::User ID",

--- a/src/system/ZAuthModule/composer.json
+++ b/src/system/ZAuthModule/composer.json
@@ -14,7 +14,7 @@
         "psr-4": { "Zikula\\ZAuthModule\\": "" }
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.2.5",
         "ircmaxell/random-lib": "1.*"
     },
     "extra": {
@@ -23,10 +23,10 @@
             "core-compatibility": ">=3.0.0",
             "displayname": "Zikula Native Authorization",
             "url": "zauth",
+            "icon": "fas fa-user-lock",
             "capabilities": {
                 "admin": {
-                    "route": "zikulazauthmodule_useradministration_list",
-                    "icon": "fas fa-user-lock"
+                    "route": "zikulazauthmodule_useradministration_list"
                 }
             },
             "securityschema": {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixes #4116 
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR moves the `icon` field out of the `capabilities` array.
Also it does some minor cleanups at composer files, like proper ordering of extra fields and minimum PHP version.
It also updates the VA modules which have these changes already commited.