### PR TITLE
UserAccountDisplayEvent

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -45,6 +45,7 @@
     - `Zikula\UsersModule\RegistrationEvents::UPDATE_REGISTRATION` is removed in favor of `Zikula\UsersModule\Event\RegistrationPostUpdatedEvent`.
     - `Zikula\UsersModule\RegistrationEvents::FULL_USER_CREATE_VETO` is removed in favor of `Zikula\UsersModule\Event\ActiveUserPreCreatedEvent`.
     - `Zikula\UsersModule\RegistrationEvents::REGISTRATION_FAILED` has been deleted.
+    - `Zikula\UsersModule\UserEvents::DISPLAY_VIEW` is removed in favor of `Zikula\UsersModule\Event\UserAccountDisplayEvent`
     - `Zikula\UsersModule\UserEvents::CREATE_ACCOUNT` is removed in favor of `Zikula\UsersModule\Event\ActiveUserPostCreatedEvent`.
     - `Zikula\UsersModule\UserEvents::UPDATE_ACCOUNT` is removed in favor of `Zikula\UsersModule\Event\ActiveUserPostUpdatedEvent`.
     - `Zikula\UsersModule\UserEvents::DELETE_ACCOUNT` is removed in favor of `Zikula\UsersModule\Event\ActiveUserPostDeletedEvent`.
@@ -99,6 +100,7 @@
   - Support for ancient Macintosh-type line-endings (\r) on user CSV file import has been dropped.
   - Old `pager` Twig function has been removed in favour of a new [Pagination utility](https://docs.ziku.la/LayoutDesign/Templating/Dev/pagination.html).
   - Old `abcpager` Twig function has been removed in favour of a new [AlphaFilter utility](https://docs.ziku.la/LayoutDesign/Templating/Dev/alphafilter.html).
+  - `dispatchEvent` Twig function changed to dispatch _any_ type of event. Old functionality still available in `dispatchGenericEvent`.
   - Dropped vendors:
     - Removed afarkas/html5shiv
     - Removed afarkas/webshim (#3925)

--- a/src/Zikula/CoreBundle/Twig/Extension/EventDispatcherExtension.php
+++ b/src/Zikula/CoreBundle/Twig/Extension/EventDispatcherExtension.php
@@ -34,11 +34,28 @@ class EventDispatcherExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('dispatchEvent', [$this, 'dispatchEvent'])
+            new TwigFunction('dispatchEvent', [$this, 'dispatchEvent']),
+            new TwigFunction('dispatchGenericEvent', [$this, 'dispatchGenericEvent'])
         ];
     }
 
-    public function dispatchEvent(string $name, GenericEvent $providedEvent = null, $subject = null, array $arguments = [], $data = null)
+    /**
+     * @param string $name
+     * @param array $arguments the arguments, MUST be values only and in the correct order
+     */
+    public function dispatchEvent(string $name, $arguments = [])
+    {
+        if (class_exists($name)) {
+            $event = new $name(...$arguments);
+            $this->eventDispatcher->dispatch($event);
+
+            return $event;
+        }
+
+        return null;
+    }
+
+    public function dispatchGenericEvent(string $name, GenericEvent $providedEvent = null, $subject = null, array $arguments = [], $data = null)
     {
         $event = $providedEvent ?? new GenericEvent($subject, $arguments, $data);
         $this->eventDispatcher->dispatch($event, $name);

--- a/src/system/UsersModule/Event/UserAccountDisplayEvent.php
+++ b/src/system/UsersModule/Event/UserAccountDisplayEvent.php
@@ -41,7 +41,8 @@ class UserAccountDisplayEvent extends UserEntityEvent
         return $this->contents;
     }
 
-    public function getContent(string $key): string {
+    public function getContent(string $key): string
+    {
         if (isset($this->contents[$key])) {
             return $this->contents[$key];
         }

--- a/src/system/UsersModule/Event/UserAccountDisplayEvent.php
+++ b/src/system/UsersModule/Event/UserAccountDisplayEvent.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\UsersModule\Event;
+
+/**
+ * A UI event that is triggered when a user's account detail is viewed. This allows another module
+ * to intercept the display of the user account detail in order to add its own information.
+ * To add content to the user account detail, render output and add it to this event.
+ *
+ * When rendering this events output in a template, simply render the event itself
+ * and the magic __toString() method will take care of the rest:
+ *
+ * {% set userAccountDisplayEvent = dispatchEvent('Zikula\\UsersModule\\Event\\UserAccountDisplayEvent', {userEntity}) %}
+ * {{ userAccountDisplayEvent|raw }}
+ */
+class UserAccountDisplayEvent extends UserEntityEvent
+{
+    /**
+     * @var array
+     */
+    private $contents = [];
+
+    public function addContent(string $key = null, string $content = ''): void
+    {
+        $this->contents[$key] = $content;
+    }
+
+    public function getContents(): array
+    {
+        return $this->contents;
+    }
+
+    public function getContent(string $key): string {
+        if (isset($this->contents[$key])) {
+            return $this->contents[$key];
+        }
+
+        return '';
+    }
+
+    public function __toString(): string
+    {
+        $contents = '';
+        foreach ($this->contents as $content) {
+            $contents .= $content;
+        }
+
+        return $contents;
+    }
+}

--- a/src/system/UsersModule/Event/UserAccountDisplayEvent.php
+++ b/src/system/UsersModule/Event/UserAccountDisplayEvent.php
@@ -21,7 +21,7 @@ namespace Zikula\UsersModule\Event;
  * When rendering this events output in a template, simply render the event itself
  * and the magic __toString() method will take care of the rest:
  *
- * {% set userAccountDisplayEvent = dispatchEvent('Zikula\\UsersModule\\Event\\UserAccountDisplayEvent', {userEntity}) %}
+ * {% set userAccountDisplayEvent = dispatchEvent('Zikula\\UsersModule\\Event\\UserAccountDisplayEvent', [userEntity]) %}
  * {{ userAccountDisplayEvent|raw }}
  */
 class UserAccountDisplayEvent extends UserEntityEvent

--- a/src/system/UsersModule/Resources/views/UserAdministration/approve.html.twig
+++ b/src/system/UsersModule/Resources/views/UserAdministration/approve.html.twig
@@ -26,7 +26,7 @@
     </div>
 </fieldset>
 
-{% set userAccountDisplayEvent = dispatchEvent('Zikula\\UsersModule\\Event\\UserAccountDisplayEvent', {user}) %}
+{% set userAccountDisplayEvent = dispatchEvent('Zikula\\UsersModule\\Event\\UserAccountDisplayEvent', [user]) %}
 {{ userAccountDisplayEvent|raw }}
 {{ notifyDisplayHooks(constant('Zikula\\UsersModule\\HookSubscriber\\RegistrationUiHooksSubscriber::REGISTRATION_DISPLAY'), user.uid) }}
 

--- a/src/system/UsersModule/Resources/views/UserAdministration/approve.html.twig
+++ b/src/system/UsersModule/Resources/views/UserAdministration/approve.html.twig
@@ -26,10 +26,8 @@
     </div>
 </fieldset>
 
-{% set eventData = dispatchEvent(constant('Zikula\\UsersModule\\UserEvents::DISPLAY_VIEW'), null, user, {id:user.uid}) %}
-{% for data in eventData %}
-    {{ data|raw }}
-{% endfor %}
+{% set userAccountDisplayEvent = dispatchEvent('Zikula\\UsersModule\\Event\\UserAccountDisplayEvent', {user}) %}
+{{ userAccountDisplayEvent|raw }}
 {{ notifyDisplayHooks(constant('Zikula\\UsersModule\\HookSubscriber\\RegistrationUiHooksSubscriber::REGISTRATION_DISPLAY'), user.uid) }}
 
 <fieldset>

--- a/src/system/UsersModule/UserEvents.php
+++ b/src/system/UsersModule/UserEvents.php
@@ -19,16 +19,6 @@ namespace Zikula\UsersModule;
 class UserEvents
 {
     /**
-     * A hook-like UI event that is triggered when a user's account detail is viewed. This allows another module
-     * to intercept the display of the user account detail in order to add its own information.
-     * To add display elements to the user account detail, render output and add this as an element in the event's
-     * data array.
-     * The subject contains the user's account record.
-     * The `'id'` argument contain's the user's uid.
-     */
-    public const DISPLAY_VIEW = 'module.users.ui.display_view';
-
-    /**
      * A hook-like event process that is triggered when the delete confirmation form is displayed. It allows other modules
      * to intercept and add to the delete confirmation form.
      * The subject of the event is not set.


### PR DESCRIPTION
- `Zikula\UsersModule\UserEvents::DISPLAY_VIEW` is removed in favor of `Zikula\UsersModule\Event\UserAccountDisplayEvent`
  - `dispatchEvent` Twig function changed to dispatch _any_ type of event. Old functionality still available in `dispatchGenericEvent`.