### PR TITLE
remove super global access from kernel

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -37,6 +37,7 @@ $_SERVER += $_ENV;
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+$_SERVER['DATABASE_URL'] = $_SERVER['DATABASE_URL'] ?? $_ENV['DATABASE_URL'] ?? '';
 
 // on install or upgrade, check if system requirements are met.
 (new RequirementChecker($_ENV['ZIKULA_INSTALLED']))->verify();

--- a/public/index.php
+++ b/public/index.php
@@ -30,7 +30,7 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? false) {
     Request::setTrustedHosts([$trustedHosts]);
 }
 
-$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG'], $_SERVER['DATABASE_URL']);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -27,22 +27,21 @@ class Kernel extends ZikulaKernel
     use MicroKernelTrait;
 
     /**
-     * @var string
+     * @var PersistedBundleHelper
      */
-    private $databaseUrl;
+    private $bundleHelper;
 
     public function __construct(string $environment, bool $debug, string $databaseUrl = '')
     {
         parent::__construct($environment, $debug);
 
-        $this->databaseUrl = $databaseUrl;
+        $this->bundleHelper = new PersistedBundleHelper($databaseUrl);
     }
 
     public function registerBundles(): iterable
     {
-        $bundleHelper = new PersistedBundleHelper($this->databaseUrl);
         $bundles = require $this->getProjectDir() . '/config/bundles.php';
-        $bundleHelper->getPersistedBundles($this, $bundles);
+        $this->bundleHelper->getPersistedBundles($this, $bundles);
 
         foreach ($bundles as $class => $envs) {
             if ($envs[$this->environment] ?? $envs['all'] ?? false) {
@@ -111,5 +110,10 @@ class Kernel extends ZikulaKernel
         $routes->import($configDir . '{routes}/' . $this->environment . '/*.yaml', '/', 'glob');
         $routes->import($configDir . '{routes}/*.yaml', '/', 'glob');
         $routes->import($configDir . '{routes}.yaml', '/', 'glob');
+    }
+
+    public function getBundleHelper(): PersistedBundleHelper
+    {
+        return $this->bundleHelper;
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -26,9 +26,21 @@ class Kernel extends ZikulaKernel
 {
     use MicroKernelTrait;
 
+    /**
+     * @var string
+     */
+    private $databaseUrl;
+
+    public function __construct(string $environment, bool $debug, string $databaseUrl)
+    {
+        parent::__construct($environment, $debug);
+
+        $this->databaseUrl = $databaseUrl;
+    }
+
     public function registerBundles(): iterable
     {
-        $bundleHelper = new PersistedBundleHelper($_ENV['DATABASE_URL'] ?? '');
+        $bundleHelper = new PersistedBundleHelper($this->databaseUrl);
         $bundles = require $this->getProjectDir() . '/config/bundles.php';
         $bundleHelper->getPersistedBundles($this, $bundles);
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -27,21 +27,22 @@ class Kernel extends ZikulaKernel
     use MicroKernelTrait;
 
     /**
-     * @var PersistedBundleHelper
+     * @var string
      */
-    private $bundleHelper;
+    private $databaseUrl;
 
     public function __construct(string $environment, bool $debug, string $databaseUrl = '')
     {
         parent::__construct($environment, $debug);
 
-        $this->bundleHelper = new PersistedBundleHelper($databaseUrl);
+        $this->databaseUrl = $databaseUrl;
     }
 
     public function registerBundles(): iterable
     {
+        $bundleHelper = new PersistedBundleHelper($this>databaseUrl);
         $bundles = require $this->getProjectDir() . '/config/bundles.php';
-        $this->bundleHelper->getPersistedBundles($this, $bundles);
+        $bundleHelper->getPersistedBundles($this, $bundles);
 
         foreach ($bundles as $class => $envs) {
             if ($envs[$this->environment] ?? $envs['all'] ?? false) {
@@ -110,10 +111,5 @@ class Kernel extends ZikulaKernel
         $routes->import($configDir . '{routes}/' . $this->environment . '/*.yaml', '/', 'glob');
         $routes->import($configDir . '{routes}/*.yaml', '/', 'glob');
         $routes->import($configDir . '{routes}.yaml', '/', 'glob');
-    }
-
-    public function getBundleHelper(): PersistedBundleHelper
-    {
-        return $this->bundleHelper;
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -31,7 +31,7 @@ class Kernel extends ZikulaKernel
      */
     private $databaseUrl;
 
-    public function __construct(string $environment, bool $debug, string $databaseUrl)
+    public function __construct(string $environment, bool $debug, string $databaseUrl = '')
     {
         parent::__construct($environment, $debug);
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -40,7 +40,7 @@ class Kernel extends ZikulaKernel
 
     public function registerBundles(): iterable
     {
-        $bundleHelper = new PersistedBundleHelper($this>databaseUrl);
+        $bundleHelper = new PersistedBundleHelper($this->databaseUrl);
         $bundles = require $this->getProjectDir() . '/config/bundles.php';
         $bundleHelper->getPersistedBundles($this, $bundles);
 

--- a/src/Zikula/CoreBundle/bin/console
+++ b/src/Zikula/CoreBundle/bin/console
@@ -34,6 +34,10 @@ if (null !== $env = $getZikulaEnv($input)) {
     putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
 }
 
+if ($input->hasParameterOption('--no-debug', true)) {
+    putenv('APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+}
+
 foreach ([__DIR__ . '/../../../../config/bootstrap.php', __DIR__ . '/../config/bootstrap.php'] as $file) {
     if (file_exists($file)) {
         require $file;

--- a/src/Zikula/CoreBundle/bin/console
+++ b/src/Zikula/CoreBundle/bin/console
@@ -34,9 +34,7 @@ if (null !== $env = $getZikulaEnv($input)) {
     putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
 }
 
-if ($input->hasParameterOption('--no-debug', true)) {
-    putenv('APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
-}
+$_SERVER['DATABASE_URL'] = $_ENV['DATABASE_URL'] = getenv('DATABASE_URL');
 
 foreach ([__DIR__ . '/../../../../config/bootstrap.php', __DIR__ . '/../config/bootstrap.php'] as $file) {
     if (file_exists($file)) {
@@ -53,6 +51,6 @@ if ($_SERVER['APP_DEBUG']) {
     }
 }
 
-$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG'], $_SERVER['DATABASE_URL']);
 $application = new Application($kernel);
 $application->run($input);

--- a/src/Zikula/CoreBundle/bin/console
+++ b/src/Zikula/CoreBundle/bin/console
@@ -34,8 +34,6 @@ if (null !== $env = $getZikulaEnv($input)) {
     putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
 }
 
-$_SERVER['DATABASE_URL'] = $_ENV['DATABASE_URL'] = getenv('DATABASE_URL');
-
 foreach ([__DIR__ . '/../../../../config/bootstrap.php', __DIR__ . '/../config/bootstrap.php'] as $file) {
     if (file_exists($file)) {
         require $file;

--- a/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
@@ -16,6 +16,7 @@ namespace Zikula\Bundle\CoreInstallerBundle\Helper;
 use Symfony\Component\Console\Style\StyleInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Zikula\Bundle\CoreBundle\Helper\BundlesSchemaHelper;
+use Zikula\Bundle\CoreBundle\Helper\PersistedBundleHelper;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\Bundle\CoreInstallerBundle\Event\CoreInstallationPreExtensionInstallation;
 use Zikula\Bundle\CoreInstallerBundle\Event\CoreInstallerBundleEvent;
@@ -40,6 +41,11 @@ class StageHelper
      * @var ZikulaHttpKernelInterface
      */
     private $kernel;
+
+    /**
+     * @var PersistedBundleHelper
+     */
+    private $persistedBundleHelper;
 
     /**
      * @var BundlesSchemaHelper
@@ -83,6 +89,7 @@ class StageHelper
 
     public function __construct(
         ZikulaHttpKernelInterface $kernel,
+        PersistedBundleHelper $persistedBundleHelper,
         BundlesSchemaHelper $bundlesSchemaHelper,
         ExtensionHelper $extensionHelper,
         EventDispatcherInterface $eventDispatcher,
@@ -95,6 +102,7 @@ class StageHelper
         string $installed
     ) {
         $this->kernel = $kernel;
+        $this->persistedBundleHelper = $persistedBundleHelper;
         $this->bundlesSchemaHelper = $bundlesSchemaHelper;
         $this->extensionHelper = $extensionHelper;
         $this->eventDispatcher = $eventDispatcher;
@@ -203,7 +211,7 @@ class StageHelper
     {
         $this->bundlesSchemaHelper->load();
         $bundles = [];
-        $this->kernel->getBundleHelper()->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
+        $this->persistedBundleHelper->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
 
         return true;
     }

--- a/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/StageHelper.php
@@ -16,7 +16,6 @@ namespace Zikula\Bundle\CoreInstallerBundle\Helper;
 use Symfony\Component\Console\Style\StyleInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Zikula\Bundle\CoreBundle\Helper\BundlesSchemaHelper;
-use Zikula\Bundle\CoreBundle\Helper\PersistedBundleHelper;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\Bundle\CoreInstallerBundle\Event\CoreInstallationPreExtensionInstallation;
 use Zikula\Bundle\CoreInstallerBundle\Event\CoreInstallerBundleEvent;
@@ -41,11 +40,6 @@ class StageHelper
      * @var ZikulaHttpKernelInterface
      */
     private $kernel;
-
-    /**
-     * @var PersistedBundleHelper
-     */
-    private $persistedBundleHelper;
 
     /**
      * @var BundlesSchemaHelper
@@ -89,7 +83,6 @@ class StageHelper
 
     public function __construct(
         ZikulaHttpKernelInterface $kernel,
-        PersistedBundleHelper $persistedBundleHelper,
         BundlesSchemaHelper $bundlesSchemaHelper,
         ExtensionHelper $extensionHelper,
         EventDispatcherInterface $eventDispatcher,
@@ -102,7 +95,6 @@ class StageHelper
         string $installed
     ) {
         $this->kernel = $kernel;
-        $this->persistedBundleHelper = $persistedBundleHelper;
         $this->bundlesSchemaHelper = $bundlesSchemaHelper;
         $this->extensionHelper = $extensionHelper;
         $this->eventDispatcher = $eventDispatcher;
@@ -211,7 +203,7 @@ class StageHelper
     {
         $this->bundlesSchemaHelper->load();
         $bundles = [];
-        $this->persistedBundleHelper->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
+        $this->kernel->getBundleHelper()->getPersistedBundles($this->kernel, $bundles); // adds autoloaders
 
         return true;
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | insight
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This moves `_ENV` access out of the kernel.

- Travis still works
- Insight gives silver

WDYT @craigh  ?
