### PR TITLE
Fix routes editing

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -19,7 +19,7 @@
   - Fix too strict requirement of URL field for theme extensions (#4353).
   - Improve behaviour of `VariableApi` when system is not installed yet (#4360).
   - Fix behavior of `prependBundlePrefix` in Routes (#4381).
-  - Fix santizing logic for routes editing (#4380).
+  - Fix sanitizing logic for routes editing (#4380).
   - Fix exception when editing routes with allowed but unset specific creation date (#4380).
   - Fix broken support for key value pairs for editing custom route parameter settings (defaults, requirements, options).
   - Improved responsive design of the extensions list.

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -19,6 +19,7 @@
   - Fix too strict requirement of URL field for theme extensions (#4353).
   - Improve behaviour of `VariableApi` when system is not installed yet (#4360).
   - Fix behavior of `prependBundlePrefix` in Routes (#4381).
+  - Fix santizing logic for routes editing (#4380).
   - Fix broken support for key value pairs for editing custom route parameter settings (defaults, requirements, options).
   - Improved responsive design of the extensions list.
   - Throw more descriptive exception when non-zasset asset is not found (#4366).

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -20,6 +20,7 @@
   - Improve behaviour of `VariableApi` when system is not installed yet (#4360).
   - Fix behavior of `prependBundlePrefix` in Routes (#4381).
   - Fix santizing logic for routes editing (#4380).
+  - Fix exception when editing routes with allowed but unset specific creation date (#4380).
   - Fix broken support for key value pairs for editing custom route parameter settings (defaults, requirements, options).
   - Improved responsive design of the extensions list.
   - Throw more descriptive exception when non-zasset asset is not found (#4366).

--- a/src/Zikula/FormExtensionBundle/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Zikula/FormExtensionBundle/Resources/views/Form/form_div_layout.html.twig
@@ -18,3 +18,8 @@
     {% endif %}
     <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ iconHtml|raw }}{{ translation_domain is same as(false) ? label : label|trans(label_translation_parameters, translation_domain) }}</button>
 {%- endblock button_widget %}
+
+{# overrides textarea_widget to catch array to string conversion issues when a form returns with errors #}
+{%- block textarea_widget -%}
+    <textarea {{ block('widget_attributes') }}>{{ value is iterable ? value|join("\n") : value }}</textarea>
+{%- endblock textarea_widget -%}

--- a/src/system/RoutesModule/Form/DataTransformer/ArrayFieldTransformer.php
+++ b/src/system/RoutesModule/Form/DataTransformer/ArrayFieldTransformer.php
@@ -35,7 +35,7 @@ class ArrayFieldTransformer extends AbstractArrayFieldTransformer
         }
 
         if (!count($values)) {
-            return null;
+            return '';
         }
 
         $values = $this->removeEmptyEntries($values);

--- a/src/system/RoutesModule/Form/DataTransformer/ArrayFieldTransformer.php
+++ b/src/system/RoutesModule/Form/DataTransformer/ArrayFieldTransformer.php
@@ -35,7 +35,7 @@ class ArrayFieldTransformer extends AbstractArrayFieldTransformer
         }
 
         if (!count($values)) {
-            return '';
+            return null;
         }
 
         $values = $this->removeEmptyEntries($values);
@@ -50,6 +50,10 @@ class ArrayFieldTransformer extends AbstractArrayFieldTransformer
 
     public function reverseTransform($value)
     {
+        if (!$value) {
+            return [];
+        }
+
         $items = parent::reverseTransform($value);
         $result = [];
         foreach ($items as $value) {

--- a/src/system/RoutesModule/Form/Handler/Common/Base/AbstractEditHandler.php
+++ b/src/system/RoutesModule/Form/Handler/Common/Base/AbstractEditHandler.php
@@ -588,6 +588,7 @@ abstract class AbstractEditHandler
             }
             if (
                 isset($this->form['moderationSpecificCreationDate'])
+                && null !== $this->form['moderationSpecificCreationDate']->getData()
                 && '' !== $this->form['moderationSpecificCreationDate']->getData()
             ) {
                 $this->entityRef->setCreatedDate($this->form['moderationSpecificCreationDate']->getData());

--- a/src/system/RoutesModule/Helper/Base/AbstractWorkflowHelper.php
+++ b/src/system/RoutesModule/Helper/Base/AbstractWorkflowHelper.php
@@ -259,10 +259,9 @@ abstract class AbstractWorkflowHelper
             } else {
                 $this->logger->error('{app}: User {user} tried to update an entity, but failed.', $logArgs);
             }
-            // if database errors occur do not throw them
-            // in order to avoid unclear error message "The entity manager is closed."
-            die($exception->getMessage());
-            //throw new RuntimeException($exception->getMessage());
+            // uncomment to reveal Doctrine/SQL error
+            // die($exception->getMessage());
+            throw new RuntimeException($exception->getMessage());
         }
     
         if (false !== $result && !$recursive) {

--- a/src/system/RoutesModule/Helper/Base/AbstractWorkflowHelper.php
+++ b/src/system/RoutesModule/Helper/Base/AbstractWorkflowHelper.php
@@ -259,7 +259,10 @@ abstract class AbstractWorkflowHelper
             } else {
                 $this->logger->error('{app}: User {user} tried to update an entity, but failed.', $logArgs);
             }
-            throw new RuntimeException($exception->getMessage());
+            // if database errors occur do not throw them
+            // in order to avoid unclear error message "The entity manager is closed."
+            die($exception->getMessage());
+            //throw new RuntimeException($exception->getMessage());
         }
     
         if (false !== $result && !$recursive) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixed #4380 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

- Fix sanitizing logic for routes editing.
- Fix exception when editing routes with allowed but unset specific creation date.
- Unhide Doctrine exceptions during route creation/editing/deletion by preventing unclear error message "The entity manager is closed" because session entity is tried to be updated after the exception happened.
- Prevent incorrect form fallback if errors occured and textarea content was already transformed back to arrays.
