### PR TITLE
integrate dynamic site name and slogan

### DIFF
--- a/docs/LayoutDesign/Templating/Functions.md
+++ b/docs/LayoutDesign/Templating/Functions.md
@@ -25,6 +25,8 @@ functions, filters, tags, tests and global variables.
 - showflashes(params = [])
 - stateLabel(extensionEntity, upgradedExtensions = null)
 - zasset(path)
+- siteName()
+- siteSlogan()
 
 ### Hooks
 

--- a/docs/LayoutDesign/Templating/Functions.md
+++ b/docs/LayoutDesign/Templating/Functions.md
@@ -10,26 +10,31 @@ functions, filters, tags, tests and global variables.
 
 ## Functions
 
-### Useful
+### General
 
 - array_unset(array, key)
 - callFunc(callable, params = [])
-- defaultPath(extensionName, type = 'user')
-- dispatchEvent($name, GenericEvent $providedEvent = null, $subject = null, array $arguments = [], $data = null)
-- getModVar(module, name, default = null)
-- getSystemVar(name, default = null)
 - hasPermission(component, instance, level)
-- pageAddAsset(type, value, weight = 100)
-- pageGetVar(name, default = null)
-- pageSetVar(name, value)
 - showflashes(params = [])
-- stateLabel(extensionEntity, upgradedExtensions = null)
-- zasset(path)
 - siteName()
 - siteSlogan()
 
-### Hooks
+### Themes and Assets
 
+- pageAddAsset(type, value, weight = 100)
+- pageGetVar(name, default = null)
+- pageSetVar(name, value)
+- zasset(path)
+
+### Extensions and Variables
+
+- getModVar(module, name, default = null)
+- getSystemVar(name, default = null)
+- defaultPath(extensionName, type = 'user')
+
+### Events and Hooks
+
+- dispatchEvent($name, GenericEvent $providedEvent = null, $subject = null, array $arguments = [], $data = null)
 - notifyDisplayHooks(eventName, id = null, urlObject = null)
 - routeUrl(routeName, routeParameters = [], fragment = null)
 
@@ -72,6 +77,7 @@ functions, filters, tags, tests and global variables.
 
 - adminPanelMenu()
 - extensionActions(extension)
+- stateLabel(extensionEntity, upgradedExtensions = null)
 - getPreviewImagePath(themeName, size = "medium")
 
 #### Blocks

--- a/src/Zikula/CoreBundle/Site/SiteDefinition.php
+++ b/src/Zikula/CoreBundle/Site/SiteDefinition.php
@@ -52,13 +52,12 @@ class SiteDefinition implements SiteDefinitionInterface
 
     public function getName(): string
     {
-        return $this->variableApi->getSystemVar('sitename', '');
+        return $this->variableApi->getSystemVar('sitename', $this->variableApi->getSystemVar('sitename_en'));
     }
 
     public function getSlogan(): string
     {
-        // not used yet, refs #3972
-        return $this->variableApi->getSystemVar('slogan', '');
+        return $this->variableApi->getSystemVar('slogan', $this->variableApi->getSystemVar('slogan_en'));
     }
 
     public function getPageTitle(): string

--- a/src/system/AtomTheme/Resources/views/master.html.twig
+++ b/src/system/AtomTheme/Resources/views/master.html.twig
@@ -3,13 +3,13 @@
     <link rel="alternate" type="text/html" href="{{ pagevars.homepath }}" />
     <link rel="self" type="application/atom+xml" href="{{ app.request.pathInfo }}" />
     <title>{{ pagevars.title }}</title>
-    <subtitle>{{ getSystemVar('slogan') }}</subtitle>
+    <subtitle>{{ siteSlogan() }}</subtitle>
     <id>{{ atomId() }}</id>
     <updated>{{ atomFeedLastUpdated() }}</updated>
     <author>
         <name>{{ getSystemVar('adminmail') }}</name>
     </author>
     <generator>Zikula {{ getSystemVar('Version_Num') }}</generator>
-    <rights>Copyright {{ getSystemVar('sitename') }}</rights>
+    <rights>Copyright {{ siteName() }}</rights>
     {{ maincontent|raw }}
 </feed>

--- a/src/system/AtomTheme/Twig/AtomThemeExtension.php
+++ b/src/system/AtomTheme/Twig/AtomThemeExtension.php
@@ -17,6 +17,7 @@ use Gedmo\Sluggable\Util as Sluggable;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
 
 class AtomThemeExtension extends AbstractExtension
@@ -31,10 +32,19 @@ class AtomThemeExtension extends AbstractExtension
      */
     private $requestStack;
 
-    public function __construct(VariableApiInterface $variableApi, RequestStack $requestStack)
-    {
+    /**
+     * @var SiteDefinitionInterface
+     */
+    private $site;
+
+    public function __construct(
+        VariableApiInterface $variableApi,
+        RequestStack $requestStack,
+        SiteDefinitionInterface $site
+    ) {
         $this->variableApi = $variableApi;
         $this->requestStack = $requestStack;
+        $this->site = $site;
     }
 
     public function getFunctions()
@@ -52,7 +62,7 @@ class AtomThemeExtension extends AbstractExtension
         $startDateParts = explode('/', $startDate);
         $startTimestamp = strtotime($startDateParts[1] . '-' . $startDateParts[0] . '-01');
         $startDate = strftime('%Y-%m-%d', $startTimestamp);
-        $sitename = Sluggable\Urlizer::urlize($this->variableApi->getSystemVar('sitename'));
+        $sitename = Sluggable\Urlizer::urlize($this->site->getName());
 
         return "tag:{$host},{$startDate}:{$sitename}";
     }

--- a/src/system/BootstrapTheme/Resources/views/Include/header.html.twig
+++ b/src/system/BootstrapTheme/Resources/views/Include/header.html.twig
@@ -3,8 +3,8 @@
 <head>
     <title>{{ pagevars.title }}</title>
     <meta charset="{{ pagevars.meta.charset }}" />
-    <meta name="description" content="{{ pagevars.meta.description|default(getSystemVar('slogan', '')) }}" />
-    <meta name="author" content="{{ getSystemVar('sitename', '') }}" />
+    <meta name="description" content="{{ pagevars.meta.description|default(siteSlogan()) }}" />
+    <meta name="author" content="{{ siteName() }}" />
     <meta name="generator" content="Zikula Application Framework" />
     <meta name="robots" content="index,follow,noodp" />
     <meta name="rating" content="General" />

--- a/src/system/BootstrapTheme/Resources/views/Include/topNav.html.twig
+++ b/src/system/BootstrapTheme/Resources/views/Include/topNav.html.twig
@@ -1,7 +1,7 @@
 <div class="navbar fixed-top navbar-expand-md navbar-light bg-light">
     <div class="container">
         <div class="navbar-header">
-            <a class="navbar-brand" href="{{ pagevars.homepath }}"><i class="fa fa-rocket fa-lg text-success"></i>&nbsp;&nbsp;{{ getSystemVar('sitename') }}</a>
+            <a class="navbar-brand" href="{{ pagevars.homepath }}"><i class="fa fa-rocket fa-lg text-success"></i>&nbsp;&nbsp;{{ siteName() }}</a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#themeNavBarCollapse" aria-controls="themeNavBarCollapse" aria-expanded="false" aria-label="{% trans %}Toggle navigation{% endtrans %}">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/src/system/MailerModule/Controller/ConfigController.php
+++ b/src/system/MailerModule/Controller/ConfigController.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Routing\Annotation\Route;
 use Zikula\Bundle\CoreBundle\Controller\AbstractController;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
 use Zikula\MailerModule\Form\Type\MailTransportConfigType;
 use Zikula\MailerModule\Form\Type\TestType;
@@ -81,9 +82,10 @@ class ConfigController extends AbstractController
     public function testAction(
         Request $request,
         VariableApiInterface $variableApi,
-        MailerInterface $mailer
+        MailerInterface $mailer,
+        SiteDefinitionInterface $site
     ): array {
-        $form = $this->createForm(TestType::class, $this->getDataValues($variableApi));
+        $form = $this->createForm(TestType::class, $this->getDataValues($variableApi, $site));
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             if ($form->get('test')->isClicked()) {
@@ -119,11 +121,12 @@ class ConfigController extends AbstractController
      * Returns required data from module variables and mailer configuration.
      */
     private function getDataValues(
-        VariableApiInterface $variableApi
+        VariableApiInterface $variableApi,
+        SiteDefinitionInterface $site
     ): array {
         $modVars = $variableApi->getAll('ZikulaMailerModule');
 
-        $modVars['sitename'] = $variableApi->getSystemVar('sitename', $variableApi->getSystemVar('sitename_en'));
+        $modVars['sitename'] = $site->getName();
         $modVars['adminmail'] = $variableApi->getSystemVar('adminmail');
 
         $modVars['fromName'] = $modVars['sitename'];

--- a/src/system/RssTheme/Resources/views/master.html.twig
+++ b/src/system/RssTheme/Resources/views/master.html.twig
@@ -9,13 +9,13 @@
 {# here you can add your image if you want to #}
 {#
 <image>
-  <title>{{ getSystemVar('sitename') }}</title>
-  <url>{{ zasset(@VendorBundleName:images/logo.png) }}</url>
+  <title>{{ siteName() }}</title>
+  <url>{{ zasset('@VendorBundleName:images/logo.png') }}</url>
   <link>{{ pagevars.homepath }}</link>
 </image>
 #}
-<managingEditor>{% trans %}Administrator{% endtrans %} {{ getSystemVar('adminmail') }} ({{ getSystemVar('sitename') }})</managingEditor>
-<webMaster>{% trans %}Administrator{% endtrans %} {{ getSystemVar('adminmail') }} ({{ getSystemVar('sitename') }})</webMaster>
+<managingEditor>{% trans %}Administrator{% endtrans %} {{ getSystemVar('adminmail') }} ({{ siteName() }})</managingEditor>
+<webMaster>{% trans %}Administrator{% endtrans %} {{ getSystemVar('adminmail') }} ({{ siteName() }})</webMaster>
 {{ maincontent|raw }}
 </channel>
 </rss>

--- a/src/system/SearchModule/Controller/SearchController.php
+++ b/src/system/SearchModule/Controller/SearchController.php
@@ -23,6 +23,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Zikula\Bundle\CoreBundle\Controller\AbstractController;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\Bundle\CoreBundle\Response\PlainResponse;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
 use Zikula\PermissionsModule\Annotation\PermissionCheck;
 use Zikula\SearchModule\Api\ApiInterface\SearchApiInterface;
@@ -152,11 +153,13 @@ class SearchController extends AbstractController
      *
      * Generate xml for opensearch syndication.
      */
-    public function opensearchAction(VariableApiInterface $variableApi): PlainResponse
-    {
+    public function opensearchAction(
+        SiteDefinitionInterface $site,
+        VariableApiInterface $variableApi
+    ): PlainResponse {
         $templateParameters = [
-            'siteName' => $variableApi->getSystemVar('sitename', $variableApi->getSystemVar('sitename_en')),
-            'slogan' => $variableApi->getSystemVar('slogan', $variableApi->getSystemVar('slogan_en')),
+            'siteName' => $site->getName(),
+            'slogan' => $site->getSlogan(),
             'adminMail' => $variableApi->getSystemVar('adminmail'),
             'hasAdultContent' => $variableApi->get('ZikulaSearchModule', 'opensearch_adult_content')
         ];

--- a/src/system/SearchModule/Listener/FrontControllerListener.php
+++ b/src/system/SearchModule/Listener/FrontControllerListener.php
@@ -17,6 +17,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
 use Zikula\PermissionsModule\Api\ApiInterface\PermissionApiInterface;
 use Zikula\ThemeModule\Engine\AssetBag;
@@ -44,6 +45,11 @@ class FrontControllerListener implements EventSubscriberInterface
     private $headerAssetBag;
 
     /**
+     * @var SiteDefinitionInterface
+     */
+    private $site;
+
+    /**
      * @var bool
      */
     private $installed;
@@ -58,6 +64,7 @@ class FrontControllerListener implements EventSubscriberInterface
         PermissionApiInterface $permissionApi,
         VariableApiInterface $variableApi,
         AssetBag $headerAssetBag,
+        SiteDefinitionInterface $site,
         string $installed,
         $isUpgrading = false // cannot cast to bool because set with expression language
     ) {
@@ -65,6 +72,7 @@ class FrontControllerListener implements EventSubscriberInterface
         $this->permissionApi = $permissionApi;
         $this->variableApi = $variableApi;
         $this->headerAssetBag = $headerAssetBag;
+        $this->site = $site;
         $this->installed = '0.0.0' !== $installed;
         $this->isUpgrading = $isUpgrading;
     }
@@ -100,7 +108,7 @@ class FrontControllerListener implements EventSubscriberInterface
 
         // The current user has the rights to search the page.
         $linkType = 'application/opensearchdescription+xml';
-        $siteName = htmlspecialchars($this->variableApi->getSystemVar('sitename'), ENT_QUOTES);
+        $siteName = htmlspecialchars($this->site->getName(), ENT_QUOTES);
         $searchUrl = htmlentities($this->router->generate('zikulasearchmodule_search_opensearch'));
 
         $headerCode = '<link rel="search" type="' . $linkType . '" title="' . $siteName . '" href="' . $searchUrl . '" />';

--- a/src/system/ThemeModule/Twig/Extension/ThemeExtension.php
+++ b/src/system/ThemeModule/Twig/Extension/ThemeExtension.php
@@ -17,12 +17,18 @@ use Exception;
 use InvalidArgumentException;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\ThemeModule\Api\ApiInterface\PageAssetApiInterface;
 use Zikula\ThemeModule\Engine\Asset;
 use Zikula\ThemeModule\Engine\AssetBag;
 
 class ThemeExtension extends AbstractExtension
 {
+    /**
+     * @var SiteDefinitionInterface
+     */
+    private $site;
+
     /**
      * @var PageAssetApiInterface
      */
@@ -33,8 +39,12 @@ class ThemeExtension extends AbstractExtension
      */
     private $assetHelper;
 
-    public function __construct(PageAssetApiInterface $pageAssetApi, Asset $assetHelper)
-    {
+    public function __construct(
+        SiteDefinitionInterface $site,
+        PageAssetApiInterface $pageAssetApi,
+        Asset $assetHelper
+    ) {
+        $this->site = $site;
         $this->pageAssetApi = $pageAssetApi;
         $this->assetHelper = $assetHelper;
     }
@@ -44,7 +54,9 @@ class ThemeExtension extends AbstractExtension
         return [
             new TwigFunction('pageAddAsset', [$this, 'pageAddAsset']),
             new TwigFunction('getPreviewImagePath', [$this, 'getPreviewImagePath'], ['is_safe' => ['html']]),
-            new TwigFunction('zasset', [$this, 'getAssetPath'])
+            new TwigFunction('zasset', [$this, 'getAssetPath']),
+            new TwigFunction('siteName', [$this, 'getSiteName']),
+            new TwigFunction('siteSlogan', [$this, 'getSiteSlogan'])
         ];
     }
 
@@ -90,5 +102,21 @@ class ThemeExtension extends AbstractExtension
     public function getAssetPath(string $path): string
     {
         return $this->assetHelper->resolve($path);
+    }
+
+    /**
+     * Returns site name.
+     */
+    public function getSiteName(): string
+    {
+        return $this->site->getName();
+    }
+
+    /**
+     * Returns site slogan.
+     */
+    public function getSiteSlogan(): string
+    {
+        return $this->site->getSlogan();
     }
 }

--- a/src/system/UsersModule/Controller/UserAdministrationController.php
+++ b/src/system/UsersModule/Controller/UserAdministrationController.php
@@ -27,6 +27,7 @@ use Translation\Extractor\Annotation\Desc;
 use Zikula\Bundle\CoreBundle\Controller\AbstractController;
 use Zikula\Bundle\CoreBundle\Filter\AlphaFilter;
 use Zikula\Bundle\CoreBundle\Response\PlainResponse;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\Bundle\HookBundle\Dispatcher\HookDispatcherInterface;
 use Zikula\Bundle\HookBundle\Hook\ProcessHook;
 use Zikula\Bundle\HookBundle\Hook\ValidationHook;
@@ -381,7 +382,8 @@ class UserAdministrationController extends AbstractController
     public function searchAction(
         Request $request,
         UserRepositoryInterface $userRepository,
-        VariableApiInterface $variableApi
+        VariableApiInterface $variableApi,
+        SiteDefinitionInterface $site
     ) {
         $form = $this->createForm(SearchUserType::class, []);
         $form->handleRequest($request);
@@ -393,7 +395,7 @@ class UserAdministrationController extends AbstractController
 
             return $this->render('@ZikulaUsersModule/UserAdministration/searchResults.html.twig', [
                 'resultsForm' => $resultsForm->createView(),
-                'mailForm' => $this->buildMailForm($variableApi)->createView()
+                'mailForm' => $this->buildMailForm($variableApi, $site)->createView()
             ]);
         }
 
@@ -410,9 +412,10 @@ class UserAdministrationController extends AbstractController
         Request $request,
         UserRepositoryInterface $userRepository,
         VariableApiInterface $variableApi,
-        MailHelper $mailHelper
+        MailHelper $mailHelper,
+        SiteDefinitionInterface $site
     ): RedirectResponse {
-        $mailForm = $this->buildMailForm($variableApi);
+        $mailForm = $this->buildMailForm($variableApi, $site);
         $mailForm->handleRequest($request);
         if ($mailForm->isSubmitted() && $mailForm->isValid()) {
             $data = $mailForm->getData();
@@ -432,10 +435,12 @@ class UserAdministrationController extends AbstractController
         return $this->redirectToRoute('zikulausersmodule_useradministration_search');
     }
 
-    private function buildMailForm(VariableApiInterface $variableApi): FormInterface
-    {
+    private function buildMailForm(
+        VariableApiInterface $variableApi,
+        SiteDefinitionInterface $site
+    ): FormInterface {
         return $this->createForm(MailType::class, [
-            'from' => $variableApi->getSystemVar('sitename'),
+            'from' => $site->getName(),
             'replyto' => $variableApi->getSystemVar('adminmail'),
             'format' => 'text',
             'batchsize' => 100

--- a/src/system/UsersModule/Helper/MailHelper.php
+++ b/src/system/UsersModule/Helper/MailHelper.php
@@ -23,6 +23,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Error\LoaderError;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
 use Zikula\PermissionsModule\Api\ApiInterface\PermissionApiInterface;
 use Zikula\UsersModule\Constant as UsersConstant;
@@ -61,13 +62,19 @@ class MailHelper
      */
     private $authenticationMappingRepository;
 
+    /**
+     * @var SiteDefinitionInterface
+     */
+    private $site;
+
     public function __construct(
         TranslatorInterface $translator,
         Environment $twig,
         VariableApiInterface $variableApi,
         MailerInterface $mailer,
         PermissionApiInterface $permissionApi,
-        AuthenticationMappingRepositoryInterface $authenticationMappingRepository
+        AuthenticationMappingRepositoryInterface $authenticationMappingRepository,
+        SiteDefinitionInterface $site
     ) {
         $this->translator = $translator;
         $this->twig = $twig;
@@ -75,6 +82,7 @@ class MailHelper
         $this->mailer = $mailer;
         $this->permissionApi = $permissionApi;
         $this->authenticationMappingRepository = $authenticationMappingRepository;
+        $this->site = $site;
     }
 
     /**
@@ -267,7 +275,7 @@ class MailHelper
             $subject = $this->generateEmailSubject($notificationType, $templateArgs);
         }
 
-        $siteName = $this->variableApi->getSystemVar('sitename', $this->variableApi->getSystemVar('sitename_en'));
+        $siteName = $this->site->getName();
 
         $email = (new Email())
             ->from(new Address($this->variableApi->getSystemVar('adminmail'), $siteName))
@@ -289,7 +297,7 @@ class MailHelper
 
     private function generateEmailSubject(string $notificationType, array $templateArgs = []): string
     {
-        $siteName = $this->variableApi->getSystemVar('sitename');
+        $siteName = $this->site->getName();
         switch ($notificationType) {
             case 'regadminnotify':
                 if (!$templateArgs['reginfo']->isApproved()) {

--- a/src/system/UsersModule/Resources/views/Email/regadminnotify.html.twig
+++ b/src/system/UsersModule/Resources/views/Email/regadminnotify.html.twig
@@ -10,7 +10,7 @@
 <h3>{{ heading }}</h3>
 
 <p>
-{% set siteLink = '<a href="%1$s">%2$s</a>'|replace({'%1$s': url('home'), '%2$s': getModVar('ZConfig', 'sitename')}) %}
+{% set siteLink = '<a href="%1$s">%2$s</a>'|replace({'%1$s': url('home'), '%2$s': siteName()}) %}
 {% if not reginfo.isApproved %}
     {% trans with {'%s': siteLink} %}A new user account has been created but not yet activated on %s.{% endtrans %}
 {% else %}

--- a/src/system/UsersModule/Resources/views/Email/regadminnotify.txt.twig
+++ b/src/system/UsersModule/Resources/views/Email/regadminnotify.txt.twig
@@ -10,9 +10,9 @@
 {{ heading }}
 
 {% if not reginfo.isApproved %}
-{% trans with {'%s': getModVar('ZConfig', 'sitename')} %}A new user account has been created but not yet activated on %s.{% endtrans %}
+{% trans with {'%s': siteName()} %}A new user account has been created but not yet activated on %s.{% endtrans %}
 {% else %}
-{% trans with {'%s': getModVar('ZConfig', 'sitename')} %}A new user account has been activated on %s.{% endtrans %}
+{% trans with {'%s': siteName()} %}A new user account has been activated on %s.{% endtrans %}
 {% endif %}
 {% if createdByAdmin %}{% trans %}It was created by an administrator or sub-administrator.{% endtrans %}{% endif %}
 {% trans %}The account details are as follows:{% endtrans %}

--- a/src/system/UsersModule/Resources/views/Email/regdeny.html.twig
+++ b/src/system/UsersModule/Resources/views/Email/regdeny.html.twig
@@ -1,8 +1,8 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaUsersModule/Email/header.txt.twig')|nl2br }}
-<h3>{% trans with {'%s': getModVar('ZConfig', 'sitename')} %}A message from %s...{% endtrans %}</h3>
+<h3>{% trans with {'%s': siteName()} %}A message from %s...{% endtrans %}</h3>
 
-<p>{% trans with {'%email': user.email, '%site': getModVar('ZConfig', 'sitename'), '%url': url('home')} %}Recently, this e-mail address (\'%email\') was used to request an account on \'%site\' (%url).{% endtrans %}
+<p>{% trans with {'%email': user.email, '%site': siteName(), '%url': url('home')} %}Recently, this e-mail address (\'%email\') was used to request an account on \'%site\' (%url).{% endtrans %}
 {% trans %}The information that was registered is as follows:{% endtrans %}</p>
 
 <p>{% trans %}User name{% endtrans %}: {{ user.uname }}</p>

--- a/src/system/UsersModule/Resources/views/Email/regdeny.txt.twig
+++ b/src/system/UsersModule/Resources/views/Email/regdeny.txt.twig
@@ -1,8 +1,8 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaUsersModule/Email/header.txt.twig') }}
-{% trans with {'%s': getModVar('ZConfig', 'sitename')} %}A message from %s...{% endtrans %}
+{% trans with {'%s': siteName()} %}A message from %s...{% endtrans %}
 
-{% trans with {'%email': user.email, '%site': getModVar('ZConfig', 'sitename'), '%url': url('home')} %}Recently, this e-mail address (\'%email\') was used to request an account on \'%site\' (%url).{% endtrans %}
+{% trans with {'%email': user.email, '%site': siteName(), '%url': url('home')} %}Recently, this e-mail address (\'%email\') was used to request an account on \'%site\' (%url).{% endtrans %}
 {% trans %}The information that was registered is as follows:{% endtrans %}
 
 {% trans %}User name{% endtrans %}: {{ user.uname }}

--- a/src/system/UsersModule/Resources/views/Email/welcome.html.twig
+++ b/src/system/UsersModule/Resources/views/Email/welcome.html.twig
@@ -1,10 +1,10 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaUsersModule/Email/header.txt.twig')|nl2br }}
-<h3>{% trans with {'%sub%': getModVar('ZConfig', 'sitename')} %}Welcome to %sub%!{% endtrans %}</h3>
+<h3>{% trans with {'%sub%': siteName()} %}Welcome to %sub%!{% endtrans %}</h3>
 
 <p>
     {% trans %}Hello!{% endtrans %}
-    {% trans with {'%email': reginfo.email, '%site': getModVar('ZConfig', 'sitename'), '%url': url('home')} %}This e-mail address (\'%email\') has been used to register an account on \'%site\' (%url).{% endtrans %}
+    {% trans with {'%email': reginfo.email, '%site': siteName(), '%url': url('home')} %}This e-mail address (\'%email\') has been used to register an account on \'%site\' (%url).{% endtrans %}
     {% trans %}The information that was registered is as follows:{% endtrans %}
 </p>
 

--- a/src/system/UsersModule/Resources/views/Email/welcome.txt.twig
+++ b/src/system/UsersModule/Resources/views/Email/welcome.txt.twig
@@ -1,10 +1,10 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaUsersModule/Email/header.txt.twig') }}
-{% trans with {'%sub%': getModVar('ZConfig', 'sitename')} %}Welcome to %sub%!{% endtrans %}
+{% trans with {'%sub%': siteName()} %}Welcome to %sub%!{% endtrans %}
 
 {% trans %}Hello!{% endtrans %}
 
-{% trans with {'%email': reginfo.email, '%site': getModVar('ZConfig', 'sitename'), '%url': url('home')} %}This e-mail address (\'%email\') has been used to register an account on \'%site\' (%url).{% endtrans %}
+{% trans with {'%email': reginfo.email, '%site': siteName(), '%url': url('home')} %}This e-mail address (\'%email\') has been used to register an account on \'%site\' (%url).{% endtrans %}
 {% trans %}The information that was registered is as follows:{% endtrans %}
 
 {% trans %}User name{% endtrans %}: {{ reginfo.uname }}

--- a/src/system/ZAuthModule/Helper/MailHelper.php
+++ b/src/system/ZAuthModule/Helper/MailHelper.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mime\Email;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Error\LoaderError;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
 
 class MailHelper
@@ -44,16 +45,23 @@ class MailHelper
      */
     private $mailer;
 
+    /**
+     * @var SiteDefinitionInterface
+     */
+    private $site;
+
     public function __construct(
         TranslatorInterface $translator,
         Environment $twig,
         VariableApiInterface $variableApi,
-        MailerInterface $mailer
+        MailerInterface $mailer,
+        SiteDefinitionInterface $site
     ) {
         $this->translator = $translator;
         $this->twig = $twig;
         $this->variableApi = $variableApi;
         $this->mailer = $mailer;
+        $this->site = $site;
     }
 
     /**
@@ -87,7 +95,7 @@ class MailHelper
             $subject = $this->generateEmailSubject($notificationType);
         }
 
-        $siteName = $this->variableApi->getSystemVar('sitename', $this->variableApi->getSystemVar('sitename_en'));
+        $siteName = $this->site->getName();
 
         $email = (new Email())
             ->from(new Address($this->variableApi->getSystemVar('adminmail'), $siteName))
@@ -109,7 +117,7 @@ class MailHelper
 
     private function generateEmailSubject(string $notificationType): string
     {
-        $siteName = $this->variableApi->getSystemVar('sitename');
+        $siteName = $this->site->getName();
         switch ($notificationType) {
             case 'importnotify':
                 return $this->translator->trans('Welcome to %siteName%!', ['%siteName%' => $siteName], 'mail');

--- a/src/system/ZAuthModule/Listener/DeletePendingRegistrationsListener.php
+++ b/src/system/ZAuthModule/Listener/DeletePendingRegistrationsListener.php
@@ -22,6 +22,7 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface;
 use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
 use Zikula\UsersModule\Event\RegistrationPostDeletedEvent;
 use Zikula\ZAuthModule\Entity\RepositoryInterface\UserVerificationRepositoryInterface;
@@ -54,18 +55,25 @@ class DeletePendingRegistrationsListener implements EventSubscriberInterface
      */
     private $translator;
 
+    /**
+     * @var SiteDefinitionInterface
+     */
+    private $site;
+
     public function __construct(
         VariableApiInterface $variableApi,
         UserVerificationRepositoryInterface $userVerificationRepository,
         EventDispatcherInterface $eventDispatcher,
         MailerInterface $mailer,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        SiteDefinitionInterface $site
     ) {
         $this->variableApi = $variableApi;
         $this->userVerificationRepository = $userVerificationRepository;
         $this->eventDispatcher = $eventDispatcher;
         $this->mailer = $mailer;
         $this->translator = $translator;
+        $this->site = $site;
     }
 
     public static function getSubscribedEvents()
@@ -90,8 +98,8 @@ class DeletePendingRegistrationsListener implements EventSubscriberInterface
 
     public function sendEmail(RegistrationPostDeletedEvent $event): void
     {
-        $siteName = $this->variableApi->getSystemVar('sitename');
         $adminMail = $this->variableApi->getSystemVar('adminmail');
+        $siteName = $this->site->getName();
         $email = (new Email())
             ->from(new Address($adminMail, $siteName))
             ->to(new Address($event->getUser()->getEmail(), $event->getUser()->getUname()))

--- a/src/system/ZAuthModule/Resources/views/Email/importnotify.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/importnotify.html.twig
@@ -1,8 +1,8 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaZAuthModule/Email/header.txt.twig')|nl2br }}
-<p>{% trans with {'%1$s': getModVar('ZConfig', 'sitename'), '%2$s': url('home')} %}Welcome to %1$s (%2$s)!{% endtrans %}</p>
+<p>{% trans with {'%1$s': siteName(), '%2$s': url('home')} %}Welcome to %1$s (%2$s)!{% endtrans %}</p>
 
-<p>{% trans with {'%1$s': user.email, '%2$s': getModVar('ZConfig', 'sitename')} %}Hello! This e-mail address (\'%1$s\') has been used to register an account on the \'%2$s\' site.{% endtrans %}</p>
+<p>{% trans with {'%1$s': user.email, '%2$s': siteName()} %}Hello! This e-mail address (\'%1$s\') has been used to register an account on the \'%2$s\' site.{% endtrans %}</p>
 
 <p>{% trans %}Your account details are as follows:{% endtrans %}</p>
 

--- a/src/system/ZAuthModule/Resources/views/Email/importnotify.txt.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/importnotify.txt.twig
@@ -1,8 +1,8 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaZAuthModule/Email/header.txt.twig') }}
-{% trans with {'%1$s': getModVar('ZConfig', 'sitename'), '%2$s': url('home')} %}Welcome to %1$s (%2$s)!{% endtrans %}
+{% trans with {'%1$s': siteName(), '%2$s': url('home')} %}Welcome to %1$s (%2$s)!{% endtrans %}
 
-{% trans with {'%1$s': user.email, '%2$s': getModVar('ZConfig', 'sitename')} %}Hello! This e-mail address (\'%1$s\') has been used to register an account on the \'%2$s\' site.{% endtrans %}
+{% trans with {'%1$s': user.email, '%2$s': siteName()} %}Hello! This e-mail address (\'%1$s\') has been used to register an account on the \'%2$s\' site.{% endtrans %}
 
 {% trans %}Your account details are as follows:{% endtrans %}
 

--- a/src/system/ZAuthModule/Resources/views/Email/lostpassword.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/lostpassword.html.twig
@@ -2,10 +2,10 @@
 {{ include('@ZikulaZAuthModule/Email/header.txt.twig')|nl2br }}
 <p>{% trans %}Hello!{% endtrans %}</p>
 
-<p>{% trans with {'%username%': uname, '%sitename%': getModVar('ZConfig', 'sitename')} %}The user account \'%username%\' at %sitename% has this e-mail address associated with it.{% endtrans %}</p>
+<p>{% trans with {'%username%': uname, '%sitename%': siteName()} %}The user account \'%username%\' at %sitename% has this e-mail address associated with it.{% endtrans %}</p>
 
 {% if requestedByAdmin %}
-<p>{% trans with {'%sub%': getModVar('ZConfig', 'sitename')} %}The administrator at %sub% requested that you reset your password.{% endtrans %}</p>
+<p>{% trans with {'%sub%': siteName()} %}The administrator at %sub% requested that you reset your password.{% endtrans %}</p>
 {% else %}
 <p>{% trans with {'%sub%': app.request.server.get('REMOTE_ADDR')} %}Someone with the IP address %sub% has just requested your account password to be reset.{% endtrans %}</p>
 {% endif %}

--- a/src/system/ZAuthModule/Resources/views/Email/lostpassword.txt.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/lostpassword.txt.twig
@@ -2,10 +2,10 @@
 {{ include('@ZikulaZAuthModule/Email/header.txt.twig') }}
 {% trans %}Hello!{% endtrans %}
 
-{% trans with {'%username%': uname, '%sitename%': getModVar('ZConfig', 'sitename')} %}The user account \'%username%\' at %sitename% has this e-mail address associated with it.{% endtrans %}
+{% trans with {'%username%': uname, '%sitename%': siteName()} %}The user account \'%username%\' at %sitename% has this e-mail address associated with it.{% endtrans %}
 
 {% if requestedByAdmin %}
-{% trans with {'%sub%': getModVar('ZConfig', 'sitename')} %}The administrator at %sub% requested that reset your password.{% endtrans %}
+{% trans with {'%sub%': siteName()} %}The administrator at %sub% requested that reset your password.{% endtrans %}
 {% else %}
 {% trans with {'%sub%': app.request.server.get('REMOTE_ADDR')} %}Someone with the IP address %sub% has just requested your account password to be reset.{% endtrans %}
 {% endif %}

--- a/src/system/ZAuthModule/Resources/views/Email/lostuname.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/lostuname.html.twig
@@ -3,9 +3,9 @@
 <p>{% trans %}Hello!{% endtrans %}</p>
 
 {% if requestedByAdmin %}
-<p>{% trans with {'%sub%': getModVar('ZConfig', 'sitename')} %}The administrator at %sub% requested that you receive your user name via e-mail.{% endtrans %}</p>
+<p>{% trans with {'%sub%': siteName()} %}The administrator at %sub% requested that you receive your user name via e-mail.{% endtrans %}</p>
 {% else %}
-<p>{% trans with {'%1$s': app.request.server.get('REMOTE_ADDR'), '%2$s': getModVar('ZConfig', 'sitename')} %}Someone with the IP address %1$s has just requested the account information at %2$s associated with this e-mail address.{% endtrans %}</p>
+<p>{% trans with {'%1$s': app.request.server.get('REMOTE_ADDR'), '%2$s': siteName()} %}Someone with the IP address %1$s has just requested the account information at %2$s associated with this e-mail address.{% endtrans %}</p>
 {% endif %}
 
 <p>{% trans with {'%user%': uname} %}The user name for your account is: %user%{% endtrans %}</p>

--- a/src/system/ZAuthModule/Resources/views/Email/lostuname.txt.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/lostuname.txt.twig
@@ -3,9 +3,9 @@
 {% trans %}Hello!{% endtrans %}
 
 {% if requestedByAdmin %}
-    {% trans with {'%sub%': getModVar('ZConfig', 'sitename')} %}The administrator at %sub% requested that you receive your user name via e-mail.{% endtrans %}
+    {% trans with {'%sub%': siteName()} %}The administrator at %sub% requested that you receive your user name via e-mail.{% endtrans %}
 {% else %}
-    {% trans with {'%1$s': app.request.server.get('REMOTE_ADDR'), '%2$s': getModVar('ZConfig', 'sitename')} %}Someone with the IP address %1$s has just requested the account information at %2$s associated with this e-mail address.{% endtrans %}
+    {% trans with {'%1$s': app.request.server.get('REMOTE_ADDR'), '%2$s': siteName()} %}Someone with the IP address %1$s has just requested the account information at %2$s associated with this e-mail address.{% endtrans %}
 {% endif %}
 
 {% trans with {'%user%': uname} %}The user name for your account is: %user%{% endtrans %}

--- a/src/system/ZAuthModule/Resources/views/Email/regverifyemail.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/regverifyemail.html.twig
@@ -1,9 +1,9 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaZAuthModule/Email/header.txt.twig')|nl2br }}
 {% set verificationurl = url('zikulazauthmodule_registration_verify', {'uname': user.uname, 'verifycode': verifycode}) %}
-<h3>{% trans with {'%sub%': getModVar('ZConfig', 'sitename')} %}Welcome to %sub%!{% endtrans %}</h3>
+<h3>{% trans with {'%sub%': siteName()} %}Welcome to %sub%!{% endtrans %}</h3>
 
-<p>{% trans with {'%email': user.email, '%site': getModVar('ZConfig', 'sitename'), '%url': url('home')} %}Hello! This e-mail address (\'%email\') has been used to register an account on \'%site\' (%url).{% endtrans %}</p>
+<p>{% trans with {'%email': user.email, '%site': siteName(), '%url': url('home')} %}Hello! This e-mail address (\'%email\') has been used to register an account on \'%site\' (%url).{% endtrans %}</p>
 <p>{% trans %}If you did not request a new user account at this web site, please either contact our site administrator, or simply disregard this message.{% endtrans %}</p>
 
 <p>{% trans %}If you did request a new user account, then your request is waiting for you to verify your e-mail address with us.{% endtrans %}

--- a/src/system/ZAuthModule/Resources/views/Email/regverifyemail.txt.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/regverifyemail.txt.twig
@@ -1,9 +1,9 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaZAuthModule/Email/header.txt.twig') }}
 {% set verificationurl = url('zikulazauthmodule_registration_verify', {'uname': user.uname, 'verifycode': verifycode}) %}
-{% trans with {'%sub%': getModVar('ZConfig', 'sitename')} %}Welcome to %sub%!{% endtrans %}
+{% trans with {'%sub%': siteName()} %}Welcome to %sub%!{% endtrans %}
 
-{% trans with {'%email': user.email, '%site': getModVar('ZConfig', 'sitename'), '%url': url('home')} %}Hello! This e-mail address (\'%email\') has been used to register an account on \'%site\' (%url).{% endtrans %}
+{% trans with {'%email': user.email, '%site': siteName(), '%url': url('home')} %}Hello! This e-mail address (\'%email\') has been used to register an account on \'%site\' (%url).{% endtrans %}
 
 {% trans %}If you did not request a new user account at this web site, please either contact our site administrator, or simply disregard this message.{% endtrans %}
 

--- a/src/system/ZAuthModule/Resources/views/Email/userverifyemail.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/userverifyemail.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaZAuthModule/Email/header.txt.twig')|nl2br }}
-<p>{% trans with {'%uname': uname, '%site': getModVar('ZConfig', 'sitename'), '%email': email, '%newemail': newemail} %}Hello! You requested to change your e-mail address for user account \'%uname\' at %site from %email to %newemail.{% endtrans %}
+<p>{% trans with {'%uname': uname, '%site': siteName(), '%email': email, '%newemail': newemail} %}Hello! You requested to change your e-mail address for user account \'%uname\' at %site from %email to %newemail.{% endtrans %}
    {% trans %}You must confirm this change before it will take effect.{% endtrans %}
 {% set expireDays = getModVar('ZikulaZAuthModule', constant('Zikula\\ZAuthModule\\ZAuthConstant::MODVAR_EXPIRE_DAYS_CHANGE_EMAIL')) %}
 {% if expireDays > 0 %}

--- a/src/system/ZAuthModule/Resources/views/Email/userverifyemail.txt.twig
+++ b/src/system/ZAuthModule/Resources/views/Email/userverifyemail.txt.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'mail' %}
 {{ include('@ZikulaZAuthModule/Email/header.txt.twig') }}
-{% trans with {'%uname': uname, '%site': getModVar('ZConfig', 'sitename'), '%email': email, '%newemail': newemail} %}Hello! You requested to change your e-mail address for user account \'%uname\' at %site from %email to %newemail.{% endtrans %}
+{% trans with {'%uname': uname, '%site': siteName(), '%email': email, '%newemail': newemail} %}Hello! You requested to change your e-mail address for user account \'%uname\' at %site from %email to %newemail.{% endtrans %}
 {% trans %}You must confirm this change before it will take effect.{% endtrans %}
 {% set expireDays = getModVar('ZikulaZAuthModule', constant('Zikula\\ZAuthModule\\ZAuthConstant::MODVAR_EXPIRE_DAYS_CHANGE_EMAIL')) %}
 {% if expireDays > 0 %}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | #3972 
| License           | MIT
| Changelog updated | no

## Description

- Use `SiteDefinitionInterface` for retrieving site name.
- Use `SiteDefinitionInterface` for retrieving site slogan.
- Add two new Twig functions `siteName()` and `siteSlogan()` for easy template ingration.
