### PR TITLE
further improving upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ install:
     - mysql zk_test < tests/test_dbs/core143.sql
     # run the upgrade from the 143 db
     - 'sed -i -E "s/ZIKULA_INSTALLED=''(.*)''/ZIKULA_INSTALLED=''1.4.3''/" .env.local'
+    - cp tests/services_custom.yaml config/services_custom.yaml
     - php bin/console zikula:upgrade -n --username=admin --password=12345678 --locale=en --router:request_context:host=localhost --router:request_context:scheme=http --router:request_context:base_url='/' -vvv
     # drop the test db
     - mysql -e 'drop database zk_test'
@@ -68,6 +69,7 @@ install:
     - mysql zk_test < tests/test_dbs/core144.sql
     # run the upgrade from the 144 db
     - 'sed -i -E "s/ZIKULA_INSTALLED=''(.*)''/ZIKULA_INSTALLED=''1.4.4''/" .env.local'
+    - cp tests/services_custom.yaml config/services_custom.yaml
     - php bin/console zikula:upgrade -n --username=admin --password=12345678 --locale=en --router:request_context:host=localhost --router:request_context:scheme=http --router:request_context:base_url='/'
     # drop the test db
     - mysql -e 'drop database zk_test'
@@ -77,6 +79,7 @@ install:
     - mysql zk_test < tests/test_dbs/core145.sql
     # run the upgrade from the 145 db
     - 'sed -i -E "s/ZIKULA_INSTALLED=''(.*)''/ZIKULA_INSTALLED=''1.4.5''/" .env.local'
+    - cp tests/services_custom.yaml config/services_custom.yaml
     - php bin/console zikula:upgrade -n --username=admin --password=12345678 --locale=en --router:request_context:host=localhost --router:request_context:scheme=http --router:request_context:base_url='/'
     # drop the test db
     - mysql -e 'drop database zk_test'
@@ -86,6 +89,7 @@ install:
     - mysql zk_test < tests/test_dbs/core146.sql
     # run the upgrade from the 146 db
     - 'sed -i -E "s/ZIKULA_INSTALLED=''(.*)''/ZIKULA_INSTALLED=''1.4.6''/" .env.local'
+    - cp tests/services_custom.yaml config/services_custom.yaml
     - php bin/console zikula:upgrade -n --username=admin --password=12345678 --locale=en --router:request_context:host=localhost --router:request_context:scheme=http --router:request_context:base_url='/'
     # drop the test db
     - mysql -e 'drop database zk_test'
@@ -95,6 +99,7 @@ install:
     - mysql zk_test < tests/test_dbs/core159.sql
   # run the upgrade from the 1.5.9 db
     - 'sed -i -E "s/ZIKULA_INSTALLED=''(.*)''/ZIKULA_INSTALLED=''1.5.9''/" .env.local'
+    - cp tests/services_custom.yaml config/services_custom.yaml
     - php bin/console zikula:upgrade -n --username=admin --password=12345678 --locale=en --router:request_context:host=localhost --router:request_context:scheme=http --router:request_context:base_url='/'
   # drop the test db
     - mysql -e 'drop database zk_test'
@@ -104,6 +109,7 @@ install:
     - mysql zk_test < tests/test_dbs/core2015.sql
   # run the upgrade from the 2.0.15 db
     - 'sed -i -E "s/ZIKULA_INSTALLED=''(.*)''/ZIKULA_INSTALLED=''2.0.15''/" .env.local'
+    - cp tests/services_custom.yaml config/services_custom.yaml
     - php bin/console zikula:upgrade -n --username=admin --password=12345678 --locale=en --router:request_context:host=localhost --router:request_context:scheme=http --router:request_context:base_url='/'
   # drop the test db
     - mysql -e 'drop database zk_test'

--- a/src/Zikula/CoreInstallerBundle/Helper/CoreInstallerExtensionHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/CoreInstallerExtensionHelper.php
@@ -287,14 +287,18 @@ class CoreInstallerExtensionHelper
                 }
                 $this->managerRegistry->getManager()->flush();
             case '2.0.15':
-                $this->variableApi->set(VariableApi::CONFIG, 'Default_Theme', 'ZikulaBootstrapTheme');
-                $this->variableApi->set('ZikulaAdminModule', 'admintheme', '');
+                // nothing
             case '3.0.0':
                 // current version - cannot perform anything yet
         }
 
         // always do this
         $this->reSyncAndActivate();
+        // set default themes to ZikulaBootstrapTheme
+        $this->variableApi->set(VariableApi::CONFIG, 'Default_Theme', 'ZikulaBootstrapTheme');
+        $this->variableApi->set('ZikulaAdminModule', 'admintheme', '');
+        // unset start page information to avoid missing module errors
+        $this->variableApi->set(VariableApi::CONFIG, 'startController_en', '');
 
         return true;
     }

--- a/src/Zikula/CoreInstallerBundle/Helper/DbCredsHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/DbCredsHelper.php
@@ -41,7 +41,7 @@ class DbCredsHelper
             'DATABASE_URL' => '!' . $data['database_driver']
                 . '://$DATABASE_USER:$DATABASE_PWD'
                 . '@' . $data['database_host'] . (!empty($data['database_port']) ? ':' . $data['database_port'] : '')
-                . '/$DATABASE_NAME?serverVersion=5.7' // any value for serverVersion will work (bypasses DBALException)
+                . '/$DATABASE_NAME?serverVersion=' . ($data['database_server_version'] ?? '5.7') // any value for serverVersion will work (bypasses DBALException)
         ];
 
         try {

--- a/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
@@ -160,6 +160,7 @@ class ParameterHelper
         $this->writeEnvVars($params);
 
         if (isset($params['upgrading']) && $params['upgrading']) {
+            $params['database_driver'] = mb_substr($params['database_driver'], 4); // remove pdo_ prefix
             (new DbCredsHelper($this->projectDir))->writeDatabaseDsn($params);
             $this->resetLegacyParams($params);
         }

--- a/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
@@ -183,7 +183,7 @@ class ParameterHelper
         $vars = [
             'APP_ENV' => $params['env'] ?? 'prod',
             'APP_DEBUG' => isset($params['debug']) ? (int) ($params['debug']) : 1,
-            'APP_SECRET' => '!\'' . $params['secret'] ?? $generator->generateString(50) . '\'',
+            'APP_SECRET' => '!\'' . isset($params['secret']) ? $params['secret'] : $generator->generateString(50) . '\'',
             'ZIKULA_INSTALLED' => '\'' . ZikulaKernel::VERSION . '\''
         ];
         (new LocalDotEnvHelper($this->projectDir))->writeLocalEnvVars($vars);

--- a/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
@@ -129,7 +129,7 @@ class ParameterHelper
         $params = $this->decodeParameters($yamlHelper->getParameters());
 
         $this->variableApi->getAll(VariableApi::CONFIG); // forces initialization of API
-        if (!isset($params['upgrading'])) {
+        if (!isset($params['upgrading']) || !$params['upgrading']) {
             $this->variableApi->set(VariableApi::CONFIG, 'locale', $params['locale']);
             // Set the System Identifier as a unique string.
             if (!$this->variableApi->get(VariableApi::CONFIG, 'system_identifier')) {
@@ -157,19 +157,11 @@ class ParameterHelper
         // store the recent version in a config var for later usage. This enables us to determine the version we are upgrading from
         $this->variableApi->set(VariableApi::CONFIG, 'Version_Num', ZikulaKernel::VERSION);
 
-        if (isset($params['upgrading'])) {
-            $params['zikula_asset_manager.combine'] = false;
+        $this->writeEnvVars($params);
+        (new DbCredsHelper($this->projectDir))->writeDatabaseDsn($params);
 
-            // unset start page information to avoid missing module errors
-            $this->variableApi->set(VariableApi::CONFIG, 'startController_en', '');
-
-            // on upgrade, if a user doesn't add their custom theme back to the /theme dir, it should be reset to a core theme, if available.
-            $defaultTheme = (string) $this->variableApi->getSystemVar('Default_Theme');
-            if (!$this->kernel->isBundle($defaultTheme) && $this->kernel->isBundle('ZikulaBootstrapTheme')) {
-                $this->variableApi->set(VariableApi::CONFIG, 'Default_Theme', 'ZikulaBootstrapTheme');
-            }
-        } else {
-            $this->writeEnvVars();
+        if (isset($params['upgrading']) && $params['upgrading']) {
+            $this->resetLegacyParams($params);
         }
 
         // write parameters into config/services_custom.yaml
@@ -181,18 +173,30 @@ class ParameterHelper
         return true;
     }
 
-    private function writeEnvVars()
+    /**
+     * @param array $params values from upgrade
+     */
+    private function writeEnvVars(array $params)
     {
         $randomLibFactory = new Factory();
         $generator = $randomLibFactory->getMediumStrengthGenerator();
         $vars = [
-            'APP_ENV' => 'prod',
-            'APP_DEBUG' => 1,
-            'APP_SECRET' => '\'' . $generator->generateString(50) . '\'',
+            'APP_ENV' => $params['env'] ?? 'prod',
+            'APP_DEBUG' => isset($params['debug']) ? intval($params['debug']) : 1,
+            'APP_SECRET' => '!\'' . $params['secret'] ?? $generator->generateString(50) . '\'',
             'ZIKULA_INSTALLED' => '\'' . ZikulaKernel::VERSION . '\''
         ];
-        $helper = new LocalDotEnvHelper($this->projectDir);
-        $helper->writeLocalEnvVars($vars);
+        (new LocalDotEnvHelper($this->projectDir))->writeLocalEnvVars($vars);
+    }
+
+    private function resetLegacyParams(array &$params): void
+    {
+        unset($params['temp_dir'], $params['system.chmod_dir'], $params['url_secret'], $params['umask']);
+        unset($params['env'], $params['debug'], $params['secret']);
+        unset($params['database_driver'], $params['database_host'], $params['database_port'], $params['database_name']);
+        unset($params['database_user'], $params['database_password'], $params['database_path'], $params['database_socket'], $params['database_server_version']);
+        $params['installed'] = '%env(ZIKULA_INSTALLED)%';
+        $params['zikula_asset_manager.combine'] = false;
     }
 
     /**

--- a/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
@@ -158,9 +158,9 @@ class ParameterHelper
         $this->variableApi->set(VariableApi::CONFIG, 'Version_Num', ZikulaKernel::VERSION);
 
         $this->writeEnvVars($params);
-        (new DbCredsHelper($this->projectDir))->writeDatabaseDsn($params);
 
         if (isset($params['upgrading']) && $params['upgrading']) {
+            (new DbCredsHelper($this->projectDir))->writeDatabaseDsn($params);
             $this->resetLegacyParams($params);
         }
 

--- a/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
@@ -183,7 +183,7 @@ class ParameterHelper
         $vars = [
             'APP_ENV' => $params['env'] ?? 'prod',
             'APP_DEBUG' => isset($params['debug']) ? (int) ($params['debug']) : 1,
-            'APP_SECRET' => '!\'' . isset($params['secret']) ? $params['secret'] : $generator->generateString(50) . '\'',
+            'APP_SECRET' => '!\'' . ($params['secret'] ?? $generator->generateString(50)) . '\'',
             'ZIKULA_INSTALLED' => '\'' . ZikulaKernel::VERSION . '\''
         ];
         (new LocalDotEnvHelper($this->projectDir))->writeLocalEnvVars($vars);

--- a/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/ParameterHelper.php
@@ -182,7 +182,7 @@ class ParameterHelper
         $generator = $randomLibFactory->getMediumStrengthGenerator();
         $vars = [
             'APP_ENV' => $params['env'] ?? 'prod',
-            'APP_DEBUG' => isset($params['debug']) ? intval($params['debug']) : 1,
+            'APP_DEBUG' => isset($params['debug']) ? (int) ($params['debug']) : 1,
             'APP_SECRET' => '!\'' . $params['secret'] ?? $generator->generateString(50) . '\'',
             'ZIKULA_INSTALLED' => '\'' . ZikulaKernel::VERSION . '\''
         ];
@@ -191,10 +191,25 @@ class ParameterHelper
 
     private function resetLegacyParams(array &$params): void
     {
-        unset($params['temp_dir'], $params['system.chmod_dir'], $params['url_secret'], $params['umask']);
-        unset($params['env'], $params['debug'], $params['secret']);
-        unset($params['database_driver'], $params['database_host'], $params['database_port'], $params['database_name']);
-        unset($params['database_user'], $params['database_password'], $params['database_path'], $params['database_socket'], $params['database_server_version']);
+        unset(
+            $params['temp_dir'],
+            $params['system.chmod_dir'],
+            $params['url_secret'],
+            $params['umask'],
+            $params['env'],
+            $params['debug'],
+            $params['secret'],
+            $params['database_driver'],
+            $params['database_host'],
+            $params['database_port'],
+            $params['database_name'],
+            $params['database_user'],
+            $params['database_password'],
+            $params['database_path'],
+            $params['database_socket'],
+            $params['database_server_version']
+        );
+
         $params['installed'] = '%env(ZIKULA_INSTALLED)%';
         $params['zikula_asset_manager.combine'] = false;
     }

--- a/src/Zikula/CoreInstallerBundle/Resources/config/upgrade_stages.yaml
+++ b/src/Zikula/CoreInstallerBundle/Resources/config/upgrade_stages.yaml
@@ -12,12 +12,15 @@ stages:
     login:
         class: Zikula\Bundle\CoreInstallerBundle\Stage\Upgrade\LoginStage
         order: 4
+    emailtransport:
+        class: Zikula\Bundle\CoreInstallerBundle\Stage\EmailTransportStage
+        order: 5
     ajaxupgrader:
         class: Zikula\Bundle\CoreInstallerBundle\Stage\Upgrade\AjaxUpgraderStage
-        order: 5
+        order: 6
     complete:
         class: Zikula\Bundle\CoreInstallerBundle\Stage\Upgrade\CompleteStage
-        order: 6
+        order: 7
     installed:
         class: Zikula\Bundle\CoreInstallerBundle\Stage\AlreadyInstalledStage
-        order: 7
+        order: 8

--- a/src/system/ZAuthModule/Form/Type/EitherLoginType.php
+++ b/src/system/ZAuthModule/Form/Type/EitherLoginType.php
@@ -20,6 +20,8 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Translation\Extractor\Annotation\Ignore;
+use Translation\Extractor\Annotation\Translate;
 
 class EitherLoginType extends AbstractType
 {
@@ -35,16 +37,20 @@ class EitherLoginType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $forgotUsername = /** @Translate */'I forgot my username';
+        $forgotPassword = /** @Translate */'I forgot my password';
         $builder
             ->add('either', TextType::class, [
                 'label' => 'User name or email',
-                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostusername') . '">I forgot my username</a>',
+                /** @Ignore */
+                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostusername') . '">' . $forgotUsername . '</a>',
                 'help_html' => true,
                 'input_group' => ['left' => '<i class="fas fa-fw fa-sign-in-alt"></i>']
             ])
             ->add('pass', PasswordType::class, [
                 'label' => 'Password',
-                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostpassword') . '">I forgot my password</a>',
+                /** @Ignore */
+                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostpassword') . '">' . $forgotPassword . '</a>',
                 'help_html' => true,
                 'input_group' => ['left' => '<i class="fas fa-fw fa-key"></i>']
             ])

--- a/src/system/ZAuthModule/Form/Type/EmailLoginType.php
+++ b/src/system/ZAuthModule/Form/Type/EmailLoginType.php
@@ -20,6 +20,8 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Translation\Extractor\Annotation\Ignore;
+use Translation\Extractor\Annotation\Translate;
 
 class EmailLoginType extends AbstractType
 {
@@ -35,6 +37,7 @@ class EmailLoginType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $forgotPassword = /** @Translate */'I forgot my password';
         $builder
             ->add('email', EmailType::class, [
                 'label' => 'Email address',
@@ -42,7 +45,8 @@ class EmailLoginType extends AbstractType
             ])
             ->add('pass', PasswordType::class, [
                 'label' => 'Password',
-                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostpassword') . '">I forgot my password</a>',
+                /** @Ignore */
+                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostpassword') . '">' . $forgotPassword . '</a>',
                 'help_html' => true,
                 'input_group' => ['left' => '<i class="fas fa-fw fa-key"></i>']
             ])

--- a/src/system/ZAuthModule/Form/Type/UnameLoginType.php
+++ b/src/system/ZAuthModule/Form/Type/UnameLoginType.php
@@ -20,6 +20,8 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Translation\Extractor\Annotation\Ignore;
+use Translation\Extractor\Annotation\Translate;
 
 class UnameLoginType extends AbstractType
 {
@@ -35,16 +37,20 @@ class UnameLoginType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $forgotUsername = /** @Translate */'I forgot my username';
+        $forgotPassword = /** @Translate */'I forgot my password';
         $builder
             ->add('uname', TextType::class, [
                 'label' => 'User name',
-                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostusername') . '">I forgot my username</a>',
+                /** @Ignore */
+                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostusername') . '">' . $forgotUsername . '</a>',
                 'help_html' => true,
                 'input_group' => ['left' => '<i class="fas fa-fw fa-user"></i>']
             ])
             ->add('pass', PasswordType::class, [
                 'label' => 'Password',
-                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostpassword') . '">I forgot my password</a>',
+                /** @Ignore */
+                'help' => '<a href="' . $this->router->generate('zikulazauthmodule_account_lostpassword') . '">' . $forgotPassword . '</a>',
                 'help_html' => true,
                 'input_group' => ['left' => '<i class="fas fa-fw fa-key"></i>']
             ])

--- a/tests/services_custom.yaml
+++ b/tests/services_custom.yaml
@@ -1,0 +1,37 @@
+parameters:
+#    upgrade instruction include remove the `installed` and `core_installed_version` key/value pairs
+    script_position: foot
+    datadir: web/uploads
+    locale: en
+    assets_version: null
+    zikula_asset_manager.combine: true
+    zikula_asset_manager.lifetime: '1 day'
+    zikula_asset_manager.compress: true
+    zikula_asset_manager.minify: true
+    security.x_frame_options: SAMEORIGIN
+    zikula.javascript.bootstrap.min.path: /bootstrap/js/bootstrap.bundle.min.js
+    zikula.stylesheet.bootstrap.min.path: /bootstrap/css/bootstrap.min.css
+    zikula.stylesheet.fontawesome.min.path: /font-awesome/css/all.min.css
+    router.request_context.host: localhost
+    router.request_context.scheme: http
+    router.request_context.base_url: /core.git/public
+#    temp values to test config upgrade
+    env: prod
+    debug: false
+    system.chmod_dir: 511
+    secret: 7IYFCbh8twxwh6R5YK0T2W8Jaq4sC2MG8MSRhIER9hYCrexmFK
+    url_secret: 0mRn9HS8Em
+    umask: null
+    database_driver: pdo_mysql
+    database_host: localhost
+    database_port: null
+    database_name: 'zk_test'
+    database_user: root
+    database_password: null
+    database_path: null
+    database_socket: null
+    database_server_version: 5.7.26
+
+services:
+    _defaults: { autowire: true, autoconfigure: true }
+    zikula.site_definition: '@Zikula\Bundle\CoreBundle\Site\SiteDefinition'


### PR DESCRIPTION
add mailer setup to upgrade. (ignores old swiftmailer settings)
transfer old params to .env.local
remove legacy params from services_custom.yaml

refs #3967
note: swiftmailer config is removed on MailerModule upgrade
