### PR TITLE
improved behavior of VariableApi

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -17,6 +17,7 @@
   - Improved help texts for mailer configuration (#4356).
   - Update maker (`make:zikula-extension`) to discourage use of Zikula as vendor (#4382).
   - Fix too strict requirement of URL field for theme extensions (#4353).
+  - Improve behaviour of `VariableApi` when system is not installed yet (#4360).
 
 - Features:
   - _there should be none_

--- a/src/system/ExtensionsModule/Api/VariableApi.php
+++ b/src/system/ExtensionsModule/Api/VariableApi.php
@@ -73,10 +73,10 @@ class VariableApi implements VariableApiInterface
     /**
      * Loads extension vars for all extensions to reduce sql statements.
      */
-    private function initialize(): void
+    private function initialize(): bool
     {
         if (!$this->installed) {
-            return;
+            return false;
         }
 
         // The empty arrays for handlers and settings are required to prevent messages with E_ALL error reporting
@@ -106,6 +106,8 @@ class VariableApi implements VariableApiInterface
         $this->localizeVariables('en');
 
         $this->isInitialized = true;
+
+        return true;
     }
 
     public function localizeVariables(string $lang): void
@@ -125,8 +127,8 @@ class VariableApi implements VariableApiInterface
         if (empty($extensionName) || !is_string($extensionName) || empty($variableName) || !is_string($variableName)) {
             throw new InvalidArgumentException();
         }
-        if (!$this->isInitialized) {
-            $this->initialize();
+        if (!$this->isInitialized && !$this->initialize()) {
+            return false;
         }
 
         return isset($this->variables[$extensionName]) && array_key_exists($variableName, $this->variables[$extensionName]);
@@ -137,8 +139,8 @@ class VariableApi implements VariableApiInterface
         if (empty($extensionName) || !is_string($extensionName) || empty($variableName) || !is_string($variableName)) {
             throw new InvalidArgumentException();
         }
-        if (!$this->isInitialized) {
-            $this->initialize();
+        if (!$this->isInitialized && !$this->initialize()) {
+            return $default;
         }
 
         if (isset($this->variables[$extensionName]) && array_key_exists($variableName, $this->variables[$extensionName])) {
@@ -158,8 +160,8 @@ class VariableApi implements VariableApiInterface
         if (empty($extensionName) || !is_string($extensionName)) {
             throw new InvalidArgumentException();
         }
-        if (!$this->isInitialized) {
-            $this->initialize();
+        if (!$this->isInitialized && !$this->initialize()) {
+            return [];
         }
 
         return $this->variables[$extensionName] ?? [];

--- a/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
+++ b/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
@@ -119,8 +119,8 @@ class DefaultPageAssetSetterListener implements EventSubscriberInterface
     private function addJquery(): void
     {
         $this->jsAssetBag->add([
-            $this->assetHelper->resolve("jquery/jquery.min.js") => AssetBag::WEIGHT_JQUERY,
-            $this->assetHelper->resolve('@ZikulaThemeModule:js/ZikulaThemeModule.JSConfig.js') => AssetBag::WEIGHT_JQUERY + 1,
+            $this->assetHelper->resolve('jquery/jquery.min.js') => AssetBag::WEIGHT_JQUERY,
+            $this->assetHelper->resolve('modules/zikulatheme/js/ZikulaThemeModule.JSConfig.js') => AssetBag::WEIGHT_JQUERY + 1,
             $this->assetHelper->resolve('bundles/core/js/jquery_config.js') => AssetBag::WEIGHT_JQUERY + 2
         ]);
     }

--- a/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
+++ b/src/system/ThemeModule/EventListener/DefaultPageAssetSetterListener.php
@@ -118,9 +118,15 @@ class DefaultPageAssetSetterListener implements EventSubscriberInterface
 
     private function addJquery(): void
     {
+        $jsConfigFile = 'js/ZikulaThemeModule.JSConfig.js';
+        $jsConfigPath = $this->assetHelper->resolve('modules/zikulatheme/' . $jsConfigFile);
+        if ($this->params['installed'] && null !== $this->themeEngine->getTheme()) {
+            $jsConfigPath = $this->assetHelper->resolve('@ZikulaThemeModule:' . $jsConfigFile);
+        }
+
         $this->jsAssetBag->add([
             $this->assetHelper->resolve('jquery/jquery.min.js') => AssetBag::WEIGHT_JQUERY,
-            $this->assetHelper->resolve('modules/zikulatheme/js/ZikulaThemeModule.JSConfig.js') => AssetBag::WEIGHT_JQUERY + 1,
+            $jsConfigPath => AssetBag::WEIGHT_JQUERY + 1,
             $this->assetHelper->resolve('bundles/core/js/jquery_config.js') => AssetBag::WEIGHT_JQUERY + 2
         ]);
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixes #4360 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Variable Api improvement

This PR makes `VariableApi` stopping any read access if the system is not installed yet. In that case it returns the corresponding fallback, that is the given default value. Write access is not changed to allow persisting variables during the installation process.

## Other change

This PR also improves 5a06f1c6bb538e562f5554b1f20b3f45a8e6ad07 combining the old and the new version, because this change broke the installer:

![Screenshot_20200709_133540](https://user-images.githubusercontent.com/277531/87035070-1a3d7f00-c1e9-11ea-806c-13f177c8fbc4.png)

