### PR TITLE
Proper utf8 support for MySQL platforms

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,5 +2,5 @@ KERNEL_CLASS=Kernel
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER='disabled=1'
 PANTHER_APP_ENV=panther
-DATABASE_URL='mysql://db_user:db_password@127.0.0.1:3306/db_name?charset=UTF8&serverVersion=5.7'
+DATABASE_URL='mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7'
 ZIKULA_INSTALLED='3.0.0'

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -193,3 +193,4 @@
   - Added automatic setting of locale parameter when generating routes in JavaScript (#3453).
   - Introduced a new `\Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface` for dynamic site attributes (#3972).
   - Extended site definition and added means for site-wide branding (#3972).
+  - Using `utf8mb4` charset on MySQL platforms for real utf8 support (#3784).

--- a/src/Zikula/CoreBundle/Doctrine/Helper/CharsetRecodeHelper.php
+++ b/src/Zikula/CoreBundle/Doctrine/Helper/CharsetRecodeHelper.php
@@ -90,7 +90,7 @@ class CharsetRecodeHelper
         return $commands;
     }
 
-    private function retrieveCommands(string $sql, string $dbName): array
+    private function retrieveCommands(string $sql): array
     {
         $result = [];
         $stmt = $this->conn->executeQuery(

--- a/src/Zikula/CoreBundle/Doctrine/Helper/CharsetRecodeHelper.php
+++ b/src/Zikula/CoreBundle/Doctrine/Helper/CharsetRecodeHelper.php
@@ -91,7 +91,7 @@ class CharsetRecodeHelper
         return $commands;
     }
 
-    private function retrieveCommands($sql): array
+    private function retrieveCommands(string $sql): array
     {
         $result = [];
         $stmt = $this->conn->executeQuery($sql);

--- a/src/Zikula/CoreBundle/Doctrine/Helper/CharsetRecodeHelper.php
+++ b/src/Zikula/CoreBundle/Doctrine/Helper/CharsetRecodeHelper.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\Bundle\CoreBundle\Doctrine\Helper;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+
+class CharsetRecodeHelper
+{
+    /**
+     * @var Connection
+     */
+    private $conn;
+
+    public function __construct(
+        Connection $connection
+    ) {
+        $this->conn = $connection;
+    }
+
+    private function isRequired(): bool
+    {
+        $driver = $this->conn->getDriver();
+
+        // recoding utf8 to utf8mb4 is only required for mysql
+        return $driver instanceof AbstractMySQLDriver;
+    }
+
+    public function getCommands(): array
+    {
+        if (!$this->isRequired()) {
+            return [];
+        }
+
+        // the following is based on
+        // https://dba.stackexchange.com/questions/8239/how-to-easily-convert-utf8-tables-to-utf8mb4-in-mysql-5-5#answer-104866
+        $dbName = $this->conn->getDatabase();
+        $tableFilter = 'table_schema LIKE "' . $dbName . '"';
+        $commands = [];
+
+        $this->conn->executeQuery('use information_schema;');
+
+        // database level
+        $rows = $this->retrieveCommands('
+            SELECT CONCAT("ALTER DATABASE `",table_schema,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;") AS _sql 
+            FROM `TABLES`
+            WHERE ' . $tableFilter . '
+            GROUP BY table_schema;
+        ');
+        $commands = array_merge($commands, $rows);
+
+        // table level
+        $rows = $this->retrieveCommands('
+            SELECT CONCAT("ALTER TABLE `",table_schema,"`.`",table_name,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;") AS _sql  
+            FROM `TABLES`
+            WHERE ' . $tableFilter . '
+            GROUP BY table_schema, table_name;
+        ');
+        $commands = array_merge($commands, $rows);
+
+        // column level
+        $rows = $this->retrieveCommands('
+            SELECT CONCAT("ALTER TABLE `",table_schema,"`.`",table_name, "` CHANGE `",column_name,"` `",column_name,"` ",data_type,"(",character_maximum_length,") CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",IF(is_nullable="YES"," NULL"," NOT NULL"),";") AS _sql 
+            FROM `COLUMNS`
+            WHERE ' . $tableFilter . '
+            AND data_type IN (\'varchar\', \'char\');
+        ');
+        $commands = array_merge($commands, $rows);
+
+        $rows = $this->retrieveCommands('
+            SELECT CONCAT("ALTER TABLE `",table_schema,"`.`",table_name, "` CHANGE `",column_name,"` `",column_name,"` ",data_type," CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",IF(is_nullable="YES"," NULL"," NOT NULL"),";") AS _sql 
+            FROM `COLUMNS`
+            WHERE ' . $tableFilter . '
+            AND data_type IN (\'text\', \'tinytext\', \'mediumtext\', \'longtext\');
+        ');
+        $commands = array_merge($commands, $rows);
+
+        $this->conn->executeQuery('use ' . $dbName . ';');
+
+        return $commands;
+    }
+
+    private function retrieveCommands($sql): array
+    {
+        $result = [];
+        $stmt = $this->conn->executeQuery($sql);
+        while ($row = $stmt->fetch()) {
+            $result[] = $row['_sql'];
+        }
+
+        return $result;
+    }
+}

--- a/src/Zikula/CoreBundle/Doctrine/Helper/CharsetRecodeHelper.php
+++ b/src/Zikula/CoreBundle/Doctrine/Helper/CharsetRecodeHelper.php
@@ -15,6 +15,7 @@ namespace Zikula\Bundle\CoreBundle\Doctrine\Helper;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\ParameterType;
 
 class CharsetRecodeHelper
 {
@@ -45,8 +46,6 @@ class CharsetRecodeHelper
 
         // the following is based on
         // https://dba.stackexchange.com/questions/8239/how-to-easily-convert-utf8-tables-to-utf8mb4-in-mysql-5-5#answer-104866
-        $dbName = $this->conn->getDatabase();
-        $tableFilter = 'table_schema LIKE "' . $dbName . '"';
         $commands = [];
 
         $this->conn->executeQuery('use information_schema;');
@@ -55,7 +54,7 @@ class CharsetRecodeHelper
         $rows = $this->retrieveCommands('
             SELECT CONCAT("ALTER DATABASE `",table_schema,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;") AS _sql 
             FROM `TABLES`
-            WHERE ' . $tableFilter . '
+            WHERE table_schema LIKE ?
             GROUP BY table_schema;
         ');
         $commands = array_merge($commands, $rows);
@@ -64,7 +63,7 @@ class CharsetRecodeHelper
         $rows = $this->retrieveCommands('
             SELECT CONCAT("ALTER TABLE `",table_schema,"`.`",table_name,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;") AS _sql  
             FROM `TABLES`
-            WHERE ' . $tableFilter . '
+            WHERE table_schema LIKE ?
             GROUP BY table_schema, table_name;
         ');
         $commands = array_merge($commands, $rows);
@@ -73,7 +72,7 @@ class CharsetRecodeHelper
         $rows = $this->retrieveCommands('
             SELECT CONCAT("ALTER TABLE `",table_schema,"`.`",table_name, "` CHANGE `",column_name,"` `",column_name,"` ",data_type,"(",character_maximum_length,") CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",IF(is_nullable="YES"," NULL"," NOT NULL"),";") AS _sql 
             FROM `COLUMNS`
-            WHERE ' . $tableFilter . '
+            WHERE table_schema LIKE ?
             AND data_type IN (\'varchar\', \'char\');
         ');
         $commands = array_merge($commands, $rows);
@@ -81,20 +80,28 @@ class CharsetRecodeHelper
         $rows = $this->retrieveCommands('
             SELECT CONCAT("ALTER TABLE `",table_schema,"`.`",table_name, "` CHANGE `",column_name,"` `",column_name,"` ",data_type," CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",IF(is_nullable="YES"," NULL"," NOT NULL"),";") AS _sql 
             FROM `COLUMNS`
-            WHERE ' . $tableFilter . '
+            WHERE table_schema LIKE ?
             AND data_type IN (\'text\', \'tinytext\', \'mediumtext\', \'longtext\');
         ');
         $commands = array_merge($commands, $rows);
 
-        $this->conn->executeQuery('use ' . $dbName . ';');
+        $this->conn->executeQuery('use ' . $this->conn->getDatabase() . ';');
 
         return $commands;
     }
 
-    private function retrieveCommands(string $sql): array
+    private function retrieveCommands(string $sql, string $dbName): array
     {
         $result = [];
-        $stmt = $this->conn->executeQuery($sql);
+        $stmt = $this->conn->executeQuery(
+            $sql,
+            [
+                $this->conn->getDatabase()
+            ],
+            [
+                ParameterType::STRING
+            ]
+        );
         while ($row = $stmt->fetch()) {
             $result[] = $row['_sql'];
         }

--- a/src/Zikula/CoreBundle/Doctrine/Helper/SchemaHelper.php
+++ b/src/Zikula/CoreBundle/Doctrine/Helper/SchemaHelper.php
@@ -17,9 +17,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\ToolsException;
 
-/**
- * Class SchemaHelper
- */
 class SchemaHelper
 {
     /**

--- a/src/Zikula/CoreBundle/EventListener/Core3UpgradeListener.php
+++ b/src/Zikula/CoreBundle/EventListener/Core3UpgradeListener.php
@@ -22,17 +22,6 @@ class Core3UpgradeListener implements EventSubscriberInterface
 {
     use ColumnExistsTrait;
 
-    /**
-     * @var CharsetRecodeHelper
-     */
-    private $charsetRecodeHelper;
-
-    public function __construct(
-        CharsetRecodeHelper $charsetRecodeHelper
-    ) {
-        $this->charsetRecodeHelper = $charsetRecodeHelper;
-    }
-
     public static function getSubscribedEvents()
     {
         return [
@@ -50,7 +39,7 @@ class Core3UpgradeListener implements EventSubscriberInterface
         }
         $commands = [];
         $commands[] = 'ALTER TABLE `bundles` DROP COLUMN `bundlestate`';
-        $commands = array_merge($commands, $this->charsetRecodeHelper->getCommands());
+        $commands = array_merge($commands, (new CharsetRecodeHelper($this->conn))->getCommands());
         foreach ($commands as $sql) {
             $this->conn->executeQuery($sql);
         }

--- a/src/Zikula/CoreBundle/EventListener/Core3UpgradeListener.php
+++ b/src/Zikula/CoreBundle/EventListener/Core3UpgradeListener.php
@@ -15,11 +15,23 @@ namespace Zikula\Bundle\CoreBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Zikula\Bundle\CoreBundle\Doctrine\ColumnExistsTrait;
+use Zikula\Bundle\CoreBundle\Doctrine\Helper\CharsetRecodeHelper;
 use Zikula\Bundle\CoreInstallerBundle\Event\CoreUpgradePreExtensionUpgrade;
 
 class Core3UpgradeListener implements EventSubscriberInterface
 {
     use ColumnExistsTrait;
+
+    /**
+     * @var CharsetRecodeHelper
+     */
+    private $charsetRecodeHelper;
+
+    public function __construct(
+        CharsetRecodeHelper $charsetRecodeHelper
+    ) {
+        $this->charsetRecodeHelper = $charsetRecodeHelper;
+    }
 
     public static function getSubscribedEvents()
     {
@@ -38,6 +50,7 @@ class Core3UpgradeListener implements EventSubscriberInterface
         }
         $commands = [];
         $commands[] = 'ALTER TABLE `bundles` DROP COLUMN `bundlestate`';
+        $commands = array_merge($commands, $this->charsetRecodeHelper->getCommands());
         foreach ($commands as $sql) {
             $this->conn->executeQuery($sql);
         }

--- a/src/Zikula/CoreInstallerBundle/Helper/DbCredsHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/DbCredsHelper.php
@@ -23,8 +23,7 @@ class DbCredsHelper
             . '/' . $data['database_name']
         ;
 
-        $databaseUrl .= '?charset=UTF8';
-        $databaseUrl .= '&serverVersion=5.7'; // any value will work (bypasses DBALException)
+        $databaseUrl .= '?serverVersion=5.7'; // any value will work (bypasses DBALException)
 
         return $databaseUrl;
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixed #3784
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

- Removes all references to any specific database charset.
  - Background: Note from DoctrineBundle v2: _When no charset parameter is defined, it now defaults to `utf8mb4` on the MySQL platform and to `utf8` on all other platforms._ -> So ideally nothing should be defined in `config/packages/doctrine.yaml` and `.env.local` (refs #3967).
- Adds a `CharsetRecodeHelper` class which holds the wisdom about how recoding process is being done.
- Integrates this into Core bundle's `Core3UpgradeListener`.

## How to test this independently

To test this procedure choose a controller method, add `\Zikula\Bundle\CoreBundle\Doctrine\Helper\CharsetRecodeHelper $charsetRecodeHelper` to it's arguments and execute this code:

```php
        $commands = $charsetRecodeHelper->getCommands();
        foreach ($commands as $sql) {
            $connection->executeQuery($sql);
        }
```
