### PR TITLE
Update make:zikula-extension

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -15,6 +15,7 @@
   - Fix invalid reset of start controller settings when upgrading from 3.0 to a newer version.
   - Fix broken autoloader recognition of additional extensions for distribution-based installations.
   - Improved help texts for mailer configuration (#4356).
+  - Update maker (make:zikula-extension) to discourage use of Zikula as vendor (#4382).
 
 - Features:
   - _there should be none_

--- a/docs/Development/Extensions/ExtensionMaker.md
+++ b/docs/Development/Extensions/ExtensionMaker.md
@@ -14,6 +14,9 @@ For example, if you are generating a Blog module and your name is Fabien, you co
 part is called the _vendor_ (in this case 'Fabien') and the second part is going to be the name of the extension.
 The full extension name combines these into FabienBlogModule.
 
+Note: use of 'Zikula' as a vendor name is strongly discouraged. If used, you must include the `--force` option when
+using the commands below. When used, your files may get automatically placed in unexpected locations.
+
 Now call the function with your namespace and choose and extension type (Module or Theme). In this case, we are
 generating a _Module_.
 

--- a/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
+++ b/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Filesystem\Filesystem;
 use Zikula\Bundle\CoreBundle\DynamicConfigDumper;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
@@ -75,6 +76,7 @@ class ExtensionMaker extends AbstractMaker
             ->setDescription('Creates a new zikula extension bundle')
             ->addArgument('namespace', InputArgument::OPTIONAL, sprintf('Choose a namespace (e.g. <fg=yellow>Acme\%s</>)', Str::asClassName(Str::getRandomTerm())))
             ->addArgument('type', InputArgument::OPTIONAL, sprintf('Choose a extension type (<fg=yellow>module or theme</>)'))
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Required to use Zikula namespace.', false)
             ->setHelp(file_get_contents(dirname(__DIR__) . '/Resources/help/ExtensionMaker.txt'))
         ;
     }
@@ -82,7 +84,7 @@ class ExtensionMaker extends AbstractMaker
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
         try {
-            $namespace = Validators::validateBundleNamespace($input->getArgument('namespace'));
+            $namespace = Validators::validateBundleNamespace($input);
         } catch (\InvalidArgumentException $exception) {
             $io->error($exception->getMessage());
 

--- a/src/Zikula/CoreBundle/Maker/SetNamespaceMaker.php
+++ b/src/Zikula/CoreBundle/Maker/SetNamespaceMaker.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Zikula\Bundle\CoreBundle\DynamicConfigDumper;
 
 class SetNamespaceMaker extends AbstractMaker
@@ -46,6 +47,7 @@ class SetNamespaceMaker extends AbstractMaker
         $command
             ->setDescription('Sets the maker namespace config')
             ->addArgument('namespace', InputArgument::OPTIONAL, 'Choose a namespace (e.g. <fg=yellow>Acme\\BlogModule</>)')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Required to use Zikula namespace.', false)
             ->setHelp('Set the maker namespace config <info>php %command.full_name% Acme/BlogModule</info>')
         ;
     }
@@ -53,7 +55,7 @@ class SetNamespaceMaker extends AbstractMaker
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
         try {
-            $namespace = Validators::validateBundleNamespace($input->getArgument('namespace'), true);
+            $namespace = Validators::validateBundleNamespace($input, true);
         } catch (\InvalidArgumentException $exception) {
             $io->error($exception->getMessage());
 

--- a/src/Zikula/CoreBundle/Maker/Validators.php
+++ b/src/Zikula/CoreBundle/Maker/Validators.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 namespace Zikula\Bundle\CoreBundle\Maker;
 
 use InvalidArgumentException;
+use Symfony\Component\Console\Input\InputInterface;
 
 class Validators
 {
-    public static function validateBundleNamespace(string $namespace, $allowSuffix = false): string
+    public static function validateBundleNamespace(InputInterface $input, $allowSuffix = false): string
     {
+        $namespace = $input->getArgument('namespace');
         $namespace = trim(str_replace('/', '\\', $namespace));
         if (!preg_match('/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\\?)+$/', $namespace)) {
             throw new InvalidArgumentException('The namespace contains invalid characters.');
@@ -38,6 +40,10 @@ class Validators
                     throw new InvalidArgumentException(sprintf('The namespace cannot contain "%s".', $word));
                 }
             }
+        }
+
+        if (('Zikula\\' === mb_substr($namespace, 0, 7)) && (false === $input->getOption('force'))) {
+            throw new InvalidArgumentException(sprintf('Use of Zikula as the vendor name is not recommended. If you use it you must also specify the %s option', '--force'));
         }
 
         // validate that the namespace is at least one level deep

--- a/src/Zikula/CoreBundle/Maker/Validators.php
+++ b/src/Zikula/CoreBundle/Maker/Validators.php
@@ -42,7 +42,7 @@ class Validators
             }
         }
 
-        if (('Zikula\\' === mb_substr($namespace, 0, 7)) && (false === $input->getOption('force'))) {
+        if ('Zikula\\' === mb_substr($namespace, 0, 7) && false === $input->getOption('force')) {
             throw new InvalidArgumentException(sprintf('Use of Zikula as the vendor name is not recommended. If you use it you must also specify the %s option', '--force'));
         }
 

--- a/src/Zikula/CoreBundle/Resources/help/ExtensionMaker.txt
+++ b/src/Zikula/CoreBundle/Resources/help/ExtensionMaker.txt
@@ -5,6 +5,7 @@ Any passed option will be used as a default value for the interaction
 optional arguments:
   <comment>namespace</comment>: e.g. Acme\\Blog (do not include suffix. e.g. 'Module')
   <comment>type</comment>: Module or Theme
+  <comment>force</comment>: Required if using 'Zikula' as vendor name (not recommended).
 
 Note that you can use <comment>/</comment> instead of <comment>\\ </comment>for the namespace delimiter if you wish.
 


### PR DESCRIPTION
update maker (make:zikula-extension) to discourage use of Zikula as vendor

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

