### PR TITLE
make URL field optional for themes

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -15,7 +15,8 @@
   - Fix invalid reset of start controller settings when upgrading from 3.0 to a newer version.
   - Fix broken autoloader recognition of additional extensions for distribution-based installations.
   - Improved help texts for mailer configuration (#4356).
-  - Update maker (make:zikula-extension) to discourage use of Zikula as vendor (#4382).
+  - Update maker (`make:zikula-extension`) to discourage use of Zikula as vendor (#4382).
+  - Fix too strict requirement of URL field for theme extensions (#4353).
 
 - Features:
   - _there should be none_

--- a/src/system/ExtensionsModule/Controller/ExtensionController.php
+++ b/src/system/ExtensionsModule/Controller/ExtensionController.php
@@ -201,7 +201,11 @@ class ExtensionController extends AbstractController
             $extension->setDescription($metaData['description']);
         }
 
-        $form = $this->createForm(ExtensionModifyType::class, $extension);
+        $formOptions = [
+            'extensionType' => mb_strtolower($extensionBundle->getNameType())
+        ];
+
+        $form = $this->createForm(ExtensionModifyType::class, $extension, $formOptions);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             if ($form->get('defaults')->isClicked()) {

--- a/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
+++ b/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
@@ -77,10 +77,10 @@ class ExtensionModifyType extends AbstractType
         $resolver->setDefined('extensionType');
         $resolver->setAllowedTypes('extensionType', 'string');
         $resolver->setAllowedValues('extensionType', ['module', 'theme']);
-        $resolver->setDefault('extensionType', 'module');
 
         $resolver->setDefaults([
-            'data_class' => ExtensionEntity::class
+            'data_class' => ExtensionEntity::class,
+            'extensionType' => 'module'
         ]);
     }
 }

--- a/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
+++ b/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
@@ -74,7 +74,6 @@ class ExtensionModifyType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
-
         $resolver->setRequired('extensionType');
         $resolver->setAllowedTypes('extensionType', 'string');
         $resolver->setAllowedValues('extensionType', ['module', 'theme']);

--- a/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
+++ b/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
@@ -38,7 +38,8 @@ class ExtensionModifyType extends AbstractType
             ->add('url', TextType::class, [
                 'label' => 'URL',
                 'input_group' => ['left' => '/'],
-                'help' => 'WARNING: changing the url affects SEO by breaking existing indexed search results.'
+                'help' => 'WARNING: changing the url affects SEO by breaking existing indexed search results.',
+                'required' => 'theme' !== $options['extensionType']
             ])
             ->add($builder->create('description', TextType::class, [
                 'label' => 'Description',
@@ -73,6 +74,11 @@ class ExtensionModifyType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
+
+        $resolver->setRequired('extensionType');
+        $resolver->setAllowedTypes('extensionType', 'string');
+        $resolver->setAllowedValues('extensionType', ['module', 'theme']);
+
         $resolver->setDefaults([
             'data_class' => ExtensionEntity::class
         ]);

--- a/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
+++ b/src/system/ExtensionsModule/Form/Type/ExtensionModifyType.php
@@ -74,9 +74,10 @@ class ExtensionModifyType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setRequired('extensionType');
+        $resolver->setDefined('extensionType');
         $resolver->setAllowedTypes('extensionType', 'string');
         $resolver->setAllowedValues('extensionType', ['module', 'theme']);
+        $resolver->setDefault('extensionType', 'module');
 
         $resolver->setDefaults([
             'data_class' => ExtensionEntity::class


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixes #4353 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

This PR adds a form option for extension editing to make the URL field optional for themes.
