### PR TITLE
support key value pairs for route parameter settings

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -18,7 +18,8 @@
   - Update maker (`make:zikula-extension`) to discourage use of Zikula as vendor (#4382).
   - Fix too strict requirement of URL field for theme extensions (#4353).
   - Improve behaviour of `VariableApi` when system is not installed yet (#4360).
-  - Fix behavior of prependBundlePrefix in Routes (#4381).
+  - Fix behavior of `prependBundlePrefix` in Routes (#4381).
+  - Fix broken support for key value pairs for editing custom route parameter settings (defaults, requirements, options).
 
 - Features:
   - _there should be none_

--- a/config/packages/workflow.yaml
+++ b/config/packages/workflow.yaml
@@ -15,7 +15,7 @@ framework:
                 submit:
                     from: initial
                     to: approved
-                updateapproved:
+                update:
                     from: approved
                     to: approved
                 delete:

--- a/src/system/RoutesModule/Form/DataTransformer/ArrayFieldTransformer.php
+++ b/src/system/RoutesModule/Form/DataTransformer/ArrayFieldTransformer.php
@@ -21,5 +21,45 @@ use Zikula\RoutesModule\Form\DataTransformer\Base\AbstractArrayFieldTransformer;
  */
 class ArrayFieldTransformer extends AbstractArrayFieldTransformer
 {
-    // feel free to add your customisation here
+    /** @var string */
+    private $delimiter = ':';
+
+    public function transform($values)
+    {
+        if (null === $values) {
+            return '';
+        }
+
+        if (!is_array($values)) {
+            return $values;
+        }
+
+        if (!count($values)) {
+            return '';
+        }
+
+        $values = $this->removeEmptyEntries($values);
+
+        $value = [];
+        foreach ($values as $k => $v) {
+            $value[] = str_replace($this->delimiter, '', $k) . $this->delimiter . $v;
+        }
+
+        return implode("\n", $value);
+    }
+
+    public function reverseTransform($value)
+    {
+        $items = parent::reverseTransform($value);
+        $result = [];
+        foreach ($items as $value) {
+            if (false === mb_strpos($value, $this->delimiter)) {
+                continue;
+            }
+            list($k, $v) = explode($this->delimiter, $value);
+            $result[trim($k)] = trim($v);
+        }
+
+        return $result;
+    }
 }

--- a/src/system/RoutesModule/Resources/docs/model/Routes.mostapp
+++ b/src/system/RoutesModule/Resources/docs/model/Routes.mostapp
@@ -37,6 +37,7 @@ application "Routes" targets ZK30 {
         Entity/Factory/EntityInitialiser.php,
         Entity/Repository/RouteRepository.php,
         Entity/RouteEntity.php,
+        Form/DataTransformer/ArrayFieldTransformer.php,
         Form/Handler/Route/EditHandler.php,
         Form/Type/RouteType.php,
         Helper/ViewHelper.php,

--- a/src/system/RoutesModule/Resources/views/Route/edit.html.twig
+++ b/src/system/RoutesModule/Resources/views/Route/edit.html.twig
@@ -32,9 +32,9 @@
         </fieldset>
         <fieldset>
             <legend>{% trans %}Parameter settings{% endtrans %}</legend>
-            {{ form_row(form.defaults) }}
-            {{ form_row(form.requirements) }}
-            {{ form_row(form.options) }}
+            {{ form_row(form.defaults, {help: 'Enter one entry per line, use <code>key:value</code> syntax.'|trans, help_html: true}) }}
+            {{ form_row(form.requirements, {help: 'Enter one entry per line, use <code>key:value</code> syntax.'|trans, help_html: true}) }}
+            {{ form_row(form.options, {help: 'Enter one entry per line, use <code>key:value</code> syntax.'|trans, help_html: true}) }}
         </fieldset>
         <fieldset>
             <legend>{% trans %}Advanced settings{% endtrans %}</legend>

--- a/src/system/ZAuthModule/.travis.yml
+++ b/src/system/ZAuthModule/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-
-before_script:
-    - composer install --dev --prefer-source
-
-php:
-  - 5.4
-  - 5.5
-  - 5.6


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | refs #4380 
| License           | MIT
| Changelog updated | yes

## Description

This PR changes the array field transformer used for defaults/options/requirements in order to support key value pairs.
