### PR TITLE
LOGIN_VETO event

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -64,6 +64,7 @@
     - `Zikula\UsersModule\AccessEvents::AUTHENTICATION_FORM_HANDLE` is removed in favor of `Zikula\UsersModule\Event\LoginFormPostValidatedEvent`
       - The event class changed from `Zikula\UsersModule\Event\UserFormDataEvent` to `LoginFormPostValidatedEvent`
     - `Zikula\UsersModule\AccessEvents::LOGIN_STARTED` has been deleted.
+    - `Zikula\UsersModule\AccessEvents::LOGIN_VETO` is removed in favor of `Zikula\UsersModule\Event\UserPreSuccessfulLoginEvent`
   - MailerApi and Swift_Mailer is fully removed in favor of the Symfony Mailer Component. Mailer is configurable in MailerModule (#4000).
   - Interface extensions and amendments
     - Removed second argument (`$first = true`) from `ZikulaHttpKernelInterface` methods `getModule`, `getTheme` and `isBundle` (#3377).

--- a/docs/AccessControl/Authentication/Dev/AuthenticationRelatedEvents.md
+++ b/docs/AccessControl/Authentication/Dev/AuthenticationRelatedEvents.md
@@ -23,6 +23,6 @@ currentMenu: authentication
 
 - React to the deletion of a pending user.
 
-`Zikula\UsersModule\AccessEvents::LOGIN_VETO`
+`Zikula\UsersModule\Event\UserPreSuccessfulLoginEvent`
 
 - force the halt of an otherwise successful login and require user action.

--- a/src/system/RoutesModule/Listener/Base/AbstractUserLoginListener.php
+++ b/src/system/RoutesModule/Listener/Base/AbstractUserLoginListener.php
@@ -17,6 +17,7 @@ namespace Zikula\RoutesModule\Listener\Base;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Zikula\Bundle\CoreBundle\Event\GenericEvent;
 use Zikula\UsersModule\AccessEvents;
+use Zikula\UsersModule\Event\UserPreSuccessfulLoginEvent;
 
 /**
  * Event handler base class for user login events.
@@ -26,44 +27,35 @@ abstract class AbstractUserLoginListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            AccessEvents::LOGIN_VETO    => ['veto', 5],
+            UserPreSuccessfulLoginEvent::class => ['veto', 5],
             AccessEvents::LOGIN_SUCCESS => ['succeeded', 5],
             AccessEvents::LOGIN_FAILED  => ['failed', 5]
         ];
     }
 
     /**
-     * Listener for the `module.users.ui.login.veto` event.
+     * Listener for the `UserPreSuccessfulLoginEvent`.
      *
-     * Occurs immediately prior to a log-in that is expected to succeed.
-     * (All prerequisites for a successful login have been checked and are satisfied.)
-     * This event allows a module to intercept the login process and prevent a successful login from taking place.
+     * Occurs immediately prior to a log-in that is expected to succeed. (All prerequisites for a
+     * successful login have been checked and are satisfied.) This event allows an extension to
+     * intercept the login process and prevent a successful login from taking place.
      *
-     * A handler that needs to veto a login attempt should call `stopPropagation()`. This will prevent other handlers
-     * from receiving the event, will return to the login process, and will prevent the login from taking place.
-     * A handler that vetoes a login attempt should set an appropriate error message and give any additional
+     * A handler that needs to veto a login attempt should call `stopPropagation()`.
+     * This will prevent other handlers from receiving the event, will
+     * return to the login process, and will prevent the login from taking place. A handler that
+     * vetoes a login attempt should set an appropriate session flash message and give any additional
      * feedback to the user attempting to log in that might be appropriate.
      *
-     * If vetoing the login, the 'returnUrl' argument should be set to redirect the user to an appropriate action.
+     * If vetoing the login, the 'returnUrl' property should be set to redirect the user to an appropriate action.
+     * Also, a 'flash' property may be set to provide information to the user for the veto.
      *
-     * Note: the user __will not__ be logged in when the event handler is executing.
-     * Any attempt to check a user's permissions, his logged-in status, or any operation will
-     * return a value equivalent to what an anonymous (guest) user would see.
-     * Care should be taken to ensure that sensitive operations done within a handler for this event
+     * Note: the user __will not__ be logged in at the point where the event handler is
+     * executing. Any attempt to check a user's permissions, his logged-in status, or any
+     * operation will return a value equivalent to what an anonymous (guest) user would see. Care
+     * should be taken to ensure that sensitive operations done within a handler for this event
      * do not introduce breaches of security.
-     *
-     * The subject of the event will contain the UserEntity.
-     * The arguments of the event are:
-     *     `'authentication_method'` will contain the name of the module
-     *     and the name of the method that was used to authenticated the user.
-     *
-     * You can access general data available in the event.
-     *
-     * The event name:
-     *     `echo 'Event: ' . $event->getName();`
-     *
      */
-    public function veto(GenericEvent $event): void
+    public function veto(UserPreSuccessfulLoginEvent $event): void
     {
     }
 

--- a/src/system/RoutesModule/Listener/Base/AbstractUserRegistrationListener.php
+++ b/src/system/RoutesModule/Listener/Base/AbstractUserRegistrationListener.php
@@ -81,8 +81,8 @@ abstract class AbstractUserRegistrationListener implements EventSubscriberInterf
      * If the registration record is a fully activated user, and the Users module is configured for automatic log-in,
      * then the system's next step (without any interaction from the user) will be the log-in process. All the customary
      * events that might fire during the log-in process could be fired at this point, including (but not limited to)
-     * `user.login.veto` (which might result in the user having to perform some action in order to proceed with the
-     * log-in process), `user.login.succeeded`, and/or `user.login.failed`.
+     * `Zikula\UsersModule\Event\UserPreSuccessfulLoginEvent` (which might result in the user having to perform some action
+     * in order to proceed with the log-in process), `user.login.succeeded`, and/or `user.login.failed`.
      *
      * The `redirectUrl` property controls where the user will be directed at the end of the registration process.
      * Initially, it will be blank, indicating that the default action should be taken. The default action depends on two

--- a/src/system/UsersModule/AccessEvents.php
+++ b/src/system/UsersModule/AccessEvents.php
@@ -19,32 +19,6 @@ namespace Zikula\UsersModule;
 class AccessEvents
 {
     /**
-     * Occurs immediately prior to a log-in that is expected to succeed. (All prerequisites for a
-     * successful login have been checked and are satisfied.) This event allows a module to
-     * intercept the login process and prevent a successful login from taking place.
-     *
-     * A handler that needs to veto a login attempt
-     * should call `stopPropagation()`. This will prevent other handlers from receiving the event, will
-     * return to the login process, and will prevent the login from taking place. A handler that
-     * vetoes a login attempt should set an appropriate session flash message and give any additional
-     * feedback to the user attempting to log in that might be appropriate.
-     *
-     * If vetoing the login, the 'returnUrl' argument should be set to redirect the user to an appropriate action.
-     * Also, a 'flash' argument may be set to provide information to the user for the veto.
-     *
-     * Note: the user __will not__ be logged in at the point where the event handler is
-     * executing. Any attempt to check a user's permissions, his logged-in status, or any
-     * operation will return a value equivalent to what an anonymous (guest) user would see. Care
-     * should be taken to ensure that sensitive operations done within a handler for this event
-     * do not introduce breaches of security.
-     *
-     * The subject of the event will contain the userEntity
-     * The arguments of the event are:
-     * `'authenticationMethod'` will contain the alias (name) of the method that was used to authenticate the user.
-     */
-    public const LOGIN_VETO = 'user.login.veto';
-
-    /**
      * Occurs right after a successful attempt to log in, and just prior to redirecting the user to the desired page.
      *
      * The event subject contains the userEntity

--- a/src/system/UsersModule/Event/RedirectableUserEntityEvent.php
+++ b/src/system/UsersModule/Event/RedirectableUserEntityEvent.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Zikula\UsersModule\Event;
 
-use Zikula\UsersModule\Entity\UserEntity;
-
 /**
  * An UserEntityEvent that adds the ability to set/get a redirectUrl.
  */
@@ -25,9 +23,8 @@ class RedirectableUserEntityEvent extends UserEntityEvent
      */
     private $redirectUrl;
 
-    public function __construct(UserEntity $userEntity, string $redirectUrl = '')
+    public function setRedirectUrl(string $redirectUrl): void
     {
-        parent::__construct($userEntity);
         $this->redirectUrl = $redirectUrl;
     }
 

--- a/src/system/UsersModule/Event/RegistrationPostSuccessEvent.php
+++ b/src/system/UsersModule/Event/RegistrationPostSuccessEvent.php
@@ -23,8 +23,8 @@ namespace Zikula\UsersModule\Event;
  * If the registration record is a fully activated user, and the Users module is configured for automatic log-in,
  * then the system's next step (without any interaction from the user) will be the log-in process. All the customary
  * events that might fire during the log-in process could be fired at this point, including (but not limited to)
- * `user.login.veto` (which might result in the user having to perform some action in order to proceed with the
- * log-in process), `user.login.succeeded`, and/or `user.login.failed`.
+ * `Zikula\UsersModule\Event\UserPreSuccessfulLoginEvent` (which might result in the user having to perform some action
+ * in order to proceed with the log-in process), `user.login.succeeded`, and/or `user.login.failed`.
  *
  * The `redirectUrl` property controls where the user will be directed at the end of the registration process.
  * Initially, it will be blank, indicating that the default action should be taken. The default action depends on two

--- a/src/system/UsersModule/Event/UserPreSuccessfulLoginEvent.php
+++ b/src/system/UsersModule/Event/UserPreSuccessfulLoginEvent.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\UsersModule\Event;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+use Zikula\UsersModule\Entity\UserEntity;
+
+/**
+ * Occurs immediately prior to a log-in that is expected to succeed. (All prerequisites for a
+ * successful login have been checked and are satisfied.) This event allows an extension to
+ * intercept the login process and prevent a successful login from taking place.
+ *
+ * A handler that needs to veto a login attempt should call `stopPropagation()`.
+ * This will prevent other handlers from receiving the event, will
+ * return to the login process, and will prevent the login from taking place. A handler that
+ * vetoes a login attempt should set an appropriate session flash message and give any additional
+ * feedback to the user attempting to log in that might be appropriate.
+ *
+ * If vetoing the login, the 'returnUrl' property should be set to redirect the user to an appropriate action.
+ * Also, a 'flash' property may be set to provide information to the user for the veto.
+ *
+ * Note: the user __will not__ be logged in at the point where the event handler is
+ * executing. Any attempt to check a user's permissions, his logged-in status, or any
+ * operation will return a value equivalent to what an anonymous (guest) user would see. Care
+ * should be taken to ensure that sensitive operations done within a handler for this event
+ * do not introduce breaches of security.
+ */
+class UserPreSuccessfulLoginEvent extends RedirectableUserEntityEvent implements StoppableEventInterface
+{
+    private $propagationStopped = false;
+
+    /**
+     * @var string
+     */
+    private $authenticationMethod;
+
+    /**
+     * @var array
+     */
+    private $flashes = [];
+
+    public function __construct(UserEntity $userEntity, string $authenticationMethod)
+    {
+        parent::__construct($userEntity);
+        $this->authenticationMethod = $authenticationMethod;
+    }
+
+    public function isPropagationStopped(): bool
+    {
+        return $this->propagationStopped;
+    }
+
+    public function stopPropagation(): void
+    {
+        $this->propagationStopped = true;
+    }
+
+    public function getAuthenticationMethod(): string
+    {
+        return $this->authenticationMethod;
+    }
+
+    public function getFlashesAsString(): string
+    {
+        return implode('<br />', $this->flashes);
+    }
+
+    public function hasFlashes(): bool
+    {
+        return !empty($this->flashes);
+    }
+
+    public function addFlash(string $message): void
+    {
+        $this->flashes[] = $message;
+    }
+}

--- a/src/system/ZAuthModule/Listener/UserEventListener.php
+++ b/src/system/ZAuthModule/Listener/UserEventListener.php
@@ -16,10 +16,8 @@ namespace Zikula\ZAuthModule\Listener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
-use Zikula\Bundle\CoreBundle\Event\GenericEvent;
-use Zikula\UsersModule\AccessEvents;
 use Zikula\UsersModule\Constant as UsersConstant;
-use Zikula\UsersModule\Entity\UserEntity;
+use Zikula\UsersModule\Event\UserPreSuccessfulLoginEvent;
 use Zikula\ZAuthModule\ZAuthConstant;
 
 class UserEventListener implements EventSubscriberInterface
@@ -43,41 +41,34 @@ class UserEventListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            AccessEvents::LOGIN_VETO => ['forcedPasswordChange']
+            UserPreSuccessfulLoginEvent::class => ['forcedPasswordChange']
         ];
     }
 
     /**
-     * Vetos (denies) a login attempt, and forces the user to change his password.
-     * This handler is triggered by the 'user.login.veto' event.  It vetos (denies) a
+     * Vetoes (denies) a login attempt, and forces the user to change his password.
+     * This handler is triggered by the 'UserPreSuccessfulLoginEvent'.  It vetoes (denies) a
      * login attempt if the users's account record is flagged to force the user to change
      * his password maintained by the Users module. If the user does not maintain a
      * password on his Users account (e.g., he registered with and logs in with a Google
      * Account or an OpenID, and never established a Users password), then this handler
      * will not trigger a change of password.
      *
-     * @param GenericEvent $event The event that triggered this handler
-     *
      * @see \Zikula\ZAuthModule\Controller\AccountController::changePasswordAction
      */
-    public function forcedPasswordChange(GenericEvent $event): void
+    public function forcedPasswordChange(UserPreSuccessfulLoginEvent $event): void
     {
-        /** @var UserEntity $user */
-        $user = $event->getSubject();
+        $user = $event->getUser();
         if ($user->getAttributes()->containsKey(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY) && $user->getAttributes()->get(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY)) {
             $event->stopPropagation();
-            $event->setArgument('returnUrl', $this->router->generate('zikulazauthmodule_account_changepassword'));
+            $event->setRedirectUrl($this->router->generate('zikulazauthmodule_account_changepassword'));
 
             $request = $this->requestStack->getCurrentRequest();
             if ($request->hasSession() && ($session = $request->getSession())) {
-                $session->set('authenticationMethod', $event->getArgument('authenticationMethod'));
+                $session->set('authenticationMethod', $event->getAuthenticationMethod());
                 $session->set(UsersConstant::FORCE_PASSWORD_SESSION_UID_KEY, $user->getUid());
-
-                $session->getFlashBag()->add(
-                    'error',
-                    "Your log-in request was not completed. You must change your web site account's password first."
-                );
             }
+            $event->addFlash("Your log-in request was not completed. You must change your web site account's password first.");
         }
     }
 }


### PR DESCRIPTION
- `Zikula\UsersModule\AccessEvents::LOGIN_VETO` is removed in favor of `Zikula\UsersModule\Event\UserPreSuccessfulLoginEvent`

