### PR TITLE
Event updates

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -49,8 +49,10 @@
     - `Zikula\UsersModule\UserEvents::CREATE_ACCOUNT` is removed in favor of `Zikula\UsersModule\Event\ActiveUserPostCreatedEvent`.
     - `Zikula\UsersModule\UserEvents::UPDATE_ACCOUNT` is removed in favor of `Zikula\UsersModule\Event\ActiveUserPostUpdatedEvent`.
     - `Zikula\UsersModule\UserEvents::DELETE_ACCOUNT` is removed in favor of `Zikula\UsersModule\Event\ActiveUserPostDeletedEvent`.
-    - `Zikula\UsersModule\UserEvents::EDIT_FORM` is removed in favor of `Zikula\UsersModule\Event\EditUserFormPostCreatedEvent`
     - `Zikula\UsersModule\UserEvents::DELETE_VALIDATE` has been deleted.
+    - `Zikula\UsersModule\UserEvents::DELETE_FORM` is removed in favor of `Zikula\UsersModule\Event\DeleteUserFormPostCreatedEvent`.
+    - `Zikula\UsersModule\UserEvents::DELETE_PROCESS` is removed in favor of `Zikula\UsersModule\Event\DeleteUserFormPostValidatedEvent`.
+    - `Zikula\UsersModule\UserEvents::EDIT_FORM` is removed in favor of `Zikula\UsersModule\Event\EditUserFormPostCreatedEvent`
       - The event class changed from `Zikula\UsersModule\Event\UserFormAwareEvent` to `EditUserFormPostCreatedEvent`
     - `Zikula\UsersModule\UserEvents::EDIT_FORM_HANDLE` is removed in favor of `Zikula\UsersModule\Event\EditUserFormPostValidatedEvent`
       - The event class changed from `Zikula\UsersModule\Event\UserFormDataEvent` to `EditUserFormPostValidatedEvent`

--- a/src/system/UsersModule/Controller/UserAdministrationController.php
+++ b/src/system/UsersModule/Controller/UserAdministrationController.php
@@ -25,7 +25,6 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Translation\Extractor\Annotation\Desc;
 use Zikula\Bundle\CoreBundle\Controller\AbstractController;
-use Zikula\Bundle\CoreBundle\Event\GenericEvent;
 use Zikula\Bundle\CoreBundle\Filter\AlphaFilter;
 use Zikula\Bundle\CoreBundle\Response\PlainResponse;
 use Zikula\Bundle\HookBundle\Dispatcher\HookDispatcherInterface;
@@ -61,7 +60,6 @@ use Zikula\UsersModule\Helper\AdministrationActionsHelper;
 use Zikula\UsersModule\Helper\MailHelper;
 use Zikula\UsersModule\Helper\RegistrationHelper;
 use Zikula\UsersModule\HookSubscriber\UserManagementUiHooksSubscriber;
-use Zikula\UsersModule\UserEvents;
 
 /**
  * Class UserAdministrationController

--- a/src/system/UsersModule/Event/DeleteUserFormPostCreatedEvent.php
+++ b/src/system/UsersModule/Event/DeleteUserFormPostCreatedEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\UsersModule\Event;
+
+use Zikula\Bundle\FormExtensionBundle\Event\FormPostCreatedEvent;
+
+/**
+ * Called on user deletion confirmation form.
+ * See also DeleteUserFormPostValidatedEvent
+ */
+class DeleteUserFormPostCreatedEvent extends FormPostCreatedEvent
+{
+}

--- a/src/system/UsersModule/Event/DeleteUserFormPostValidatedEvent.php
+++ b/src/system/UsersModule/Event/DeleteUserFormPostValidatedEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\UsersModule\Event;
+
+/**
+ * Called on user delete form to handle form submission.
+ * See also DeleteUserFormPostCreatedEvent
+ */
+class DeleteUserFormPostValidatedEvent extends UserFormPostValidatedEvent
+{
+}

--- a/src/system/UsersModule/Helper/DeleteHelper.php
+++ b/src/system/UsersModule/Helper/DeleteHelper.php
@@ -16,7 +16,6 @@ namespace Zikula\UsersModule\Helper;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Zikula\Bundle\CoreBundle\Event\GenericEvent;
 use Zikula\Bundle\HookBundle\Dispatcher\HookDispatcherInterface;
 use Zikula\Bundle\HookBundle\Hook\ProcessHook;
 use Zikula\GroupsModule\Constant;
@@ -25,10 +24,8 @@ use Zikula\UsersModule\Constant as UsersConstant;
 use Zikula\UsersModule\Entity\RepositoryInterface\UserRepositoryInterface;
 use Zikula\UsersModule\Entity\UserEntity;
 use Zikula\UsersModule\Event\ActiveUserPostDeletedEvent;
-use Zikula\UsersModule\Event\DeleteUserFormPostValidatedEvent;
 use Zikula\UsersModule\Event\RegistrationPostDeletedEvent;
 use Zikula\UsersModule\HookSubscriber\UserManagementUiHooksSubscriber;
-use Zikula\UsersModule\UserEvents;
 
 class DeleteHelper
 {

--- a/src/system/UsersModule/Helper/DeleteHelper.php
+++ b/src/system/UsersModule/Helper/DeleteHelper.php
@@ -25,6 +25,7 @@ use Zikula\UsersModule\Constant as UsersConstant;
 use Zikula\UsersModule\Entity\RepositoryInterface\UserRepositoryInterface;
 use Zikula\UsersModule\Entity\UserEntity;
 use Zikula\UsersModule\Event\ActiveUserPostDeletedEvent;
+use Zikula\UsersModule\Event\DeleteUserFormPostValidatedEvent;
 use Zikula\UsersModule\Event\RegistrationPostDeletedEvent;
 use Zikula\UsersModule\HookSubscriber\UserManagementUiHooksSubscriber;
 use Zikula\UsersModule\UserEvents;
@@ -119,7 +120,6 @@ class DeleteHelper
         } else {
             $this->eventDispatcher->dispatch(new RegistrationPostDeletedEvent($user));
         }
-        $this->eventDispatcher->dispatch(new GenericEvent(null, ['id' => $user->getUid()]), UserEvents::DELETE_PROCESS);
         $this->hookDispatcher->dispatch(UserManagementUiHooksSubscriber::DELETE_PROCESS, new ProcessHook($user->getUid()));
         $this->userRepository->removeAndFlush($user);
     }

--- a/src/system/UsersModule/Resources/views/UserAdministration/delete.html.twig
+++ b/src/system/UsersModule/Resources/views/UserAdministration/delete.html.twig
@@ -9,9 +9,8 @@
 {% endfor %}
 {{ form_start(form) }}
 {{ form_errors(form) }}
-{% set eventData = dispatchEvent(constant('Zikula\\UsersModule\\UserEvents::DELETE_FORM')) %}
-{% for data in eventData %}
-    {{ data }}
+{% for template in additionalTemplates %}
+    include(template.view, template.params, ignore_missing = true)
 {% endfor %}
 {{ notifyDisplayHooks(constant('Zikula\\UsersModule\\HookSubscriber\\UserManagementUiHooksSubscriber::DELETE_FORM')) }}
 <div class="form-group row">

--- a/src/system/UsersModule/UserEvents.php
+++ b/src/system/UsersModule/UserEvents.php
@@ -19,16 +19,6 @@ namespace Zikula\UsersModule;
 class UserEvents
 {
     /**
-     * A hook-like event process that is triggered when the delete confirmation form is displayed. It allows other modules
-     * to intercept and add to the delete confirmation form.
-     * The subject of the event is not set.
-     * The the argument `'id'` is the uid of the user who will be deleted if confirmed.
-     */
-    public const DELETE_FORM = 'module.users.ui.form_delete';
-
-    public const DELETE_PROCESS = 'module.users.ui.process_delete';
-
-    /**
      * A hook-like UI event triggered when the users search form is displayed. Allows other
      * modules to intercept and insert their own elements for submission to the search form.
      * To add elements to the search form, render the output and then add this as an array element to the event's


### PR DESCRIPTION
- `Zikula\UsersModule\UserEvents::DELETE_FORM` is removed in favor of `Zikula\UsersModule\Event\DeleteUserFormPostCreatedEvent`.
    - `Zikula\UsersModule\UserEvents::DELETE_PROCESS` is removed in favor of `Zikula\UsersModule\Event\DeleteUserFormPostValidatedEvent`.
