### PR TITLE
added docs about permissions and categories

### DIFF
--- a/docs/AccessControl/Permissions/Dev/Implementation.md
+++ b/docs/AccessControl/Permissions/Dev/Implementation.md
@@ -112,7 +112,7 @@ class PersonController extends AbstractController
 }
 ```
 
-Note this is not limited to one permission check for each method. It is possible to have multiple occurrences in a method's doc block, these are all evaluated independently then.
+Note this is limited to one permission check for each method. It is not possible to have multiple occurrences in a method's doc block. If more complex evaluations are required, permission API should be used instead (see above).
 
 It is also possible to use the annotation on class-level. But it is not allowed to use it for a class *and* for it's methods concurrently.
 

--- a/docs/AccessControl/Permissions/Dev/Implementation.md
+++ b/docs/AccessControl/Permissions/Dev/Implementation.md
@@ -1,0 +1,173 @@
+---
+currentMenu: permissions
+---
+# How to implement permissions
+
+## Basic usage
+
+Typically required permissions are checked for using the [PermissionApi](PermissionApi.md).
+
+### In controllers
+
+The `Zikula\Bundle\CoreBundle\Controller\AbstractController\AbstractController` class provides a shortcut method:
+
+- `hasPermission(string $component = null, string $instance = null, int $level = null, int $user = null): bool`
+
+The following code shows a possible example how to use this in a controller method:
+
+```php
+namespace Acme\PersonModule\Controller;
+
+use Acme\PersonModule\Entity\PersonEntity;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Zikula\Bundle\CoreBundle\Controller\AbstractController;
+
+class PersonController extends AbstractController
+{
+    /**
+     * @Route("/admin/edit/{personid}", requirements={"personid" = "^[1-9]\d*$"})
+     * @Theme("admin")
+     * @Template("@AcmePersonModule/Person/edit.html.twig")
+     *
+     * Modify a person.
+     *
+     * @return array|RedirectResponse
+     * @throws AccessDeniedException Thrown if the user hasn't permissions to edit the person
+     */
+    public function editAction(
+        Request $request,
+        PersonEntity $person
+    ) {
+        if (!$this->hasPermission('AcmePersonModule::', $person->getId() . '::', ACCESS_EDIT)) {
+            throw new AccessDeniedException();
+        }
+
+        // ...
+    }
+}
+```
+
+### Direct usage
+
+Of course the [PermissionApi](PermissionApi.md) can also be injected as a service into any class if desired.
+
+```php
+namespace Acme\PersonModule\Helper;
+
+use Acme\PersonModule\Entity\PersonEntity;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Zikula\PermissionsModule\Api\ApiInterface\PermissionApiInterface;
+
+class MyService
+{
+    /**
+     * @var PermissionApiInterface
+     */
+    private $permissionApi;
+
+    public function __construct(PermissionApiInterface $permissionApi)
+    {
+        $this->permissionApi = $permissionApi;
+    }
+
+    public function processPerson(PersonEntity $person)
+    {
+        if (!$this->permissionApi->hasPermission('AcmePersonModule::', $person->getId() . '::', ACCESS_EDIT)) {
+            throw new AccessDeniedException();
+        }
+    }
+}
+```
+
+## Using an annotation
+
+Controllers may also use a [PermissionCheck Annotation](PermissionCheckAnnotation.md) to perform permission checks in a declarative way.
+
+The controller example from above would look like this then:
+
+```php
+namespace Acme\PersonModule\Controller;
+
+use Acme\PersonModule\Entity\PersonEntity;
+use Symfony\Component\HttpFoundation\Request;
+use Zikula\Bundle\CoreBundle\Controller\AbstractController;
+use Zikula\PermissionsModule\Annotation\PermissionCheck;
+
+class PersonController extends AbstractController
+{
+    /**
+     * @Route("/admin/edit/{personid}", requirements={"personid" = "^[1-9]\d*$"})
+     * @PermissionCheck({"$_zkModule::", "$personid::", "edit"})
+     * @Theme("admin")
+     * @Template("@AcmePersonModule/Person/edit.html.twig")
+     */
+    public function editAction(
+        Request $request,
+        PersonEntity $person
+    ) {
+        // ...
+    }
+}
+```
+
+Note this is not limited to one permission check for each method. It is possible to have multiple occurrences in a method's doc block, these are all evaluated independently then.
+
+It is also possible to use the annotation on class-level. But it is not allowed to use it for a class *and* for it's methods concurrently.
+
+Example for a class-level use case:
+
+```php
+namespace Acme\PersonModule\Controller;
+
+use Acme\PersonModule\Entity\PersonEntity;
+use Symfony\Component\HttpFoundation\Request;
+use Zikula\Bundle\CoreBundle\Controller\AbstractController;
+use Zikula\PermissionsModule\Annotation\PermissionCheck;
+
+/**
+ * @PermissionCheck("admin")
+ */
+class ConfigController extends AbstractController
+{
+    public function someAction(Request $request)
+    {
+        // ...
+    }
+
+    public function otherAction(Request $request)
+    {
+        // ...
+    }
+}
+```
+
+For more details see the [PermissionCheck Annotation document](PermissionCheckAnnotation.md).
+
+## Special aspects
+
+### Check permissions for specific users
+
+By default permission checks are always executed for the current user. Internally the [PermissionApi](PermissionApi.md) uses the [CurrentUserApi](../../Users/Dev/CurrentUserApi.md) for that.
+
+In order to explicitly perform a permission check for a specific user, it is possible to assign the corresponding user ID as the fourth parameter for the `hasPermission()` method of both `AbstractController` and `PermissionApi`.
+
+Note the annotation-based checks are always done for the current user.
+
+### Permissions for *own* data
+
+The permissions system does not have a default way to express ownerships. The reason for this is that extensions may implement arbitrary logic and rules for when some data is considered as owned by a user.
+
+Common approaches for handling such requirements are for example:
+
+- Use a separate permission component, like `AcmeRecipesModule:Own:(Ingredients|Recipes)`.
+- Do a comparison of the current user's ID with the owner ID.
+- Use dedicated configuration options, for example user group selectors, to store a group ID which may do additional things (independent of permissions).
+- Combine these steps.
+
+### Category-based permissions
+
+If an extension utilises the side-wide category system. it could become helpful to be able to filter data based on permissions for categories.
+
+For further information about this please refer to the [Categories docs](../Integration/Categories/README.md), particularly [CategoryPermissionApi](../Integration/Categories/Dev/CategoryPermissionApi.md).

--- a/docs/AccessControl/Permissions/Dev/Implementation.md
+++ b/docs/AccessControl/Permissions/Dev/Implementation.md
@@ -145,6 +145,18 @@ class ConfigController extends AbstractController
 
 For more details see the [PermissionCheck Annotation document](PermissionCheckAnnotation.md).
 
+## Twig templates
+
+You can use `hasPermission` inside templates similarly as in PHP. The only difference is that the permission level constants need to be declared as strings.
+
+Example:
+
+```twig
+{% if hasPermission('AcmePersonModule::', person.id ~ '::', 'ACCESS_READ') %}
+    <h3>{{ person.name }}</h3>
+{% endif %}
+```
+
 ## Special aspects
 
 ### Check permissions for specific users

--- a/docs/AccessControl/Permissions/Dev/Implementation.md
+++ b/docs/AccessControl/Permissions/Dev/Implementation.md
@@ -3,6 +3,35 @@ currentMenu: permissions
 ---
 # How to implement permissions
 
+## Declare permission schema
+
+An extension needs to declare all permission components and instance templates in `composer.json`. This is required to let the permissions system know them which helps supporting site administrators [looking up components and instances](../Management.md).
+
+The following example shows how this is done:
+
+```yaml
+{
+    "name": "acme/person-module",
+    ...
+    "extra": {
+        "zikula": {
+            ...
+            "securityschema": {
+                "AcmePersonModule::": "::",
+                "AcmePersonModule:SomeBlock:": "Block title::",
+                "AcmePersonModule:Person:": "Person ID::",
+                "AcmePersonModule:Address:": "Address ID::",
+                ...
+            }
+        }
+    }
+}
+```
+
+Each entry in the `securityschema` array consists of a component (key) and a template for the instances (value).
+
+The extension author is completely free in deciding which components and instances are supported.
+
 ## Basic usage
 
 Typically required permissions are checked for using the [PermissionApi](PermissionApi.md).

--- a/docs/AccessControl/Permissions/Elements.md
+++ b/docs/AccessControl/Permissions/Elements.md
@@ -1,0 +1,66 @@
+---
+currentMenu: permissions
+---
+# Fundamental elements of a permission rule
+
+Each permission rule consists of the following parts:
+
+Group
+: The user group to which the rule applies.
+
+Component
+: The type(s) of content to which the rule applies.
+
+Instance
+: The concrete instance(s) of the component to which the rule applies.
+
+Permission level
+: The level of authorisation granted.
+
+## Permission levels
+
+Zikula uses the following nine permission levels:
+
+No access (`ACCESS_NONE`)
+: Users must not access the requested content and won't see affected instances at all.
+
+Overview access (`ACCESS_OVERVIEW`)
+: Users may see requested content, but have no access to it for reading its details.
+
+Read access (`ACCESS_READ`)
+: Users may see and read affected instances.
+
+Comment access (`ACCESS_COMMENT`)
+: Users may read requested content and they can add commenting additions to it.
+
+Moderate access (`ACCESS_MODERATE`)
+: Users may moderate affected instances in case some kind of a moderation exists.
+
+Edit access (`ACCESS_EDIT`)
+: Users may edit affected content instances. They may not add new instances though. For example a news system reviewer is allowed to edit articles to correct typos, but may not submit new content.
+
+Add access (`ACCESS_ADD`)
+: Users may add new content instances for the affected component types. Possibly they may also approve pending content instances.
+
+Delete access (`ACCESS_DELETE`)
+: Users may delete existing content instances of the affected component types.
+
+Admin access (`ACCESS_ADMIN`)
+: Users have full administrative rights for the affected content instances.
+
+Important notes:
+
+1. Higher permission levels include lower ones. For example delete access means that also moderate, edit and add access are available.
+2. Any Zikula extension is free to decide how it interprets the permission levels. So what comment or moderate access specifically means can be different across multiple extensions and workflows.
+
+## About components
+
+The component specifies the type(s) of content to which a specific rule applies.
+
+Any component consists of up to three levels that are separated by colons. The first level typically represents the extension or an extension's block within which the corresponding content types are processed.
+
+## About instances
+
+The instance part describes to which concrete instance(s) of the component a specific rule applies. If for example an extension allows creating recipes then each recipe record represents one instance of the corresponding permission component. Another example are blocks: it is possible to create several blocks of the same type, each of them is a dedicated instance of that block type.
+
+The instance part of permission rules may also consists of up to three levels (again separated by colons), which allows nested contexts to be specified if required.

--- a/docs/AccessControl/Permissions/IndividualRules.md
+++ b/docs/AccessControl/Permissions/IndividualRules.md
@@ -1,0 +1,14 @@
+---
+currentMenu: permissions
+---
+# Using individual / additional components
+
+Should it become necessary to perform individual checks - for example in a custom [theme](../../LayoutDesign/Themes/README.md) - individual components can be used at any time. The permissions system is not limited to those components that have been announced by extensions.
+
+So it is possible any time to create rules for a `MySpecial:Individual:Check` component and check for that in a template like this:
+
+```twig
+{% if hasPermission('MySpecial:Individual:Check', '::', 'ACCESS_READ') %}
+    <h3>This is only for some VIP</h3>
+{% endif %}
+```

--- a/docs/AccessControl/Permissions/Management.md
+++ b/docs/AccessControl/Permissions/Management.md
@@ -1,0 +1,27 @@
+---
+currentMenu: permissions
+---
+# Further aspects for managing permissions
+
+## Why the order matters
+
+An important thing to know is that the order of rules is important. As all rules are part of an ordered table the permissions system as a whole can be imagined as a hierarchy: the system evaluates permissions from top to bottom whereby the first match for a given request is used. Background is the performance, so that not with each check for access rights unnecessarily many rules must be evaluated.
+
+This is especially important to remember with regards to that any user may be a member of multiple user groups. As a rule of thumb it is a good approach to have rules for groups with higher permissions above rules for other groups which should have less abilities.
+
+If for example a moderators group should be able to add posts and other users may only read posts, then the rule for moderators should come before the rule for users to ensure that moderators get their permission also if they are part of the users group additionally.
+
+## Looking up components and instances
+
+The permissions administration page allows to open an overview of all registered components along with a template for possible instances by clicking on the *"Permission rules information"* link. Note this overview includes all currently available components, depending on which extensions are installed and activated.
+
+## Testing permission rules
+
+Whenever there is an uncertainty about whether a specific permission is correctly configured or not it is possible to test permissions for any user name. Below the permission rules table there is a form which shows if a user has a given permission level for a given component and instance or not.
+
+## Keeping the overview
+
+A permission rule has two more fields that are only for assisting the site administrator and have not been mentioned yet above:
+
+- An optional comment which can store explanations for the rule that are displayed as a tooltip when hovering over the corresponding table row.
+- A Bootstrap colour class which can be used for building visual groups to mark multiple related rules.

--- a/docs/AccessControl/Permissions/README.md
+++ b/docs/AccessControl/Permissions/README.md
@@ -1,11 +1,27 @@
 ---
 currentMenu: permissions
 ---
-# Permission system
+# Permissions system
 
-TBD
+The permission system of Zikula is very flexible and powerful: it allows a very fine-grained control over who is allowed to do what. This power also contains a certain complexity though. In this section permission rules are explained. It also discusses how permissions management works and what developers need to consider.
+
+## Permission rules are for user groups
+
+First of all, permission rules are always applied to [user groups](../Groups/README.md). Many years ago permission rules were also possible for single users, but this this had been waived for performance reasons. So if it should ever become necessary to regulate things differently for a certain user, a separate user group must be created for this.
+
+## Basics
+
+- [Fundamental elements of a permission rule](Elements.md)
+- [Further aspects for managing permissions](Management.md)
+
+## Advanced topics
+
+- [Using individual / additional components](IndividualRules.md)
+- [Powerful permission rules with regular expressions](RegularExpressions.md)
 
 ## For developers
 
+- [How to implement permissions](Dev/Implementation.md)
 - [PermissionApi](Dev/PermissionApi.md)
+- [PermissionCheck Annotation](PermissionCheckAnnotation.md)
 - [CategoryPermissionApi](../Integration/Categories/Dev/CategoryPermissionApi.md)

--- a/docs/AccessControl/Permissions/README.md
+++ b/docs/AccessControl/Permissions/README.md
@@ -23,5 +23,5 @@ First of all, permission rules are always applied to [user groups](../Groups/REA
 
 - [How to implement permissions](Dev/Implementation.md)
 - [PermissionApi](Dev/PermissionApi.md)
-- [PermissionCheck Annotation](PermissionCheckAnnotation.md)
+- [PermissionCheck Annotation](Dev/PermissionCheckAnnotation.md)
 - [CategoryPermissionApi](../Integration/Categories/Dev/CategoryPermissionApi.md)

--- a/docs/AccessControl/Permissions/RegularExpressions.md
+++ b/docs/AccessControl/Permissions/RegularExpressions.md
@@ -1,0 +1,81 @@
+---
+currentMenu: permissions
+---
+# Powerful permission rules with regular expressions
+
+## A look a little deeper
+
+Both components and instances can be described using regular expressions. Here lies part of the flexibility and power of the permission system.
+
+First, it is possible to use a period with asterisk as a wildcard to designate a section as *everything* - so `.*` just means *all instances*.
+
+Furthermore, colons are used for both components and instances to separate three sections or divisions, as written above. Each section can be described by a term. If one term is specific enough, the rest are also assumed to mean *everything*, though the wildcard is not required.
+
+So there are two shorthand notations: asterisks can be omitted in specific references and colons can be omitted for global references.
+
+Here are concrete examples to make that clear:
+
+- `.*` is equal to `.*:.*:.*`
+- `MyComponent::` is equal to `MyComponent:.*:.*`
+
+For a first impression of how flexible this notation can be used consider a fictional `AcmeRecipesModule` which allows to manage recipes, ingredients and reviews. Here are some possible applications for different components (each with instance set to `.*`):
+
+- `AcmeRecipesModule::` applies for all entities in the recipes database.
+- `AcmeRecipesModule:Recipe:` applies for all recipe entities, but not for ingredients or reviews.
+- `AcmeRecipesModule:(Recipe|Ingredient):` applies for all recipe and ingredient entities, but not for reviews.
+
+A first simple example for a specific instance would be:
+
+- `AcmeRecipesModule:Recipe:` with `1::` applies only for the recipe entity with ID `1`.
+- `AcmeRecipesModule:Recipe:` with `Delicious cookie::` applies only for the recipe entity with title `Delicious cookie`.
+
+Which of them or if both are applicable depends on how `AcmeRecipesModule` uses and interprets the permission rules.
+
+## Advanced examples
+
+Let's venture into slightly more complex applications. The following more sophisticated examples will not be used in daily business, but could become handy if needed.
+
+### Using multiple divisions
+
+As shown in the previous section it is quite common to have a component consisting of multiple levels which helps to target not an entire extension as a whole, but only specific sub components or content types within that extension.
+
+Using multiple levels in the instance part is a less common scenario because it makes only sense for use cases when instances may occur in different constellations.
+
+Let's assume that some users must neither see nor read the ingredient page of *Sugar*, but they should be able to see everything related to *Sugar* within the recipe for the delicious cookies from above.
+
+One possible realisation for that requirement could look like this:
+
+- `AcmeRecipesModule:Recipe:RecipeIngredient` with `Delicious cookie:Sugar:` and `ACCESS_READ`
+
+Nested instances therefore could make sense if different contexts need to be differentiated for the same data.
+
+Of course it would also be possible to use multiple different components and/or combinations of components. Again, how a specific extension applies this in its implementation is individual.
+
+### Hook providers
+
+Extensions offering [hook providers](../../Development/Hooks/README.md) have extended requirements. Because they could want to support different permission schemes depending on the extensions that are connected as hook subscribers. The idea is that it is possible to define permissions for attached comments / reviews / files / etc. based on the objects where these are attached to.
+
+Hence, it makes sense to use the subscriber's name as first level for the instance part.
+
+The following examples are for a `AcmeFileManagerModule` that allows to attach uploads and files to other extensions.
+
+The three instance levels could be used like this:
+
+1. the subscriber extension
+2. the object identifier, that is the ID of the connected object, like a news article, a forum topic, a recipe etc.
+3. the file identifier, that is the ID of an uploaded and/or attached file
+
+This scheme would lead to the following possible examples for the instance part of corresponding permission rules:
+
+- `AcmeForumModule:6:` targets all files attached to the forum topic with ID 6
+- `AcmeForumModule:6:(3|5)` targets only files 3 and 5 in topic 6
+- `AcmeNewsModule:(3|4|5):` targets all files in articles 3, 4 and 5
+- `AcmeRecipesModule::` targets all files in the recipes database
+- `AcmeNewsModule:[^34]:` targets all files in all articles except 3 und 4
+- `AcmeRecipesModule:\d*[^34]\d*` all except those which IDs contain 3 or 4
+
+### The ANY instance
+
+If the instance part is set to `ANY` this causes a special processing. The permissions system interprets this as the user has ANY access to the given component, without the need to determine the exact instance. In practice this results in that the permission levels of all permission rules for that component are collected *until* the first one whose instance matches `::` (or `''` or `:::::`, doesn't matter). Afterwards the highest permission level that has been collected is granted.
+
+This special syntax may be useful in rare cases but should always be used with care.

--- a/docs/Integration/Categories/README.md
+++ b/docs/Integration/Categories/README.md
@@ -3,9 +3,32 @@ currentMenu: categories
 ---
 # Categories
 
-The categories module provides a centralized management of site-wide categories which can be arbitrarily used by any extensions.
+## About side-wide categories
 
-TBD
+The Zikula Core contains a central category management system that allows you to implement a wide range of solutions. The most common use of categories is certainly a thematic assignment of content. For example, news articles can be assigned to different topics. The categories module provides a centralized management of site-wide categories which can be arbitrarily used by any extensions.
+
+## General benefits
+
+First of all, the category system offers some functions that are generally useful.
+
+- Categories are managed in a large tree. So they can be subdivided and structured according to any criteria.
+- In contrast to a fixed drop-down list, categories can be easily extended by the site operator. Additional categories can be created at any time, which then automatically appear and can be selected for all modules that use the corresponding categories.
+- Categories can be translated: Name and description can be stored in several languages directly when editing a category.
+- A category can have attributes: these are dynamic properties that can be specified in addition to the master data. For example, you could assign a color to each category, or the name of a responsible person, or any other information.
+
+## Category registries
+
+The most powerful function, however, which really brings out the advantages mentioned above, is "Category Registries". These are entry points that determine where in the category tree a module wants to use categories for a particular entity.
+
+Several modules can use the same subtrees or different ones. For example, content pages and news articles could either use the same subject areas (politics, business, sports, etc.) or completely different categories could be used for the two areas. Each module can define whether only one or more of the categories from the subtree is allowed.
+
+If several modules use the same categories, it is possible to link relevant content. One could show suitable downloads or videos under an article. Or you could display information from a knowledge base for the current product group in a webshop.
+
+The site operator can freely set the entry points of the registries. And above all, additional registries can be defined. An entity can also use several registries at the same time and thus get several category fields. So if the selection of a topic for a news article is not sufficient, but the selection of a department should also be possible, this can be realized via a second entry point, which refers to a subtree, under which categories for the different departments are located.
+
+This means that you can have any number of drop-down elements for a specific entity, which get their content from the categories. And all this content is dynamically extendable, translatable, can be provided with attributes and can be reused in other modules.
+
+Finally, it is also possible to filter content based on access rights to the categories, if supported by the corresponding module. There are two variants: either the content is allowed for which access rights exist to all categories of all registries, or the content is allowed for which at least one authorization exists.
 
 ## For developers
 

--- a/src/system/PermissionsModule/Api/PermissionApi.php
+++ b/src/system/PermissionsModule/Api/PermissionApi.php
@@ -133,7 +133,11 @@ class PermissionApi implements PermissionApiInterface
             $component = $this->normalizeRegexString($perm['component']);
             $instance = $this->normalizeRegexString($perm['instance']);
             $level = (int)$perm['level']; // this string must be a numeric and not normalized.
-            $groupPerms[] = ['component' => $component, 'instance' => $instance, 'level' => $level];
+            $groupPerms[] = [
+                'component' => $component,
+                'instance' => $instance,
+                'level' => $level
+            ];
         }
 
         $this->groupPermsByUser[$user] = $groupPerms;

--- a/src/system/PermissionsModule/Controller/PermissionController.php
+++ b/src/system/PermissionsModule/Controller/PermissionController.php
@@ -57,6 +57,7 @@ class PermissionController extends AbstractController
         $components = [$this->trans('All components') => '-1'] + $permissionRepository->getAllComponents();
         $colours = [$this->trans('All colours') => '-1'] + $permissionRepository->getAllColours();
         $permissionLevels = $permissionApi->accessLevelNames();
+        unset($permissionLevels[-1]);
 
         $filterForm = $this->createForm(FilterListType::class, [], [
             'groupChoices' => $groups,
@@ -104,6 +105,7 @@ class PermissionController extends AbstractController
 
         $groupNames = $groupsRepository->getGroupNamesById();
         $accessLevelNames = $permissionApi->accessLevelNames();
+        unset($accessLevelNames[-1]);
 
         $form = $this->createForm(PermissionType::class, $permissionEntity, [
             'groups' => $groupNames,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR adds documentation for the permissions system.

It also adds a description of some features of the categories system.

Furthermore it removes the `invalid` permission level from UI dropdowns.
