### PR TITLE
remove extends Event from several events

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -88,6 +88,12 @@
     - `Zikula\ExtensionsModule\ExtensionEvents::EXTENSION_ENABLE` is removed in favor of `Zikula\ExtensionsModule\Event\ExtensionPostEnabledEvent`.
     - `Zikula\ExtensionsModule\ExtensionEvents::EXTENSION_DISABLE` is removed in favor of `Zikula\ExtensionsModule\Event\ExtensionPostDisabledEvent`.
     - `Zikula\ExtensionsModule\ExtensionEvents::EXTENSION_REMOVE` is removed in favor of `Zikula\ExtensionsModule\Event\ExtensionPostRemoveEvent`.
+    - `Zikula\ExtensionsModule\Event\ConnectionsMenuEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
+    - `Zikula\MenuModule\Event\ConfigureMenuEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
+    - `Zikula\ThemeModule\Bridge\Event\TwigPostRenderEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
+    - `Zikula\ThemeModule\Bridge\Event\TwigPreRenderEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
+    - `Zikula\Bundle\FormExtensionBundle\Event\FormTypeChoiceEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
+    - `Zikula\Bundle\HookBundle\Hook\Hook` (and all its subclasses) no longer extends `Symfony\Contracts\EventDispatcher\Event`.
   - MailerApi and Swift_Mailer is fully removed in favor of the Symfony Mailer Component. Mailer is configurable in MailerModule (#4000).
   - Interface extensions and amendments
     - Removed second argument (`$first = true`) from `ZikulaHttpKernelInterface` methods `getModule`, `getTheme` and `isBundle` (#3377).

--- a/src/Zikula/FormExtensionBundle/Event/FormTypeChoiceEvent.php
+++ b/src/Zikula/FormExtensionBundle/Event/FormTypeChoiceEvent.php
@@ -13,13 +13,9 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\FormExtensionBundle\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Zikula\Bundle\FormExtensionBundle\FormTypesChoices;
 
-/**
- * Form type choice event.
- */
-class FormTypeChoiceEvent extends Event
+class FormTypeChoiceEvent
 {
     public const NAME = 'zikula_form_extension_bundle.form_type_choice_event';
 

--- a/src/Zikula/HookBundle/Dispatcher/HookDispatcher.php
+++ b/src/Zikula/HookBundle/Dispatcher/HookDispatcher.php
@@ -13,18 +13,12 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\HookBundle\Dispatcher;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Zikula\Bundle\HookBundle\Hook\Hook;
 
-/**
- * HookDispatcher class.
- */
 class HookDispatcher implements HookDispatcherInterface
 {
     /**
-     * Storage.
-     *
      * @var StorageInterface
      */
     private $storage;
@@ -47,7 +41,7 @@ class HookDispatcher implements HookDispatcherInterface
         return $this->storage;
     }
 
-    public function dispatch(string $name, Hook $hook): Event
+    public function dispatch(string $name, Hook $hook): Hook
     {
         $this->decorateHook($name, $hook);
         if (!$hook->getAreaId()) {

--- a/src/Zikula/HookBundle/Dispatcher/HookDispatcherInterface.php
+++ b/src/Zikula/HookBundle/Dispatcher/HookDispatcherInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\HookBundle\Dispatcher;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Zikula\Bundle\HookBundle\Dispatcher\Exception\LogicException;
 use Zikula\Bundle\HookBundle\Hook\Hook;
 
@@ -30,7 +29,7 @@ interface HookDispatcherInterface
     /**
      * Dispatch hook listeners.
      */
-    public function dispatch(string $eventName, Hook $hook): Event;
+    public function dispatch(string $eventName, Hook $hook): Hook;
 
     /**
      * Return all bindings for a given area.

--- a/src/Zikula/HookBundle/Hook/Hook.php
+++ b/src/Zikula/HookBundle/Hook/Hook.php
@@ -13,12 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\HookBundle\Hook;
 
-use Symfony\Contracts\EventDispatcher\Event;
-
-/**
- * Hook class.
- */
-class Hook extends Event
+class Hook
 {
     /**
      * Subscriber object id.
@@ -35,8 +30,6 @@ class Hook extends Event
     protected $areaId;
 
     /**
-     * Caller.
-     *
      * @var string
      */
     protected $caller;

--- a/src/Zikula/HookBundle/Twig/Extension/HookExtension.php
+++ b/src/Zikula/HookBundle/Twig/Extension/HookExtension.php
@@ -106,8 +106,11 @@ class HookExtension extends AbstractExtension
      */
     public function notifyFilters(string $content, string $filterEventName)
     {
-        $hook = new FilterHook($content);
+        $hook = $this->hookDispatcher->dispatch($filterEventName, new FilterHook($content));
+        if ($hook instanceof FilterHook) {
+            return $hook->getData();
+        }
 
-        return $this->hookDispatcher->dispatch($filterEventName, $hook)->getData();
+        return $content;
     }
 }

--- a/src/system/ExtensionsModule/Event/ConnectionsMenuEvent.php
+++ b/src/system/ExtensionsModule/Event/ConnectionsMenuEvent.php
@@ -14,9 +14,8 @@ declare(strict_types=1);
 namespace Zikula\ExtensionsModule\Event;
 
 use Knp\Menu\ItemInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 
-class ConnectionsMenuEvent extends Event
+class ConnectionsMenuEvent
 {
     /**
      * The full menu object

--- a/src/system/MenuModule/Event/ConfigureMenuEvent.php
+++ b/src/system/MenuModule/Event/ConfigureMenuEvent.php
@@ -15,12 +15,11 @@ namespace Zikula\MenuModule\Event;
 
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event class for extending menus.
  */
-class ConfigureMenuEvent extends Event
+class ConfigureMenuEvent
 {
     public const POST_CONFIGURE = 'zikulamenumodule.menu_post_configure';
 

--- a/src/system/ThemeModule/Bridge/Event/TwigPostRenderEvent.php
+++ b/src/system/ThemeModule/Bridge/Event/TwigPostRenderEvent.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ThemeModule\Bridge\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
-
-class TwigPostRenderEvent extends Event
+class TwigPostRenderEvent
 {
     /**
      * @var string

--- a/src/system/ThemeModule/Bridge/Event/TwigPreRenderEvent.php
+++ b/src/system/ThemeModule/Bridge/Event/TwigPreRenderEvent.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ThemeModule\Bridge\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
-
-class TwigPreRenderEvent extends Event
+class TwigPreRenderEvent
 {
     /**
      * @var string


### PR DESCRIPTION
- `Zikula\ExtensionsModule\Event\ConnectionsMenuEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
    - `Zikula\MenuModule\Event\ConfigureMenuEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
    - `Zikula\ThemeModule\Bridge\Event\TwigPostRenderEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
    - `Zikula\ThemeModule\Bridge\Event\TwigPreRenderEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
    - `Zikula\Bundle\FormExtensionBundle\Event\FormTypeChoiceEvent` no longer extends `Symfony\Contracts\EventDispatcher\Event`.
    - `Zikula\Bundle\HookBundle\Hook\Hook` (and all its subclasses) no longer extends `Symfony\Contracts\EventDispatcher\Event`.