### PR TITLE
removed obsolete file protection step

### DIFF
--- a/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
@@ -184,34 +184,6 @@ class ParameterHelper
         $helper->writeLocalEnvVars($vars);
     }
 
-    public function protectFiles(): bool
-    {
-        // protect services_custom.yaml files
-        $files = array_diff(scandir($this->configDir), ['.', '..']);
-        foreach ($files as $file) {
-            $this->protectFile($this->configDir . '/' . $file);
-        }
-
-        $this->protectFile($this->projectDir . '/.env.local');
-
-        // clear the cache
-        $this->cacheClearer->clear('symfony.config');
-
-        return true;
-    }
-
-    private function protectFile(string $filePath): void
-    {
-        return; // see #4099
-        //@chmod($filePath, 0400);
-        //if (!is_readable($filePath)) {
-        @chmod($filePath, 0440);
-        if (!is_readable($filePath)) {
-            @chmod($filePath, 0444);
-        }
-        //}
-    }
-
     /**
      * Remove base64 encoding for admin parameters.
      */

--- a/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
@@ -158,8 +158,6 @@ class StageHelper
                 return $this->parameterHelper->finalizeParameters();
             case 'installassets':
                 return $this->extensionHelper->installAssets();
-            case 'protect':
-                return $this->parameterHelper->protectFiles();
             case 'reinitparams':
                 return $this->parameterHelper->reInitParameters();
             case 'upgrade_event':

--- a/src/Zikula/CoreInstallerBundle/Stage/Install/AjaxInstallerStage.php
+++ b/src/Zikula/CoreInstallerBundle/Stage/Install/AjaxInstallerStage.php
@@ -206,20 +206,13 @@ class AjaxInstallerStage implements AjaxStageInterface
                 AjaxStageInterface::FAIL => $this->trans('There was an error finalizing the parameters')
             ],
             24 => [
-                AjaxStageInterface::NAME => 'protect',
-                AjaxStageInterface::PRE => $this->trans('Protect configuration files'),
-                AjaxStageInterface::DURING => $this->trans('Protecting configuration files'),
-                AjaxStageInterface::SUCCESS => $this->trans('Configuration files protected'),
-                AjaxStageInterface::FAIL => $this->trans('There was an error protecting configuration files')
-            ],
-            25 => [
                 AjaxStageInterface::NAME => 'installassets',
                 AjaxStageInterface::PRE => $this->trans('Install assets'),
                 AjaxStageInterface::DURING => $this->trans('Installing assets to /public'),
                 AjaxStageInterface::SUCCESS => $this->trans('Assets installed'),
                 AjaxStageInterface::FAIL => $this->trans('Failed to install assets')
             ],
-            26 => [
+            25 => [
                 AjaxStageInterface::NAME => 'finish',
                 AjaxStageInterface::PRE => $this->trans('Finish'),
                 AjaxStageInterface::DURING => $this->trans('Finish'),

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1682,10 +1682,6 @@ https: null
 'Creating admin account': null
 'Admin account created': null
 'There was an error creating admin account': null
-'Protect configuration files': null
-'Protecting configuration files': null
-'Configuration files protected': null
-'There was an error protecting configuration files': null
 'Install assets': null
 'Installing assets to /public': null
 'Assets installed': null


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixed #4099 
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR removes the file protection step from the installer.

## Motivation

After reading "[Setting up or Fixing File Permissions](https://symfony.com/doc/current/setup/file_permissions.html)" and [this change](https://github.com/symfony/symfony-docs/commit/d50d0e61d539750b9654b3498f6a9c95361c635c#diff-2431472755b734c40ef5fd8e7738beda) I realised that only `public/` will be reachable from the web anymore. So we would only trip up the site admin if he can no longer open the files.

Added a note to #3967 about that only `public/` needs to be configured as web root, referring to "[Configuring a Web Server](https://symfony.com/doc/current/setup/web_server_configuration.html)".

## Counterargument

If there are hosting scenarios where people are not able to point their web root to `public/` then `.env.local` will be reachable from the web.

Hence, I added another possible solution in #4250.