### PR TITLE
fix autoloader determination

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -13,6 +13,7 @@
   - Fix invalid access to obsolete parameter when upgrading from 3.0 to a newer version.
   - Fix wrong link to upgrade docs in the upgrader (#4364).
   - Fix invalid reset of start controller settings when upgrading from 3.0 to a newer version.
+  - Fix broken autoloader recognition of additional extensions for distribution-based installations.
 
 - Features:
   - _there should be none_

--- a/src/Zikula/CoreBundle/Composer/Scanner.php
+++ b/src/Zikula/CoreBundle/Composer/Scanner.php
@@ -72,7 +72,11 @@ class Scanner
     public function decode(string $jsonFilePath)
     {
         $base = str_replace('\\', '/', dirname($jsonFilePath));
-        $srcPath = dirname(__DIR__, 3) . '/'; // should work when Bundle in vendor too
+        $srcPath = dirname(__DIR__, 3) . '/';
+        if ('vendor/' === mb_substr($srcPath, -7)) {
+            // distribution-based installation
+            $srcPath = str_replace('vendor/', 'src/', $srcPath);
+        }
         $base = mb_substr($base, mb_strlen($srcPath));
 
         $json = json_decode(file_get_contents($jsonFilePath), true);

--- a/src/Zikula/CoreBundle/Composer/Scanner.php
+++ b/src/Zikula/CoreBundle/Composer/Scanner.php
@@ -72,11 +72,7 @@ class Scanner
     public function decode(string $jsonFilePath)
     {
         $base = str_replace('\\', '/', dirname($jsonFilePath));
-        $srcPath = dirname(__DIR__, 3) . '/';
-        if ('vendor/' === mb_substr($srcPath, -7)) {
-            // distribution-based installation
-            $srcPath = str_replace('vendor/', 'src/', $srcPath);
-        }
+        $srcPath = dirname(__DIR__, 4) . '/src/';
         $base = mb_substr($base, mb_strlen($srcPath));
 
         $json = json_decode(file_get_contents($jsonFilePath), true);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | https://github.com/zikula-modules/News/issues/139 + https://github.com/Guite/MostGenerator/issues/1239
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

To apply this fix to a broken installation ~~truncate the `bundles` table in the database and~~ call `/extensions/list` ~~afterwards~~ to let the system re-sync all bundles.