### PR TITLE
remove non-default languages from config when multilingual is disabled.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -136,7 +136,8 @@
   - Fixed problem where stale pending registrations were not deleted (#4069).
   - Fixed problem with preview of theme (#3957).
   - Fixed problem where hooks tables are not updated when upgrading from Core-1.x.x (#3977).
-  - fix orphaned users on attempt to delete stale pending registrations (#4218).
+  - Fix orphaned users on attempt to delete stale pending registrations (#4218).
+  - Fix non-default languages being available when multilingual is disabled (#3938).
 
 - Features:
   - Utilise autowiring and autoconfiguring functionality from Symfony (#3940).

--- a/src/system/SettingsModule/Api/LocaleApi.php
+++ b/src/system/SettingsModule/Api/LocaleApi.php
@@ -17,6 +17,8 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Intl\Locales;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
+use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
+use Zikula\ExtensionsModule\Api\VariableApi;
 use Zikula\SettingsModule\Api\ApiInterface\LocaleApiInterface;
 use Zikula\SettingsModule\Helper\LocaleConfigHelper;
 
@@ -37,6 +39,11 @@ class LocaleApi implements LocaleApiInterface
      * @var RequestStack
      */
     private $requestStack;
+
+    /**
+     * @var VariableApiInterface
+     */
+    private $variableApi;
 
     /**
      * @var LocaleConfigHelper
@@ -66,6 +73,7 @@ class LocaleApi implements LocaleApiInterface
     public function __construct(
         ZikulaHttpKernelInterface $kernel,
         RequestStack $requestStack,
+        VariableApiInterface $variableApi,
         LocaleConfigHelper $localeConfigHelper,
         string $defaultLocale = 'en',
         string $installed = '0.0.0'
@@ -76,6 +84,7 @@ class LocaleApi implements LocaleApiInterface
         ];
         $this->kernel = $kernel;
         $this->requestStack = $requestStack;
+        $this->variableApi = $variableApi;
         $this->localeConfigHelper = $localeConfigHelper;
         $this->defaultLocale = $defaultLocale;
         $this->installed = '0.0.0' !== $installed;
@@ -99,8 +108,11 @@ class LocaleApi implements LocaleApiInterface
             return $this->supportedLocales[$this->sectionKey];
         }
 
-        // read in locales from translation path
-        $this->collectLocales($includeRegions);
+        $multiLingualEnabled = (bool) $this->variableApi->get(VariableApi::CONFIG, 'multilingual', 1);
+        if ($multiLingualEnabled) {
+            // read in locales from translation path
+            $this->collectLocales($includeRegions);
+        }
 
         // ensure config file is still in sync
         if (true === $includeRegions) {

--- a/src/system/SettingsModule/Tests/Api/LocaleApiTest.php
+++ b/src/system/SettingsModule/Tests/Api/LocaleApiTest.php
@@ -16,6 +16,7 @@ namespace Zikula\SettingsModule\Tests\Api;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
+use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
 use Zikula\SettingsModule\Api\ApiInterface\LocaleApiInterface;
 use Zikula\SettingsModule\Api\LocaleApi;
 use Zikula\SettingsModule\Helper\LocaleConfigHelper;
@@ -102,7 +103,9 @@ class LocaleApiTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
+        $variableApi = $this->getMockBuilder(VariableApiInterface::class)->getMock();
+        $variableApi->method('get')->willReturn(1);
 
-        return new LocaleApi($kernel, $requestStack, $localeConfigHelper, 'en', '3.0.0');
+        return new LocaleApi($kernel, $requestStack, $variableApi, $localeConfigHelper, 'en', '3.0.0');
     }
 }


### PR DESCRIPTION
fixes #3938