### PR TITLE
moved admin panel calls from extension templates into theme

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -194,3 +194,4 @@
   - Introduced a new `\Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface` for dynamic site attributes (#3972).
   - Extended site definition and added means for site-wide branding (#3972).
   - Using `utf8mb4` charset on MySQL platforms for real utf8 support (#3784).
+  - Moved calling `adminHeader()` and `adminFooter()` into theme level (#4255).

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -194,4 +194,4 @@
   - Introduced a new `\Zikula\Bundle\CoreBundle\Site\SiteDefinitionInterface` for dynamic site attributes (#3972).
   - Extended site definition and added means for site-wide branding (#3972).
   - Using `utf8mb4` charset on MySQL platforms for real utf8 support (#3784).
-  - Moved calling `adminHeader()` and `adminFooter()` into theme level (#4255).
+  - Moved calling `adminHeader()` and `adminFooter()` into theme layer (#4255).

--- a/docs/Development/General/Refactoring_3.md
+++ b/docs/Development/General/Refactoring_3.md
@@ -246,7 +246,7 @@ and so on…
 
 ### Template paths
 
-- change all template names from e.g. `Bundle:Controller:Action.html.twig` to `@Bundle/Controller/Action.html.twig`
+- Change all template names from e.g. `Bundle:Controller:Action.html.twig` to `@Bundle/Controller/Action.html.twig`.
 - Modules and themes retain the `Module` or `Theme` suffix but bundles do not.
 
 ### Templates
@@ -271,3 +271,8 @@ and so on…
 | Language name | `{{ myLanguage\|languagename }}` | `{{ myLanguage\|language_name }}` | [language_name](https://twig.symfony.com/language_name) reference |
 | Locale name | unavailable | `{{ myLocale\|locale_name }}` | [locale_name](https://twig.symfony.com/locale_name) reference |
 | Timezone name | unavailable | `{{ myTimezone\|timezone_name }}` | [timezone_name](https://twig.symfony.com/timezone_name) reference |
+
+### Admin panel integration
+
+- Remove all calls of `adminHeader()` and `adminFooter()` from extension templates.
+- Ensure that your admin theme calls them instead at a central place where appropriate.

--- a/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
@@ -43,6 +43,11 @@ class StageHelper
     private $kernel;
 
     /**
+     * @var PersistedBundleHelper
+     */
+    private $persistedBundleHelper;
+
+    /**
      * @var BundlesSchemaHelper
      */
     private $bundlesSchemaHelper;
@@ -79,6 +84,7 @@ class StageHelper
 
     public function __construct(
         ZikulaHttpKernelInterface $kernel,
+        PersistedBundleHelper $persistedBundleHelper,
         BundlesSchemaHelper $bundlesSchemaHelper,
         ExtensionHelper $extensionHelper,
         EventDispatcherInterface $eventDispatcher,
@@ -90,6 +96,7 @@ class StageHelper
         string $installed
     ) {
         $this->kernel = $kernel;
+        $this->persistedBundleHelper = $persistedBundleHelper;
         $this->bundlesSchemaHelper = $bundlesSchemaHelper;
         $this->extensionHelper = $extensionHelper;
         $this->eventDispatcher = $eventDispatcher;
@@ -194,9 +201,8 @@ class StageHelper
     private function createBundles(): bool
     {
         $this->bundlesSchemaHelper->load();
-        $bundleHelper = new PersistedBundleHelper();
         $bundles = [];
-        $bundleHelper->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
+        $this->persistedBundleHelper->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
 
         return true;
     }

--- a/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
@@ -43,11 +43,6 @@ class StageHelper
     private $kernel;
 
     /**
-     * @var PersistedBundleHelper
-     */
-    private $persistedBundleHelper;
-
-    /**
      * @var BundlesSchemaHelper
      */
     private $bundlesSchemaHelper;
@@ -84,7 +79,6 @@ class StageHelper
 
     public function __construct(
         ZikulaHttpKernelInterface $kernel,
-        PersistedBundleHelper $persistedBundleHelper,
         BundlesSchemaHelper $bundlesSchemaHelper,
         ExtensionHelper $extensionHelper,
         EventDispatcherInterface $eventDispatcher,
@@ -96,7 +90,6 @@ class StageHelper
         string $installed
     ) {
         $this->kernel = $kernel;
-        $this->persistedBundleHelper = $persistedBundleHelper;
         $this->bundlesSchemaHelper = $bundlesSchemaHelper;
         $this->extensionHelper = $extensionHelper;
         $this->eventDispatcher = $eventDispatcher;
@@ -201,8 +194,9 @@ class StageHelper
     private function createBundles(): bool
     {
         $this->bundlesSchemaHelper->load();
+        $bundleHelper = new PersistedBundleHelper();
         $bundles = [];
-        $this->persistedBundleHelper->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
+        $bundleHelper->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
 
         return true;
     }

--- a/src/Zikula/HookBundle/Resources/views/Hook/edit.html.twig
+++ b/src/Zikula/HookBundle/Resources/views/Hook/edit.html.twig
@@ -1,7 +1,3 @@
-{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
-{{ pageAddAsset('javascript', asset('bundles/zikulahook/js/hookui.js')) }}
-{{ pageAddAsset('stylesheet', asset('bundles/zikulahook/css/hooks.css')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-paperclip"></span>
     {% trans %}Hooks{% endtrans %}
@@ -53,4 +49,7 @@
 {% if isSubscriber %}
     <div id="areaDefinitions" data-areas='[{% if isSubscriber and subscriberAreas is not empty %}{% for sarea in subscriberAreas %}{% set sarea_md5 = sarea|php('md5') %}"sarea_{{ sarea_md5 }}"{% if not loop.last %},{% endif %}{% endfor %}{% endif %}]'></div>
 {% endif %}
-{{ adminFooter() }}
+
+{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
+{{ pageAddAsset('javascript', asset('bundles/zikulahook/js/hookui.js')) }}
+{{ pageAddAsset('stylesheet', asset('bundles/zikulahook/css/hooks.css')) }}

--- a/src/system/AdminModule/Resources/public/css/style.css
+++ b/src/system/AdminModule/Resources/public/css/style.css
@@ -2,7 +2,7 @@
  * Admin area (introduced in Core 1.3)
  ******************************************************************************/
 
-#z-maincontent div.z-admin-content {
+body div.z-admin-content {
     background: #fff;
     color: #333;
     width: auto;
@@ -11,7 +11,7 @@
     padding: 5px 1%;
 }
 
-#z-maincontent div.z-admin-content .navbar {
+body div.z-admin-content .navbar {
     margin: 0.5em 0;
 }
 
@@ -19,8 +19,8 @@
 * Styling for all general headers in the entire admin box.
 ******************************************************************************/
 
-#z-maincontent div.z-admin-content h2,
-#z-maincontent div.z-admin-content h3 {
+body div.z-admin-content h2,
+body div.z-admin-content h3 {
     background: none;
     color: #333;
     text-align: left;
@@ -32,12 +32,12 @@
 * Module- and pageheaders (iconheader)
 ******************************************************************************/
 
-#z-maincontent div.z-admin-content-modtitle {
+body div.z-admin-content-modtitle {
     padding: 5px 0;
 }
 
-#z-maincontent div.z-admin-content-modtitle:after,
-#z-maincontent div.z-admin-content-pagetitle:after {
+body div.z-admin-content-modtitle:after,
+body div.z-admin-content-pagetitle:after {
     /* clearfix */
     content: ".";
     display: block;
@@ -46,17 +46,17 @@
     visibility: hidden;
 }
 
-#z-maincontent div.z-admin-content-modtitle img {
+body div.z-admin-content-modtitle img {
     float: left;
     margin-right: 10px;
 }
 
-#z-maincontent div.z-admin-content-pagetitle img {
+body div.z-admin-content-pagetitle img {
     float: left;
     margin-right: 5px;
 }
 
-#z-maincontent div.z-admin-content-modtitle h2 {
+body div.z-admin-content-modtitle h2 {
     background: none;
     border: none;
     color: #333;
@@ -68,11 +68,11 @@
     text-align: left;
 }
 
-#z-maincontent div.z-admin-content-pagetitle {
+body div.z-admin-content-pagetitle {
     padding: 10px 0;
 }
 
-#z-maincontent div.z-admin-content-pagetitle h3 {
+body div.z-admin-content-pagetitle h3 {
     background: none;
     color: #333;
     font-size: 18px;

--- a/src/system/AdminModule/Resources/views/Admin/delete.html.twig
+++ b/src/system/AdminModule/Resources/views/Admin/delete.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-trash-alt"></span>
     {% trans %}Delete module category{% endtrans %}
@@ -18,4 +17,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/AdminModule/Resources/views/Admin/editCategory.html.twig
+++ b/src/system/AdminModule/Resources/views/Admin/editCategory.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     {% if form.vars.value.cid %}
         <span class="fas fa-pencil-alt"></span>
@@ -27,4 +26,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/AdminModule/Resources/views/Admin/view.html.twig
+++ b/src/system/AdminModule/Resources/views/Admin/view.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Module categories list{% endtrans %}
@@ -53,4 +52,3 @@
     </tbody>
 </table>
 {{ include(paginator.template) }}
-{{ adminFooter() }}

--- a/src/system/AdminModule/Resources/views/Config/config.html.twig
+++ b/src/system/AdminModule/Resources/views/Config/config.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
@@ -36,4 +35,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/BlocksModule/Resources/views/Admin/delete.html.twig
+++ b/src/system/BlocksModule/Resources/views/Admin/delete.html.twig
@@ -1,11 +1,8 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-trash-alt"></span> {% trans %}Delete block{% endtrans %} '{{ block.title }}'
     {{ pageSetVar('title', 'Delete block'|trans) }}
 </h3>
-
 <p class="alert alert-warning">{% trans with {'%title%': block.title} %}Do you really want to delete block '%title%'?{% endtrans %}</p>
-
 {{ form_start(form) }}
 {{ form_errors(form) }}
 <div class="form-group row">
@@ -15,4 +12,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/BlocksModule/Resources/views/Admin/edit.html.twig
+++ b/src/system/BlocksModule/Resources/views/Admin/edit.html.twig
@@ -1,5 +1,3 @@
-{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.Edit.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-edit"></span>
     {% if form.vars.value.bid %}
@@ -58,4 +56,4 @@
 </div>
 {{ form_end(form) }}
 <div id="filterDefinitions" data-count="{{ form.filters|length }}"></div>
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.Edit.js')) }}

--- a/src/system/BlocksModule/Resources/views/Admin/new.html.twig
+++ b/src/system/BlocksModule/Resources/views/Admin/new.html.twig
@@ -1,5 +1,3 @@
-{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.New.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-plus-square"></span>
     {% trans %}Create block{% endtrans %}
@@ -19,4 +17,4 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.New.js')) }}

--- a/src/system/BlocksModule/Resources/views/Admin/view.html.twig
+++ b/src/system/BlocksModule/Resources/views/Admin/view.html.twig
@@ -1,6 +1,3 @@
-{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.Common.js')) }}
-{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.View.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Blocks list{% endtrans %}
@@ -122,8 +119,6 @@ To delete a block position, click on the 'Delete' icon and confirm the action in
 </div>
 <p class="alert alert-warning"><i class="fas fa-exclamation-triangle text-danger"></i> {% trans %}Marked positions are not available in the current default theme.{% endtrans %}</p>
 
-{{ adminFooter() }}
-
 {# block preview modal #}
 <div class="modal fade" id="zikulablocksmodule-block-view-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog">
@@ -141,3 +136,6 @@ To delete a block position, click on the 'Delete' icon and confirm the action in
         </div>
     </div>
 </div>
+
+{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.Common.js')) }}
+{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.View.js')) }}

--- a/src/system/BlocksModule/Resources/views/Config/config.html.twig
+++ b/src/system/BlocksModule/Resources/views/Config/config.html.twig
@@ -1,10 +1,8 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
     {{ pageSetVar('title', 'Block settings'|trans) }}
 </h3>
-
 {{ form_start(form) }}
 {{ form_errors(form) }}
 {{ form_row(form.collapseable) }}
@@ -15,4 +13,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/BlocksModule/Resources/views/Placement/edit.html.twig
+++ b/src/system/BlocksModule/Resources/views/Placement/edit.html.twig
@@ -1,6 +1,3 @@
-{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.Common.js')) }}
-{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.Modifyposition.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-cubes"></span>
     {% trans %}Block placements{% endtrans %}
@@ -111,4 +108,5 @@
         {% endfor %}
     </tbody>
 </table>
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.Common.js')) }}
+{{ pageAddAsset('javascript', zasset('@ZikulaBlocksModule:js/Zikula.Blocks.Admin.Modifyposition.js')) }}

--- a/src/system/BlocksModule/Resources/views/Position/delete.html.twig
+++ b/src/system/BlocksModule/Resources/views/Position/delete.html.twig
@@ -1,11 +1,8 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-trash-alt"></span> {% trans %}Delete block position{% endtrans %} '{{ position.name }}'
     {{ pageSetVar('title', 'Delete block position'|trans) }}
 </h3>
-
 <p class="alert alert-warning">{% trans with {'%name%': position.name} %}Do you really want to delete position '%name%'?{% endtrans %}</p>
-
 {{ form_start(form) }}
 {{ form_errors(form) }}
 <div class="form-group row">
@@ -15,4 +12,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/BlocksModule/Resources/views/Position/edit.html.twig
+++ b/src/system/BlocksModule/Resources/views/Position/edit.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-edit"></span>
     {% if form.vars.value.pid %}
@@ -27,4 +26,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/BootstrapTheme/Resources/views/Body/1col.html.twig
+++ b/src/system/BootstrapTheme/Resources/views/Body/1col.html.twig
@@ -1,3 +1,5 @@
 <div class="container 1col">
+    {{ admin|default ? adminHeader() : '' }}
     {{ maincontent|raw }}
+    {{ admin|default ? adminFooter() : '' }}
 </div>

--- a/src/system/BootstrapTheme/Resources/views/Body/2col.html.twig
+++ b/src/system/BootstrapTheme/Resources/views/Body/2col.html.twig
@@ -4,8 +4,10 @@
             {{ showblockposition('left') }}
         </div>
         <div id="themeMainContent" class="col-md-9">
+            {{ admin|default ? adminHeader() : '' }}
             {{ showflashes() }}
             {{ maincontent|raw }}
+            {{ admin|default ? adminFooter() : '' }}
         </div>
     </div>
 </div>

--- a/src/system/BootstrapTheme/Resources/views/Body/3col.html.twig
+++ b/src/system/BootstrapTheme/Resources/views/Body/3col.html.twig
@@ -4,8 +4,10 @@
             {{ showblockposition('left') }}
         </div>
         <div id="themeMainContent" class="col-md-4">
+            {{ admin|default ? adminHeader() : '' }}
             {{ showflashes() }}
             {{ maincontent|raw }}
+            {{ admin|default ? adminFooter() : '' }}
         </div>
         <div id="themeRightColumn" class="col-md-4">
             {{ showblockposition('right') }}

--- a/src/system/CategoriesModule/Resources/views/Category/list.html.twig
+++ b/src/system/CategoriesModule/Resources/views/Category/list.html.twig
@@ -1,9 +1,3 @@
-{{ pageAddAsset('javascript', asset('jstree/dist/jstree.min.js')) }}
-{{ pageAddAsset('stylesheet', asset('jstree/dist/themes/default/style.min.css')) }}
-{{ pageAddAsset('stylesheet', zasset('@ZikulaThemeModule:css/jstree.Common.css')) }}
-{{ pageAddAsset('javascript', zasset('@ZikulaCategoriesModule:js/ZikulaCategoriesModule.Category.List.js')) }}
-{{ pageAddAsset('javascript', zasset('@ZikulaCategoriesModule:js/ZikulaCategoriesModule.Category.Edit.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Categories list{% endtrans %}
@@ -75,5 +69,9 @@
         </div>
     </div>
 </div>
-{{ adminFooter() }}
 {{ include('@ZikulaFormExtension/Form/icon_picker.html.twig') }}{# need to preload for editing inside modal #}
+{{ pageAddAsset('javascript', asset('jstree/dist/jstree.min.js')) }}
+{{ pageAddAsset('stylesheet', asset('jstree/dist/themes/default/style.min.css')) }}
+{{ pageAddAsset('stylesheet', zasset('@ZikulaThemeModule:css/jstree.Common.css')) }}
+{{ pageAddAsset('javascript', zasset('@ZikulaCategoriesModule:js/ZikulaCategoriesModule.Category.List.js')) }}
+{{ pageAddAsset('javascript', zasset('@ZikulaCategoriesModule:js/ZikulaCategoriesModule.Category.Edit.js')) }}

--- a/src/system/CategoriesModule/Resources/views/Registry/delete.html.twig
+++ b/src/system/CategoriesModule/Resources/views/Registry/delete.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-trash-alt"></span> {% trans %}Delete registry entry{% endtrans %}
     {{ pageSetVar('title', 'Delete registry entry'|trans) }}
@@ -20,4 +19,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/CategoriesModule/Resources/views/Registry/edit.html.twig
+++ b/src/system/CategoriesModule/Resources/views/Registry/edit.html.twig
@@ -1,11 +1,8 @@
-{{ pageAddAsset('javascript', zasset('@ZikulaCategoriesModule:js/ZikulaCategoriesModule.Registry.Edit.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-archive"></span>
     {% trans %}Edit category registry{% endtrans %}
     {{ pageSetVar('title', 'Edit category registry'|trans) }}
 </h3>
-
 {{ form_start(form) }}
 <div>
     <table class="table table-bordered table-striped">
@@ -69,4 +66,4 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', zasset('@ZikulaCategoriesModule:js/ZikulaCategoriesModule.Registry.Edit.js')) }}

--- a/src/system/ExtensionsModule/Resources/views/Config/config.html.twig
+++ b/src/system/ExtensionsModule/Resources/views/Config/config.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
@@ -20,5 +19,4 @@
 </div>
 {{ form_end(form) }}
 <div id="hardResetParameters" data-elementid="{{ form.hardreset.vars.id }}"></div>
-{{ adminFooter() }}
 {{ pageAddAsset('javascript', zasset('@ZikulaExtensionsModule:js/Zikula.Extensions.Config.js')) }}

--- a/src/system/ExtensionsModule/Resources/views/Extension/compatibility.html.twig
+++ b/src/system/ExtensionsModule/Resources/views/Extension/compatibility.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-info-circle"></span>
     {% trans %}Incompatible version with the core{% endtrans %} - {{ extension.displayname }}
@@ -18,4 +17,3 @@
         <a class="btn btn-primary" href="{{ path('zikulaextensionsmodule_extension_list') }}"><i class="fas fa-check"></i> {% trans %}Ok{% endtrans %}</a>
     </div>
 </div>
-{{ adminFooter() }}

--- a/src/system/ExtensionsModule/Resources/views/Extension/install.html.twig
+++ b/src/system/ExtensionsModule/Resources/views/Extension/install.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-plus"></span>
     {% trans %}Install extension{% endtrans %} '{{ extension.displayname }}'
@@ -47,4 +46,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/ExtensionsModule/Resources/views/Extension/list.html.twig
+++ b/src/system/ExtensionsModule/Resources/views/Extension/list.html.twig
@@ -1,6 +1,3 @@
-{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
-{{ pageAddAsset('javascript', zasset('@ZikulaExtensionsModule:js/Zikula.Extensions.Extension.List.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Extensions list{% endtrans %}
@@ -58,7 +55,6 @@
     </tbody>
 </table>
 {{ include(paginator.template) }}
-{{ adminFooter() }}
 
 {% macro adminRoute(extension) %}
     {# currently disabled because it may happen that routes for a newly activated module are not usable yet
@@ -85,3 +81,5 @@
         </span>
     {% endif %}
 {% endmacro %}
+{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
+{{ pageAddAsset('javascript', zasset('@ZikulaExtensionsModule:js/Zikula.Extensions.Extension.List.js')) }}

--- a/src/system/ExtensionsModule/Resources/views/Extension/modify.html.twig
+++ b/src/system/ExtensionsModule/Resources/views/Extension/modify.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 {{ showflashes() }}
 <h3>
     <span class="fas fa-wrench"></span>
@@ -19,4 +18,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/ExtensionsModule/Resources/views/Extension/uninstall.html.twig
+++ b/src/system/ExtensionsModule/Resources/views/Extension/uninstall.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-trash-alt"></span>
     {% trans %}Uninstall extension{% endtrans %} '{{ extension.displayname }}'
@@ -37,4 +36,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/GroupsModule/Resources/views/Application/admin.html.twig
+++ b/src/system/GroupsModule/Resources/views/Application/admin.html.twig
@@ -1,5 +1,4 @@
 {% set templateTitle = 'Administrate membership application'|trans %}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-{% if action == 'accept' %}user-plus{% else %}user-times{% endif %}"></span>
     {{ templateTitle }}
@@ -24,4 +23,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/GroupsModule/Resources/views/Config/config.html.twig
+++ b/src/system/GroupsModule/Resources/views/Config/config.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
@@ -22,4 +21,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/GroupsModule/Resources/views/Group/adminList.html.twig
+++ b/src/system/GroupsModule/Resources/views/Group/adminList.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Groups list{% endtrans %}
@@ -123,4 +122,3 @@
     </table>
 {% endif %}
 {{ include(paginator.template) }}
-{{ adminFooter() }}

--- a/src/system/GroupsModule/Resources/views/Group/create.html.twig
+++ b/src/system/GroupsModule/Resources/views/Group/create.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-plus"></span>
     {% trans %}Create new group{% endtrans %}
@@ -22,4 +21,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/GroupsModule/Resources/views/Group/edit.html.twig
+++ b/src/system/GroupsModule/Resources/views/Group/edit.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-pencil-alt"></span>
     {% trans %}Edit group{% endtrans %}
@@ -23,4 +22,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/GroupsModule/Resources/views/Group/remove.html.twig
+++ b/src/system/GroupsModule/Resources/views/Group/remove.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-trash-alt"></span>
     {% trans %}Delete group{% endtrans %}
@@ -18,4 +17,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/GroupsModule/Resources/views/Membership/adminList.html.twig
+++ b/src/system/GroupsModule/Resources/views/Membership/adminList.html.twig
@@ -1,5 +1,3 @@
-{{ pageAddAsset('javascript', zasset('@ZikulaUsersModule:js/Zikula.Users.Admin.View.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-users"></span>
     {% trans %}Group membership{% endtrans %} ({{ group.name }})
@@ -70,4 +68,4 @@
     <tbody>
     </tbody>
 </table>
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', zasset('@ZikulaUsersModule:js/Zikula.Users.Admin.View.js')) }}

--- a/src/system/GroupsModule/Resources/views/Membership/remove.html.twig
+++ b/src/system/GroupsModule/Resources/views/Membership/remove.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-user-times"></span>
     {% trans %}Remove user from group{% endtrans %}
@@ -21,4 +20,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/MailerModule/Resources/views/Config/config.html.twig
+++ b/src/system/MailerModule/Resources/views/Config/config.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
@@ -34,4 +33,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/MailerModule/Resources/views/Config/test.html.twig
+++ b/src/system/MailerModule/Resources/views/Config/test.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-envelope"></span>
     {% trans %}Test mailer settings{% endtrans %}
@@ -33,4 +32,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/MenuModule/Resources/views/Menu/delete.html.twig
+++ b/src/system/MenuModule/Resources/views/Menu/delete.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 {{ pageSetVar('title', 'Delete Root'|trans) }}
 <h3>
     <span class="fas fa-trash-alt"> {% trans %}Delete Root{% endtrans %}</span>
@@ -13,4 +12,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/MenuModule/Resources/views/Menu/editRootNode.html.twig
+++ b/src/system/MenuModule/Resources/views/Menu/editRootNode.html.twig
@@ -1,8 +1,6 @@
-{{ pageAddAsset('javascript', zasset('@ZikulaMenuModule:js/Zikula.Menu.Node.Edit.js')) }}
-{{ adminHeader() }}
 {{ pageSetVar('title', 'Create or Edit Root Node'|trans) }}
 <h3>
     <span class="fas fa-plus"> {% trans %}Create or edit root node{% endtrans %}</span>
 </h3>
 {{ include('@ZikulaMenuModule/Menu/edit.html.twig') }}
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', zasset('@ZikulaMenuModule:js/Zikula.Menu.Node.Edit.js')) }}

--- a/src/system/MenuModule/Resources/views/Menu/list.html.twig
+++ b/src/system/MenuModule/Resources/views/Menu/list.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 {{ pageSetVar('title', 'Menu list'|trans) }}
 <h3><span class="fas fa-list"></span> {% trans %}Menus{% endtrans %}</h3>
 <table id="menu-list" class="table table-bordered table-striped">
@@ -34,4 +33,3 @@
         {% endfor %}
     </tbody>
 </table>
-{{ adminFooter() }}

--- a/src/system/MenuModule/Resources/views/Menu/view.html.twig
+++ b/src/system/MenuModule/Resources/views/Menu/view.html.twig
@@ -1,9 +1,3 @@
-{{ pageAddAsset('javascript', asset('jstree/dist/jstree.min.js')) }}
-{{ pageAddAsset('stylesheet', asset('jstree/dist/themes/default/style.min.css')) }}
-{{ pageAddAsset('stylesheet', zasset('@ZikulaThemeModule:css/jstree.Common.css')) }}
-{{ pageAddAsset('javascript', zasset('@ZikulaMenuModule:js/ZikulaMenuModule.Admin.View.js')) }}
-{{ pageAddAsset('javascript', zasset('@ZikulaMenuModule:js/Zikula.Menu.Node.Edit.js')) }}
-{{ adminHeader() }}
 {{ pageSetVar('title', 'Menu'|trans) }}
 <h3>
     <span class="fas fa-list"></span>
@@ -51,4 +45,8 @@
         </div>
     </div>
 </div>
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', asset('jstree/dist/jstree.min.js')) }}
+{{ pageAddAsset('stylesheet', asset('jstree/dist/themes/default/style.min.css')) }}
+{{ pageAddAsset('stylesheet', zasset('@ZikulaThemeModule:css/jstree.Common.css')) }}
+{{ pageAddAsset('javascript', zasset('@ZikulaMenuModule:js/ZikulaMenuModule.Admin.View.js')) }}
+{{ pageAddAsset('javascript', zasset('@ZikulaMenuModule:js/Zikula.Menu.Node.Edit.js')) }}

--- a/src/system/PermissionsModule/Resources/views/Config/config.html.twig
+++ b/src/system/PermissionsModule/Resources/views/Config/config.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
@@ -20,4 +19,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/PermissionsModule/Resources/views/Permission/list.html.twig
+++ b/src/system/PermissionsModule/Resources/views/Permission/list.html.twig
@@ -1,7 +1,3 @@
-{{ pageAddAsset('stylesheet', asset('jquery-ui/themes/base/jquery-ui.min.css')) }}
-{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
-{{ pageAddAsset('javascript', zasset('@ZikulaPermissionsModule:js/Zikula.Permission.Admin.View.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Permission rules list{% endtrans %}
@@ -130,4 +126,6 @@
         </div>
     </div>
 </div>
-{{ adminFooter() }}
+{{ pageAddAsset('stylesheet', asset('jquery-ui/themes/base/jquery-ui.min.css')) }}
+{{ pageAddAsset('javascript', asset('jquery-ui/jquery-ui.min.js'), constant('Zikula\\ThemeModule\\Engine\\AssetBag::WEIGHT_JQUERY_UI')) }}
+{{ pageAddAsset('javascript', zasset('@ZikulaPermissionsModule:js/Zikula.Permission.Admin.View.js')) }}

--- a/src/system/RoutesModule/Resources/views/adminBase.html.twig
+++ b/src/system/RoutesModule/Resources/views/adminBase.html.twig
@@ -1,17 +1,6 @@
 {# purpose of this template: admin area base layout #}
 {% extends '@ZikulaRoutesModule/base.html.twig' %}
-{% block header %}
-    {% if not app.request.query.getBoolean('raw', false) %}
-        {{ adminHeader() }}
-    {% endif %}
-    {{ parent() }}
-{% endblock %}
 {% block appTitle %}{# empty on purpose #}{% endblock %}
 {% block titleArea %}
     <h3><i class="fas fa-{% block admin_page_icon %}{% endblock %}"></i> {% block title %}{% endblock %}</h3>
-{% endblock %}
-{% block footer %}
-    {% if not app.request.query.getBoolean('raw', false) %}
-        {{ adminFooter() }}
-    {% endif %}
 {% endblock %}

--- a/src/system/SearchModule/Resources/views/Config/config.html.twig
+++ b/src/system/SearchModule/Resources/views/Config/config.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
@@ -33,4 +32,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/SecurityCenterModule/Resources/views/Config/allowedhtml.html.twig
+++ b/src/system/SecurityCenterModule/Resources/views/Config/allowedhtml.html.twig
@@ -1,6 +1,4 @@
 {% trans_default_domain 'security' %}
-{{ pageAddAsset('javascript', zasset('@ZikulaSecurityCenterModule:js/ZikulaSecurityCenterModule.Admin.AllowedHtml.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Allowed HTML settings{% endtrans %}
@@ -94,4 +92,4 @@
         </div>
     </div>
 </form>
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', zasset('@ZikulaSecurityCenterModule:js/ZikulaSecurityCenterModule.Admin.AllowedHtml.js')) }}

--- a/src/system/SecurityCenterModule/Resources/views/Config/config.html.twig
+++ b/src/system/SecurityCenterModule/Resources/views/Config/config.html.twig
@@ -1,5 +1,4 @@
 {% trans_default_domain 'security' %}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Security settings{% endtrans %}
@@ -65,4 +64,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/SecurityCenterModule/Resources/views/Config/purifierconfig.html.twig
+++ b/src/system/SecurityCenterModule/Resources/views/Config/purifierconfig.html.twig
@@ -1,6 +1,4 @@
 {% trans_default_domain 'security' %}
-{{ pageAddAsset('javascript', zasset('@ZikulaSecurityCenterModule:js/ZikulaSecurityCenterModule.Admin.PurifierConfig.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}HTMLPurifier settings{% endtrans %}
@@ -92,4 +90,4 @@
         </div>
     </div>
 </form>
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', zasset('@ZikulaSecurityCenterModule:js/ZikulaSecurityCenterModule.Admin.PurifierConfig.js')) }}

--- a/src/system/SecurityCenterModule/Resources/views/IdsLog/export.html.twig
+++ b/src/system/SecurityCenterModule/Resources/views/IdsLog/export.html.twig
@@ -1,5 +1,4 @@
 {% trans_default_domain 'security' %}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-download"></span>
     {% trans %}Export IDS log{% endtrans %}
@@ -30,4 +29,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/SecurityCenterModule/Resources/views/IdsLog/purge.html.twig
+++ b/src/system/SecurityCenterModule/Resources/views/IdsLog/purge.html.twig
@@ -1,5 +1,4 @@
 {% trans_default_domain 'security' %}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-trash-alt"></span>
     {% trans %}Purge IDS log{% endtrans %}
@@ -28,4 +27,3 @@
     </div>
 </fieldset>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/SecurityCenterModule/Resources/views/IdsLog/view.html.twig
+++ b/src/system/SecurityCenterModule/Resources/views/IdsLog/view.html.twig
@@ -1,5 +1,4 @@
 {% trans_default_domain 'security' %}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-archive"></span>
     {% trans %}View IDS log{% endtrans %}
@@ -114,5 +113,4 @@
 {% else %}
     <p class="alert alert-info text-center">{% trans %}No logged intrusions found.{% endtrans %}</p>
 {% endif %}
-{{ adminFooter() }}
 {{ pageAddAsset('javascript', zasset('@ZikulaSecurityCenterModule:js/ZikulaSecurityCenterModule.IdsLogFilter.js')) }}

--- a/src/system/SettingsModule/Resources/views/Settings/locale.html.twig
+++ b/src/system/SettingsModule/Resources/views/Settings/locale.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Localisation settings{% endtrans %}
@@ -30,4 +29,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/SettingsModule/Resources/views/Settings/main.html.twig
+++ b/src/system/SettingsModule/Resources/views/Settings/main.html.twig
@@ -1,10 +1,8 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Main settings{% endtrans %}
     {{ pageSetVar('title', 'Main settings'|trans) }}
 </h3>
-
 {{ form_start(form) }}
 {{ form_errors(form) }}
 {% set currentLocale = app.request.locale|default('en') %}
@@ -114,4 +112,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/SettingsModule/Resources/views/Settings/phpinfo.html.twig
+++ b/src/system/SettingsModule/Resources/views/Settings/phpinfo.html.twig
@@ -1,5 +1,3 @@
-{{ pageAddAsset('javascript', zasset('@ZikulaSettingsModule:js/ZikulaSettingsModule.Admin.Phpinfo.js')) }}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-info-circle"></span>
     {% trans %}PHP configuration{% endtrans %}
@@ -8,4 +6,4 @@
 <div id="phpinfo">
     {{ phpinfo|raw }}
 </div>
-{{ adminFooter() }}
+{{ pageAddAsset('javascript', zasset('@ZikulaSettingsModule:js/ZikulaSettingsModule.Admin.Phpinfo.js')) }}

--- a/src/system/ThemeModule/Resources/views/Config/config.html.twig
+++ b/src/system/ThemeModule/Resources/views/Config/config.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
@@ -79,4 +78,3 @@
         </table>
     </div>
 </fieldset>
-{{ adminFooter() }}

--- a/src/system/ThemeModule/Resources/views/Var/var.html.twig
+++ b/src/system/ThemeModule/Resources/views/Var/var.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {{ themeName }} {% trans %}Theme config{% endtrans %}
@@ -9,4 +8,3 @@
 {{ form_start(form) }}
 {{ form_widget(form) }}
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/UsersModule/Resources/views/Config/authenticationMethods.html.twig
+++ b/src/system/UsersModule/Resources/views/Config/authenticationMethods.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-lock"></span>
     {% trans %}Authentication methods{% endtrans %}
@@ -28,4 +27,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/UsersModule/Resources/views/Config/config.html.twig
+++ b/src/system/UsersModule/Resources/views/Config/config.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
@@ -45,5 +44,4 @@
 </div>
 {{ form_end(form) }}
 <div id="configElementIdentifiers" data-registration-enabled="{{ form[constant('MODVAR_REGISTRATION_ENABLED', UC)].vars.id }}" data-auto-login="{{ form[constant('MODVAR_REGISTRATION_AUTO_LOGIN', UC)].vars.id }}" data-approval-required="{{ form[constant('MODVAR_REGISTRATION_APPROVAL_REQUIRED', UC)].vars.id }}"></div>
-{{ adminFooter() }}
 {{ pageAddAsset('javascript', zasset('@ZikulaUsersModule:js/Zikula.Users.Config.js')) }}

--- a/src/system/UsersModule/Resources/views/FileIO/export.html.twig
+++ b/src/system/UsersModule/Resources/views/FileIO/export.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-download"></span>
     {% trans %}Export users{% endtrans %}
@@ -27,4 +26,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/UsersModule/Resources/views/Migration/migrate.html.twig
+++ b/src/system/UsersModule/Resources/views/Migration/migrate.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-cogs"></span>
     {% trans %}Migrate Users to ZAuth{% endtrans %}
@@ -18,8 +17,7 @@
         <span class="sr-only">{% trans %}Progress bar{% endtrans %}</span>
     </div>
 </div>
-<div class="alert alert-info">{% trans with {'%f': count} %}There are %f users to try to migrate.{% endtrans %}</div>
-<div class="text-center"><i id='spinner' class="fas fa-cog fa-2x fa-spin fa-fw" style="display: none"></i> <button id="migrate" class="btn btn-lg btn-success">{% trans %}Begin Migration{% endtrans %}</button></div>
+<div class="alert alert-info">{% trans with {'%f%': count} %}There are %f% users to try to migrate.{% endtrans %}</div>
+<div class="text-center"><i id="spinner" class="fas fa-cog fa-2x fa-spin fa-fw" style="display: none"></i> <button id="migrate" class="btn btn-lg btn-success">{% trans %}Begin Migration{% endtrans %}</button></div>
 <div id="redirectUrlAfterSuccess" data-route="{{ path('zikulausersmodule_useradministration_list') }}"></div>
-{{ adminFooter() }}
 {{ pageAddAsset('javascript', zasset('@ZikulaUsersModule:js/Zikula.Users.Admin.Migration.js')) }}

--- a/src/system/UsersModule/Resources/views/UserAdministration/approve.html.twig
+++ b/src/system/UsersModule/Resources/views/UserAdministration/approve.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-plus"></span>
     {% trans with {"%sub%": user.uname} %}Approve registration of %sub%{% endtrans %}
@@ -55,4 +54,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/UsersModule/Resources/views/UserAdministration/delete.html.twig
+++ b/src/system/UsersModule/Resources/views/UserAdministration/delete.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-trash-alt"></span>
     {% trans %}Delete confirmation{% endtrans %}
@@ -19,4 +18,3 @@
         {{ form_widget(form.cancel) }}
     </div>
 </div>
-{{ form_end(form) }}

--- a/src/system/UsersModule/Resources/views/UserAdministration/list.html.twig
+++ b/src/system/UsersModule/Resources/views/UserAdministration/list.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Users list{% endtrans %}
@@ -78,5 +77,4 @@
     <tbody>
     </tbody>
 </table>
-{{ adminFooter() }}
 {{ pageAddAsset('javascript', zasset('@ZikulaUsersModule:js/Zikula.Users.Admin.View.js')) }}

--- a/src/system/UsersModule/Resources/views/UserAdministration/modify.html.twig
+++ b/src/system/UsersModule/Resources/views/UserAdministration/modify.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-plus"></span>
     {% trans with {'%uname': form.vars.value.uname} %}Edit user account of %uname{% endtrans %}
@@ -59,4 +58,3 @@
     </div>
 </fieldset>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/UsersModule/Resources/views/UserAdministration/search.html.twig
+++ b/src/system/UsersModule/Resources/views/UserAdministration/search.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-search"></span>
     {% trans %}Find users{% endtrans %}
@@ -22,4 +21,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/UsersModule/Resources/views/UserAdministration/searchResults.html.twig
+++ b/src/system/UsersModule/Resources/views/UserAdministration/searchResults.html.twig
@@ -1,8 +1,4 @@
 {% from '@ZikulaUsersModule/UserAdministration/userlist.html.twig' import userStatus as userStatus %}
-{% if hasPermission('ZikulaUsersModule', '::', 'ACCESS_DELETE') %}
-    {{ pageAddAsset('javascript', zasset('@ZikulaUsersModule:js/ZikulaUsersModule.Admin.SearchResults.js')) }}
-{% endif %}
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Search results{% endtrans %}
@@ -112,4 +108,6 @@
     </div>
     {{ form_end(mailForm) }}
 </div>
-{{ adminFooter() }}
+{% if hasPermission('ZikulaUsersModule', '::', 'ACCESS_DELETE') %}
+    {{ pageAddAsset('javascript', zasset('@ZikulaUsersModule:js/ZikulaUsersModule.Admin.SearchResults.js')) }}
+{% endif %}

--- a/src/system/ZAuthModule/Resources/views/Config/config.html.twig
+++ b/src/system/ZAuthModule/Resources/views/Config/config.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-wrench"></span>
     {% trans %}Settings{% endtrans %}
@@ -36,5 +35,4 @@
 </div>
 {{ form_end(form) }}
 <div id="antispamQuestionIdentifiers" data-question="{{ form[constant('MODVAR_REGISTRATION_ANTISPAM_QUESTION', ZAC)].vars.id }}" data-answer="{{ form[constant('MODVAR_REGISTRATION_ANTISPAM_ANSWER', ZAC)].vars.id }}"></div>
-{{ adminFooter() }}
 {{ pageAddAsset('javascript', zasset('@ZikulaZAuthModule:js/Zikula.ZAuth.Config.js')) }}

--- a/src/system/ZAuthModule/Resources/views/FileIO/import.html.twig
+++ b/src/system/ZAuthModule/Resources/views/FileIO/import.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-upload"></span>
     {% trans %}Import users{% endtrans %}
@@ -53,4 +52,3 @@
         <dd>{% trans %}robert,hispassword,robert@example.org{% endtrans %}</dd>
     </dl>
 </div>
-{{ adminFooter() }}

--- a/src/system/ZAuthModule/Resources/views/UserAdministration/batchForcePasswordChange.html.twig
+++ b/src/system/ZAuthModule/Resources/views/UserAdministration/batchForcePasswordChange.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <i class="fas fa-lock"></i> {% trans %}Force Password change for users{% endtrans %}
     {{ pageSetVar('title', 'Force Password change for users'|trans) }}
@@ -22,4 +21,3 @@
     </div>
 </fieldset>
 {{ form_end(form) }}
-{{ adminFooter() }}

--- a/src/system/ZAuthModule/Resources/views/UserAdministration/create.html.twig
+++ b/src/system/ZAuthModule/Resources/views/UserAdministration/create.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-plus"></span>
     {% trans %}Create new user{% endtrans %}
@@ -40,7 +39,6 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}
 <div id="setPassIdentifiers" data-setpassid="{{ form.setpass.vars.id }}" data-passid="{{ form.pass.vars.id }}"></div>
 {{ pageAddAsset('javascript', zasset('@ZikulaZAuthModule:js/Zikula.ZAuth.UserAdmin.js')) }}
 {% if getModVar('ZikulaZAuthModule', constant('Zikula\\ZAuthModule\\ZAuthConstant::MODVAR_PASSWORD_STRENGTH_METER_ENABLED')) %}

--- a/src/system/ZAuthModule/Resources/views/UserAdministration/list.html.twig
+++ b/src/system/ZAuthModule/Resources/views/UserAdministration/list.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-list"></span>
     {% trans %}Users list{% endtrans %}
@@ -67,5 +66,4 @@
     <tbody>
     </tbody>
 </table>
-{{ adminFooter() }}
 {{ pageAddAsset('javascript', zasset('@ZikulaUsersModule:js/Zikula.Users.Admin.View.js')) }}

--- a/src/system/ZAuthModule/Resources/views/UserAdministration/modify.html.twig
+++ b/src/system/ZAuthModule/Resources/views/UserAdministration/modify.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-plus"></span>
     {% trans with {'%uname': form.vars.value.uname} %}Edit user account of %uname{% endtrans %}
@@ -35,7 +34,6 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}
 <div id="setPassIdentifiers" data-setpassid="{{ form.setpass.vars.id }}" data-passid="{{ form.pass.vars.id }}"></div>
 {{ pageAddAsset('javascript', zasset('@ZikulaZAuthModule:js/Zikula.ZAuth.UserAdmin.js')) }}
 {% if getModVar('ZikulaZAuthModule', constant('Zikula\\ZAuthModule\\ZAuthConstant::MODVAR_PASSWORD_STRENGTH_METER_ENABLED')) %}

--- a/src/system/ZAuthModule/Resources/views/UserAdministration/togglePasswordChange.html.twig
+++ b/src/system/ZAuthModule/Resources/views/UserAdministration/togglePasswordChange.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     {% if mustChangePass %}
         <i class="fas fa-lock"></i> {% trans with {'%1s': user.uname} %}Cancel forced password change for %1s{% endtrans %}
@@ -27,4 +26,3 @@
     </div>
     {{ form_end(form) }}
 </fieldset>
-{{ adminFooter() }}

--- a/src/system/ZAuthModule/Resources/views/UserAdministration/verify.html.twig
+++ b/src/system/ZAuthModule/Resources/views/UserAdministration/verify.html.twig
@@ -1,4 +1,3 @@
-{{ adminHeader() }}
 <h3>
     <span class="fas fa-user"></span>
     {% trans with {'%sub%': mapping.uname} %}Confirm verification code is to be sent to %sub%{% endtrans %}
@@ -14,4 +13,3 @@
     </div>
 </div>
 {{ form_end(form) }}
-{{ adminFooter() }}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixed #4255 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

This PR moves `adminHeader()` and `adminFooter()` calls into the theme layer.

## TODO (post-merge)

- [ ] VA modules
- [ ] Generator