### PR TITLE
set different file permissions depending on installer environment

### DIFF
--- a/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
@@ -202,14 +202,14 @@ class ParameterHelper
 
     private function protectFile(string $filePath): void
     {
-        return; // see #4099
-        //@chmod($filePath, 0400);
-        //if (!is_readable($filePath)) {
-        @chmod($filePath, 0440);
-        if (!is_readable($filePath)) {
+        if ('cli' === php_sapi_name()) {
             @chmod($filePath, 0444);
+        } else {
+            @chmod($filePath, 0440);
+            if (!is_readable($filePath)) {
+                @chmod($filePath, 0444);
+            }
         }
-        //}
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixed #4099
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR sets file permissions less strict when installing using CLI. Because when using CLI this is typically done with the own user while HTTP is done by the web user.

This is an alternative approach compared to #4249.