### PR TITLE
inject environment vars instead of using super global

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -39,7 +39,7 @@ $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !=
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
 
 // on install or upgrade, check if system requirements are met.
-RequirementChecker::verify();
+(new RequirementChecker($_ENV['ZIKULA_INSTALLED']))->verify();
 
 // globally ignore @type annotation. Necessary to be able to use the extended array documentation syntax.
 AnnotationReader::addGlobalIgnoredName('type');

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -28,7 +28,7 @@ class Kernel extends ZikulaKernel
 
     public function registerBundles(): iterable
     {
-        $bundleHelper = new PersistedBundleHelper();
+        $bundleHelper = new PersistedBundleHelper($_ENV['DATABASE_URL'] ?? '');
         $bundles = require $this->getProjectDir() . '/config/bundles.php';
         $bundleHelper->getPersistedBundles($this, $bundles);
 

--- a/src/Zikula/CoreBundle/Helper/PersistedBundleHelper.php
+++ b/src/Zikula/CoreBundle/Helper/PersistedBundleHelper.php
@@ -30,6 +30,16 @@ class PersistedBundleHelper
      */
     private $extensionStateMap = [];
 
+    /**
+     * @var string
+     */
+    private $databaseUrl;
+
+    public function __construct(string $databaseUrl = '')
+    {
+        $this->databaseUrl = $databaseUrl;
+    }
+
     public function getPersistedBundles(ZikulaHttpKernelInterface $kernel, array &$bundles): void
     {
         try {
@@ -75,7 +85,7 @@ class PersistedBundleHelper
     private function getConnection(): Connection
     {
         $connectionParams = [
-            'url' => $_ENV['DATABASE_URL'] ?? ''
+            'url' => $this->databaseUrl ?? ''
         ];
 
         return DriverManager::getConnection($connectionParams, new Configuration());

--- a/src/Zikula/CoreBundle/Resources/config/services.yaml
+++ b/src/Zikula/CoreBundle/Resources/config/services.yaml
@@ -6,6 +6,7 @@ services:
         bind:
             $installed: '%env(ZIKULA_INSTALLED)%'
             $projectDir: '%kernel.project_dir%'
+            $databaseUrl: '%env(DATABASE_URL)%'
 
     # alias interface to doctrine service
     Doctrine\Persistence\ManagerRegistry: '@doctrine'

--- a/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
@@ -43,6 +43,11 @@ class StageHelper
     private $kernel;
 
     /**
+     * @var PersistedBundleHelper
+     */
+    private $persistedBundleHelper;
+
+    /**
      * @var BundlesSchemaHelper
      */
     private $bundlesSchemaHelper;
@@ -79,6 +84,7 @@ class StageHelper
 
     public function __construct(
         ZikulaHttpKernelInterface $kernel,
+        PersistedBundleHelper $persistedBundleHelper,
         BundlesSchemaHelper $bundlesSchemaHelper,
         ExtensionHelper $extensionHelper,
         EventDispatcherInterface $eventDispatcher,
@@ -90,6 +96,7 @@ class StageHelper
         string $installed
     ) {
         $this->kernel = $kernel;
+        $this->persistedBundleHelper = $persistedBundleHelper;
         $this->bundlesSchemaHelper = $bundlesSchemaHelper;
         $this->extensionHelper = $extensionHelper;
         $this->eventDispatcher = $eventDispatcher;
@@ -196,9 +203,8 @@ class StageHelper
     private function createBundles(): bool
     {
         $this->bundlesSchemaHelper->load();
-        $bundleHelper = new PersistedBundleHelper();
         $bundles = [];
-        $bundleHelper->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
+        $this->persistedBundleHelper->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
 
         return true;
     }

--- a/src/Zikula/CoreInstallerBundle/Resources/config/services.yaml
+++ b/src/Zikula/CoreInstallerBundle/Resources/config/services.yaml
@@ -6,6 +6,8 @@ services:
             $installed: '%env(ZIKULA_INSTALLED)%'
             $projectDir: '%kernel.project_dir%'
             $locale: '%locale%'
+            $databaseUrl: '%env(DATABASE_URL)%'
+            $mailerDsn: '%env(MAILER_DSN)%'
 
     _instanceof:
         Zikula\Component\Wizard\StageInterface:

--- a/src/Zikula/CoreInstallerBundle/Stage/EmailTransportStage.php
+++ b/src/Zikula/CoreInstallerBundle/Stage/EmailTransportStage.php
@@ -26,9 +26,15 @@ class EmailTransportStage implements StageInterface, FormHandlerInterface
      */
     private $projectDir;
 
-    public function __construct(string $projectDir)
+    /**
+     * @var string
+     */
+    private $mailerDsn;
+
+    public function __construct(string $projectDir, string $mailerDsn = '')
     {
         $this->projectDir = $projectDir;
+        $this->mailerDsn = $mailerDsn;
     }
 
     public function getName(): string
@@ -53,7 +59,7 @@ class EmailTransportStage implements StageInterface, FormHandlerInterface
 
     public function isNecessary(): bool
     {
-        $mailerDsn = $_ENV['MAILER_DSN'] ?? '';
+        $mailerDsn = $this->mailerDsn;
         if (!empty($mailerDsn) && 'smtp://localhost' !== $mailerDsn) {
             return false;
         }

--- a/src/Zikula/CoreInstallerBundle/Stage/Install/DbCredsStage.php
+++ b/src/Zikula/CoreInstallerBundle/Stage/Install/DbCredsStage.php
@@ -38,10 +38,16 @@ class DbCredsStage implements StageInterface, FormHandlerInterface
      */
     private $projectDir;
 
-    public function __construct(string $projectDir)
+    /**
+     * @var string
+     */
+    private $databaseUrl;
+
+    public function __construct(string $projectDir, string $databaseUrl = '')
     {
         $this->yamlManager = new YamlDumper($projectDir . '/config', 'services_custom.yaml');
         $this->projectDir = $projectDir;
+        $this->databaseUrl = $databaseUrl;
     }
 
     public function getName(): string
@@ -67,7 +73,7 @@ class DbCredsStage implements StageInterface, FormHandlerInterface
     public function isNecessary(): bool
     {
         $params = $this->yamlManager->getParameters();
-        $databaseUrl = $_ENV['DATABASE_URL'] ?? '';
+        $databaseUrl = $this->databaseUrl;
         if (empty($databaseUrl) || 'nothing' === $databaseUrl) {
             // check if credentials are temporarily stored as parameter during installation
             $databaseUrl = $params['database_url'] ?? '';

--- a/src/Zikula/CoreInstallerBundle/Util/RequirementChecker.php
+++ b/src/Zikula/CoreInstallerBundle/Util/RequirementChecker.php
@@ -18,19 +18,32 @@ use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaKernel;
 
 class RequirementChecker
 {
-    private static $parameters;
+    /**
+     * @var array
+     */
+    private $parameters;
+
+    /**
+     * @var string
+     */
+    private $installedVersion;
+
+    public function __construct(string $installed)
+    {
+        $this->installedVersion = $installed;
+    }
 
     /**
      * If not installed, or if currentVersion != installedVersion run
      * requirement checks. Die on failure.
      */
-    public static function verify(): void
+    public function verify(): void
     {
         // on install or upgrade, check if system requirements are met.
-        if (version_compare($_ENV['ZIKULA_INSTALLED'], ZikulaKernel::VERSION, '<')) {
-            self::loadParametersFromFile();
+        if (version_compare($this->installedVersion, ZikulaKernel::VERSION, '<')) {
+            $this->loadParametersFromFile();
             $versionChecker = new ZikulaRequirements();
-            $versionChecker->runSymfonyChecks(self::$parameters);
+            $versionChecker->runSymfonyChecks($this->parameters);
             if (empty($versionChecker->requirementsErrors)) {
                 return;
             }
@@ -53,14 +66,14 @@ class RequirementChecker
 
     public static function getParameter($name)
     {
-        self::loadParametersFromFile();
+        $this->loadParametersFromFile();
 
-        return self::$parameters[$name];
+        return $this->parameters[$name];
     }
 
     private static function loadParametersFromFile(): void
     {
-        if (is_array(self::$parameters)) {
+        if (is_array($this->parameters)) {
             return;
         }
         $projectDir = dirname(__DIR__, 4); // should work when Bundle in vendor too
@@ -71,6 +84,6 @@ class RequirementChecker
         $parameters = $kernelConfig['parameters'];
         $parameters['kernel.project_dir'] = $projectDir;
 
-        self::$parameters = $parameters;
+        $this->parameters = $parameters;
     }
 }

--- a/src/Zikula/CoreInstallerBundle/Util/RequirementChecker.php
+++ b/src/Zikula/CoreInstallerBundle/Util/RequirementChecker.php
@@ -64,14 +64,14 @@ class RequirementChecker
         }
     }
 
-    public static function getParameter($name)
+    public function getParameter($name)
     {
         $this->loadParametersFromFile();
 
         return $this->parameters[$name];
     }
 
-    private static function loadParametersFromFile(): void
+    private function loadParametersFromFile(): void
     {
         if (is_array($this->parameters)) {
             return;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

Environment variables should be injected so the code is independent of where the variable comes from.
