### PR TITLE
make AssetBag 'dumb' again.

### DIFF
--- a/docs/LayoutDesign/Templating/PageAssets.md
+++ b/docs/LayoutDesign/Templating/PageAssets.md
@@ -49,13 +49,13 @@ $this->get('zikula_core.common.theme.assets_js')->add([
 Weights utilized by core assets are listed below.
 
 ```php
-public const WEIGHT_JQUERY = 19;
-public const WEIGHT_JQUERY_UI = 20;
-public const WEIGHT_BOOTSTRAP_JS = 21;
-public const WEIGHT_BOOTSTRAP_ZIKULA = 22;
-public const WEIGHT_ROUTER_JS = 24;
-public const WEIGHT_ROUTES_JS = 25;
-public const WEIGHT_JS_TRANSLATOR = 26;
+public const WEIGHT_JQUERY = 20;
+public const WEIGHT_JQUERY_UI = 25;
+public const WEIGHT_BOOTSTRAP_JS = 30;
+public const WEIGHT_BOOTSTRAP_ZIKULA = 31;
+public const WEIGHT_ROUTER_JS = 40;
+public const WEIGHT_ROUTES_JS = 41;
+public const WEIGHT_JS_TRANSLATOR = 50;
 public const WEIGHT_DEFAULT = 100;
 public const WEIGHT_JS_TRANSLATIONS = 110;
 public const WEIGHT_THEME_STYLESHEET = 120;

--- a/src/Zikula/FormExtensionBundle/Resources/views/Form/bootstrap_4_zikula_admin_layout.html.twig
+++ b/src/Zikula/FormExtensionBundle/Resources/views/Form/bootstrap_4_zikula_admin_layout.html.twig
@@ -158,7 +158,7 @@ col-md-9
     {% endif %}
     {# load required assets: jQuery UI + custom search code #}
     {{ pageAddAsset('stylesheet', asset('jquery-ui/themes/base/jquery-ui.min.css')) }}
-    {{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js')) }}
+    {{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
     {{ pageAddAsset('stylesheet', zasset('@ZikulaUsersModule:css/livesearch.css')) }}
     {{ pageAddAsset('javascript', zasset('@ZikulaUsersModule:js/Zikula.Users.LiveSearch.js')) }}
 {% endblock %}

--- a/src/Zikula/HookBundle/Resources/views/Hook/edit.html.twig
+++ b/src/Zikula/HookBundle/Resources/views/Hook/edit.html.twig
@@ -1,4 +1,4 @@
-{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js')) }}
+{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
 {{ pageAddAsset('javascript', asset('bundles/zikulahook/js/hookui.js')) }}
 {{ pageAddAsset('stylesheet', asset('bundles/zikulahook/css/hooks.css')) }}
 {{ adminHeader() }}

--- a/src/system/AdminModule/Resources/views/AdminInterface/categories.tabs.html.twig
+++ b/src/system/AdminModule/Resources/views/AdminInterface/categories.tabs.html.twig
@@ -1,5 +1,5 @@
 {{ pageAddAsset('stylesheet', asset('jquery-ui/themes/base/jquery-ui.min.css')) }}
-{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js')) }}
+{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
 {{ pageAddAsset('javascript', zasset('@ZikulaAdminModule:js/ZikulaAdminModule.AdminTabs.js')) }}
 {{ pageAddAsset('stylesheet', zasset('@ZikulaAdminModule:css/style.css')) }}
 

--- a/src/system/ExtensionsModule/Resources/views/Extension/list.html.twig
+++ b/src/system/ExtensionsModule/Resources/views/Extension/list.html.twig
@@ -1,4 +1,4 @@
-{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js')) }}
+{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
 {{ pageAddAsset('javascript', zasset('@ZikulaExtensionsModule:js/Zikula.Extensions.Extension.List.js')) }}
 {{ adminHeader() }}
 <h3>

--- a/src/system/PermissionsModule/Resources/views/Permission/list.html.twig
+++ b/src/system/PermissionsModule/Resources/views/Permission/list.html.twig
@@ -1,5 +1,5 @@
 {{ pageAddAsset('stylesheet', asset('jquery-ui/themes/base/jquery-ui.min.css')) }}
-{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js')) }}
+{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
 {{ pageAddAsset('javascript', zasset('@ZikulaPermissionsModule:js/Zikula.Permission.Admin.View.js')) }}
 {{ adminHeader() }}
 <h3>

--- a/src/system/RoutesModule/Resources/views/base.html.twig
+++ b/src/system/RoutesModule/Resources/views/base.html.twig
@@ -22,6 +22,6 @@
 {% block assets %}
     {{ pageAddAsset('stylesheet', zasset('@ZikulaRoutesModule:css/custom.css'), 120) }}
     {{ pageAddAsset('stylesheet', asset('jquery-ui/themes/base/jquery-ui.min.css')) }}
-    {{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js')) }}
+    {{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
     {{ pageAddAsset('javascript', zasset('@ZikulaRoutesModule:js/ZikulaRoutesModule.js')) }}
 {% endblock %}

--- a/src/system/ThemeModule/Engine/Asset/CssResolver.php
+++ b/src/system/ThemeModule/Engine/Asset/CssResolver.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Zikula\ThemeModule\Engine\Asset;
 
-use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\ThemeModule\Engine\AssetBag;
 
 /**
@@ -39,15 +38,14 @@ class CssResolver implements ResolverInterface
     private $combine;
 
     public function __construct(
-        ZikulaHttpKernelInterface $kernel,
+        string $env,
         AssetBag $bag,
         MergerInterface $merger,
         bool $combine = false
     ) {
-        $this->kernel = $kernel;
         $this->bag = $bag;
         $this->merger = $merger;
-        $this->combine = 'prod' === $this->kernel->getEnvironment() && $combine;
+        $this->combine = ('prod' === $env) && $combine;
     }
 
     public function compile(): string

--- a/src/system/ThemeModule/Engine/Asset/JsResolver.php
+++ b/src/system/ThemeModule/Engine/Asset/JsResolver.php
@@ -76,7 +76,7 @@ class JsResolver implements ResolverInterface
             if ('jquery-ui.min.js' === mb_substr($source, -16)
                 || 'jquery-ui.js' === mb_substr($source, -12)
             ) {
-                $this->bag->add([$source => AssetBag::WEIGHT_JQUERY]);
+                $this->bag->add([$source => AssetBag::WEIGHT_JQUERY_UI]);
             }
         }
     }

--- a/src/system/ThemeModule/Engine/Asset/JsResolver.php
+++ b/src/system/ThemeModule/Engine/Asset/JsResolver.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Zikula\ThemeModule\Engine\Asset;
 
-use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\ThemeModule\Engine\AssetBag;
 
 /**
@@ -39,19 +38,19 @@ class JsResolver implements ResolverInterface
     private $combine;
 
     public function __construct(
-        ZikulaHttpKernelInterface $kernel,
+        string $env,
         AssetBag $bag,
         MergerInterface $merger,
         bool $combine = false
     ) {
-        $this->kernel = $kernel;
         $this->bag = $bag;
         $this->merger = $merger;
-        $this->combine = 'prod' === $this->kernel->getEnvironment() && $combine;
+        $this->combine = ('prod' === $env) && $combine;
     }
 
     public function compile(): string
     {
+        $this->validateBag();
         $assets = $this->bag->allWithWeight();
         if ($this->combine) {
             $assets = $this->merger->merge($assets);
@@ -67,5 +66,18 @@ class JsResolver implements ResolverInterface
     public function getBag(): AssetBag
     {
         return $this->bag;
+    }
+
+    private function validateBag(): void
+    {
+        foreach ($this->getBag()->all() as $source) {
+            // if already there, add jquery-ui again to force weight setting is correct
+            // jQueryUI must be loaded before Bootstrap, refs #3912
+            if ('jquery-ui.min.js' === mb_substr($source, -16)
+                || 'jquery-ui.js' === mb_substr($source, -12)
+            ) {
+                $this->bag->add([$source => AssetBag::WEIGHT_JQUERY]);
+            }
+        }
     }
 }

--- a/src/system/ThemeModule/Engine/AssetBag.php
+++ b/src/system/ThemeModule/Engine/AssetBag.php
@@ -72,13 +72,6 @@ class AssetBag implements IteratorAggregate, Countable
         }
 
         foreach ($asset as $source => $weight) {
-            // jQueryUI must be loaded before Bootstrap, refs #3912
-            if ('jquery-ui.min.js' === mb_substr($source, -16)
-                || 'jquery-ui.js' === mb_substr($source, -12)
-            ) {
-                $weight = self::WEIGHT_JQUERY_UI;
-            }
-
             if (!isset($this->assets[$source]) || (isset($this->assets[$source]) && $this->assets[$source] > $weight)) {
                 // keep original weight if lighter. set if not set already.
                 $this->assets[$source] = $weight;

--- a/src/system/ThemeModule/Resources/config/services.yaml
+++ b/src/system/ThemeModule/Resources/config/services.yaml
@@ -69,13 +69,13 @@ services:
 
     Zikula\ThemeModule\Engine\Asset\JsResolver:
         arguments:
-          $kernel: '@kernel'
+          $env: '%env(APP_ENV)%'
           $bag: '@zikula_core.common.theme.assets_js'
           $combine: '%zikula_asset_manager.combine%'
 
     Zikula\ThemeModule\Engine\Asset\CssResolver:
         arguments:
-          $kernel: '@kernel'
+          $env: '%env(APP_ENV)%'
           $bag: '@zikula_core.common.theme.assets_css'
           $combine: '%zikula_asset_manager.combine%'
 

--- a/src/system/ThemeModule/Tests/Engine/AssetBagTest.php
+++ b/src/system/ThemeModule/Tests/Engine/AssetBagTest.php
@@ -76,17 +76,17 @@ class AssetBagTest extends TestCase
 
     /**
      * @covers AssetBag::add()
-     * @see http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.sort-order
+     * Order of array elements doesn't matter when using assert(Not)Equals
+     * reflects https://www.php.net/manual/en/language.operators.array.php
+     * equality, not identity. use assert(Not)Same for identity.
      */
     public function testAddSameWeighted(): void
     {
-        $this->markTestSkipped('Currently skipped due to indeterminate behaviour in PHP 7.');
-
         $bag = new AssetBag();
         $bag->add(['B' => 3]);
         $bag->add(['A' => 3]);
         $bag->add(['C' => 3]);
-        $this->assertNotEquals(['A', 'B', 'C'], $bag->all()); // order cannot be assumed with same weight
+        $this->assertNotSame(['A', 'B', 'C'], $bag->all()); // order cannot be assured with same weight
     }
 
     /**
@@ -125,6 +125,7 @@ class AssetBagTest extends TestCase
 
     /**
      * @covers AssetBag::add()
+     * see note in testAddSameWeighted re: array equality vs. identity
      */
     public function testKeepLowestWeightedSubmission(): void
     {
@@ -137,6 +138,12 @@ class AssetBagTest extends TestCase
         $bag->add(['C' => 2]);
         $bag->add(['A' => 5]);
         $bag->add(['A' => 7]);
-        $this->assertEquals('A', $bag->all()[2]); // asset listed at lowest weight submitted
+        $this->assertEquals(3, $bag->allWithWeight()['A']);  // asset listed at lowest weight submitted
+        $expected = [
+            'B' => 1,
+            'C' => 2,
+            'A' => 3,
+        ];
+        $this->assertEquals($expected, $bag->allWithWeight());
     }
 }


### PR DESCRIPTION
make AssetBag 'dumb' again. move checks to resolver class. update pageAddAsset() calls to use weight for jquery-ui. resolvers don't need full kernel, only env. update tests to use assertSame for arrays.