### PR TITLE
use constants for command exit codes

### DIFF
--- a/src/Zikula/CoreBundle/Command/AssetsInstallCommand.php
+++ b/src/Zikula/CoreBundle/Command/AssetsInstallCommand.php
@@ -124,6 +124,6 @@ EOT
             }
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
+++ b/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
@@ -152,7 +152,7 @@ EOT
         $io->success('User generation complete!');
         $io->text(sprintf('%d users created (group name: <info>group%s</info>).', $amount, $key));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function configureActivatedStatus(string $value): int

--- a/src/Zikula/CoreInstallerBundle/Command/Install/FinishCommand.php
+++ b/src/Zikula/CoreInstallerBundle/Command/Install/FinishCommand.php
@@ -77,7 +77,7 @@ class FinishCommand extends Command
         if (true === $this->installed) {
             $io->error($this->translator->trans('Zikula already appears to be installed.'));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if ($input->isInteractive()) {
@@ -90,6 +90,6 @@ class FinishCommand extends Command
 
         $io->success($this->translator->trans('Install Successful!'));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Zikula/CoreInstallerBundle/Command/Install/StartCommand.php
+++ b/src/Zikula/CoreInstallerBundle/Command/Install/StartCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreInstallerBundle\Command\Install;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -86,14 +87,14 @@ class StartCommand extends AbstractCoreInstallerCommand
         if (true === $this->installed) {
             $io->error($this->translator->trans('Zikula already appears to be installed.'));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $iniWarnings = $this->phpHelper->setUp();
         if (!empty($iniWarnings)) {
             $this->printWarnings($output, $iniWarnings);
 
-            return 2;
+            return Command::FAILURE;
         }
 
         if ($input->isInteractive()) {
@@ -127,7 +128,7 @@ class StartCommand extends AbstractCoreInstallerCommand
             if (!$confirmation) {
                 $io->error($this->translator->trans('Installation aborted'));
 
-                return 3;
+                return Command::FAILURE;
             }
         }
 
@@ -136,7 +137,7 @@ class StartCommand extends AbstractCoreInstallerCommand
 
         $io->success($this->translator->trans('First stage of installation complete. Run `php bin/console zikula:install:finish` to complete the installation.'));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function doDBCreds(InputInterface $input, OutputInterface $output, StyleInterface $io): bool

--- a/src/Zikula/CoreInstallerBundle/Command/UpgradeCommand.php
+++ b/src/Zikula/CoreInstallerBundle/Command/UpgradeCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreInstallerBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -115,7 +116,7 @@ class UpgradeCommand extends AbstractCoreInstallerCommand
         if (version_compare($this->installed, UpgraderController::ZIKULACORE_MINIMUM_UPGRADE_VERSION, '<')) {
             $output->writeln($this->translator->trans('The currently installed version of Zikula (%currentVersion%) is too old. You must upgrade to version %minimumVersion% before you can use this upgrade.', ['%currentVersion%' => $this->installed, '%minimumVersion%' => UpgraderController::ZIKULACORE_MINIMUM_UPGRADE_VERSION]));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $io = new SymfonyStyle($input, $output);
@@ -129,7 +130,7 @@ class UpgradeCommand extends AbstractCoreInstallerCommand
         if (!empty($iniWarnings)) {
             $this->printWarnings($output, $iniWarnings);
 
-            return 2;
+            return Command::FAILURE;
         }
 
         $yamlManager = new YamlDumper($this->kernel->getProjectDir() . '/config', 'services_custom.yaml');
@@ -160,7 +161,7 @@ class UpgradeCommand extends AbstractCoreInstallerCommand
 
         $io->success($this->translator->trans('Upgrade successful!'));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function migrateUsers(InputInterface $input, OutputInterface $output, SymfonyStyle $io): void

--- a/src/system/ExtensionsModule/Command/ZikulaExtensionInstallCommand.php
+++ b/src/system/ExtensionsModule/Command/ZikulaExtensionInstallCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ExtensionsModule\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -45,7 +46,7 @@ class ZikulaExtensionInstallCommand extends AbstractExtensionCommand
                 $io->error('Extension is already installed but possibly inactive.');
             }
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (!$this->kernel->isBundle($bundleName)) {
@@ -68,7 +69,7 @@ class ZikulaExtensionInstallCommand extends AbstractExtensionCommand
         if (!empty($dependencyNames)) {
             $io->error(sprintf('Cannot install because this extension depends on other extensions. Please install the following extensions first: %s', implode(', ', $dependencyNames)));
 
-            return 2;
+            return Command::FAILURE;
         }
 
         if (false === $this->extensionHelper->install($extension)) {
@@ -76,7 +77,7 @@ class ZikulaExtensionInstallCommand extends AbstractExtensionCommand
                 $io->error('Could not install the extension');
             }
 
-            return 3;
+            return Command::FAILURE;
         }
 
         $this->eventDispatcher->dispatch(new ExtensionPostCacheRebuildEvent($this->kernel->getBundle($extension->getName()), $extension));
@@ -85,7 +86,7 @@ class ZikulaExtensionInstallCommand extends AbstractExtensionCommand
             $io->success('Extension installed');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function load(string $bundleName): void

--- a/src/system/ExtensionsModule/Command/ZikulaExtensionStatusCommand.php
+++ b/src/system/ExtensionsModule/Command/ZikulaExtensionStatusCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ExtensionsModule\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -42,14 +43,14 @@ class ZikulaExtensionStatusCommand extends AbstractExtensionCommand
         if (!$input->isInteractive()) {
             $io->error('This command only runs in interactive mode.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $this->reSync();
         if (null === $extension = $this->extensionRepository->findOneBy(['name' => $bundleName])) {
             $io->error('The extension cannot be found, please check the name.');
 
-            return 2;
+            return Command::FAILURE;
         }
 
         $status = $this->translateState($extension->getState());
@@ -57,7 +58,7 @@ class ZikulaExtensionStatusCommand extends AbstractExtensionCommand
             if ('status' === $get) {
                 $io->text($status);
 
-                return 0;
+                return Command::SUCCESS;
             }
             $method = 'get' . ucfirst($get);
             try {
@@ -67,7 +68,7 @@ class ZikulaExtensionStatusCommand extends AbstractExtensionCommand
                 $io->error(sprintf('There is no property %s', $get));
             }
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $io->title(sprintf('Status of %s', $bundleName));
@@ -82,7 +83,7 @@ class ZikulaExtensionStatusCommand extends AbstractExtensionCommand
             ]
         );
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function translateState(int $state): string

--- a/src/system/ExtensionsModule/Command/ZikulaExtensionSyncCommand.php
+++ b/src/system/ExtensionsModule/Command/ZikulaExtensionSyncCommand.php
@@ -71,6 +71,6 @@ class ZikulaExtensionSyncCommand extends Command
 
         $io->success('Complete');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/system/ExtensionsModule/Command/ZikulaExtensionUninstallCommand.php
+++ b/src/system/ExtensionsModule/Command/ZikulaExtensionUninstallCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ExtensionsModule\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,7 +43,7 @@ class ZikulaExtensionUninstallCommand extends AbstractExtensionCommand
                 $io->error('The extension is not installed and therefore cannot be uninstalled.');
             }
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (Constant::STATE_MISSING === $extension->getState()) {
@@ -50,7 +51,7 @@ class ZikulaExtensionUninstallCommand extends AbstractExtensionCommand
                 $io->error('The extension cannot be uninstalled because its files are missing.');
             }
 
-            return 2;
+            return Command::FAILURE;
         }
 
         $requiredDependents = $this->dependencyHelper->getDependentExtensions($extension);
@@ -63,7 +64,7 @@ class ZikulaExtensionUninstallCommand extends AbstractExtensionCommand
                 $io->error(sprintf('The extension is a required dependency of [%s]. Please uninstall these extensions first.', $names));
             }
 
-            return 3;
+            return Command::FAILURE;
         }
 
         $blocks = $this->blockRepository->findBy(['module' => $extension]);
@@ -74,7 +75,7 @@ class ZikulaExtensionUninstallCommand extends AbstractExtensionCommand
                 $io->error('Could not uninstall the extension');
             }
 
-            return 4;
+            return Command::FAILURE;
         }
 
         $this->reSync();
@@ -83,6 +84,6 @@ class ZikulaExtensionUninstallCommand extends AbstractExtensionCommand
             $io->success('The extension has been uninstalled.');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/system/ExtensionsModule/Command/ZikulaExtensionUpgradeCommand.php
+++ b/src/system/ExtensionsModule/Command/ZikulaExtensionUpgradeCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ExtensionsModule\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -41,7 +42,7 @@ class ZikulaExtensionUpgradeCommand extends AbstractExtensionCommand
                 $io->error('The extension is not installed and therefore cannot be upgraded.');
             }
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (false !== $extension = $this->isUpgradeable($bundleName)) {
@@ -49,7 +50,7 @@ class ZikulaExtensionUpgradeCommand extends AbstractExtensionCommand
                 $io->error('The extension cannot be upgraded because its version number has not changed.');
             }
 
-            return 2;
+            return Command::FAILURE;
         }
 
         if (!$this->extensionHelper->upgrade($extension)) {
@@ -57,14 +58,14 @@ class ZikulaExtensionUpgradeCommand extends AbstractExtensionCommand
                 $io->error('The extension could not be upgraded.');
             }
 
-            return 3;
+            return Command::FAILURE;
         }
 
         if ($input->isInteractive()) {
             $io->success('The extension has been upgraded.');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function isUpgradeable(string $bundleName)

--- a/src/system/SettingsModule/Command/UpdateTranslationConfigurationsCommand.php
+++ b/src/system/SettingsModule/Command/UpdateTranslationConfigurationsCommand.php
@@ -49,6 +49,6 @@ class UpdateTranslationConfigurationsCommand extends Command
 
         $io->success('Complete');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/system/UsersModule/Command/DeleteCommand.php
+++ b/src/system/UsersModule/Command/DeleteCommand.php
@@ -81,7 +81,7 @@ EOT
         if (count(array_filter($params)) > 1) {
             $io->error('Do not use more than one option or argument.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $users = new ArrayCollection();
@@ -92,7 +92,7 @@ EOT
                 } catch (\InvalidArgumentException $exception) {
                     $io->error($exception->getMessage());
 
-                    return 2;
+                    return Command::FAILURE;
                 }
                 break;
             }
@@ -101,7 +101,7 @@ EOT
         if ($users->isEmpty()) {
             $io->error('No users found!');
 
-            return 3;
+            return Command::FAILURE;
         }
 
         $io->title('Zikula user deletion');
@@ -116,6 +116,6 @@ EOT
 
         $io->success(sprintf('Success! %d users %s.', $count, $force ? 'deleted' : 'converted to ghost'));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/system/ZAuthModule/Command/ZikulaUsersImportCommand.php
+++ b/src/system/ZAuthModule/Command/ZikulaUsersImportCommand.php
@@ -55,14 +55,15 @@ class ZikulaUsersImportCommand extends Command
 
         $file = new File($path);
         $error = $this->ioHelper->importUsersFromFile($file, $delimiter);
-        if (empty($error)) {
-            $createdUsers = $this->ioHelper->getCreatedUsers();
-            $io->success(sprintf('Import successful. %d users imported', count($createdUsers)));
+        if (!empty($error)) {
+            $io->error($error);
 
-            return 0;
+            return Command::FAILURE;
         }
-        $io->error($error);
 
-        return 1;
+        $createdUsers = $this->ioHelper->getCreatedUsers();
+        $io->success(sprintf('Import successful. %d users imported', count($createdUsers)));
+
+        return Command::SUCCESS;
     }
 }

--- a/src/system/ZAuthModule/Command/ZikulaZauthEditCommand.php
+++ b/src/system/ZAuthModule/Command/ZikulaZauthEditCommand.php
@@ -110,12 +110,12 @@ EOT
         } catch (\Exception $e) {
             $io->error($this->translator->trans('Found more than one user by that criteria. Try a different criteria (uid works best).'));
 
-            return 1;
+            return Command::FAILURE;
         }
         if (empty($mapping)) {
             $io->error($this->translator->trans('Found zero users by that criteria. Try a different criteria (uid works best).'));
 
-            return 1;
+            return Command::FAILURE;
         }
         $choices = [
             $this->translator->trans('password'),
@@ -130,7 +130,7 @@ EOT
         if (0 !== count($errors)) {
             $io->error($this->translator->trans('Invalid %choice%', ['%choice%' => $choice]) . '. ' . $errors[0]->getMessage());
 
-            return 2;
+            return Command::FAILURE;
         }
 
         switch ($choice) {
@@ -149,6 +149,6 @@ EOT
         $this->authenticationMappingRepository->persistAndFlush($mapping);
         $io->success($this->translator->trans('The %choice% has been changed.', ['%choice%' => $choice]));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | #4095
| License           | MIT
| Changelog updated | no

## Description

This PR adds constants for command exit codes that have been added in Symfony 5.1.
More information: https://symfony.com/blog/new-in-symfony-5-1-misc-improvements-part-1#added-constants-for-command-exit-codes
