### PR TITLE
Allow creating and changing mappings without setting a password

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -23,6 +23,7 @@
   - Improved responsive design of the extensions list.
   - Throw more descriptive exception when non-zasset asset is not found (#4366).
   - Install extension assets on installation and upgrade (#4367).
+  - Allow creating and changing mappings without setting a password  (#4395).
 
 - Features:
   - _there should be none_

--- a/src/system/ZAuthModule/Entity/AuthenticationMappingEntity.php
+++ b/src/system/ZAuthModule/Entity/AuthenticationMappingEntity.php
@@ -141,9 +141,11 @@ class AuthenticationMappingEntity extends EntityAccess implements UserInterface
         return $this->pass;
     }
 
-    public function setPass(string $pass): void
+    public function setPass(?string $pass): void
     {
-        $this->pass = $pass;
+        if (isset($pass)) {
+            $this->pass = $pass;
+        }
     }
 
     public function getUserEntityData(): array

--- a/src/system/ZAuthModule/Resources/public/js/Zikula.ZAuth.UserAdmin.js
+++ b/src/system/ZAuthModule/Resources/public/js/Zikula.ZAuth.UserAdmin.js
@@ -6,8 +6,8 @@
         var setPassEle = $('#' + idElem.data('setpassid'));
         var setPassAlert = setPassEle.parent().find('.alert');
         var setPassWrap = $('#' + idElem.data('setpassid') + '_wrap');
-        var passFirst = $('#' + idElem.data('passid') + '_first');
-        var passSecond = $('#' + idElem.data('passid') + '_second');
+        var passFirst = $('#' + idElem.data('passid') + '_pass_first');
+        var passSecond = $('#' + idElem.data('passid') + '_pass_second');
         var showPasswordsRequired = function() {
             passFirst.prop('required', true);
             passFirst.parents('.form-group').find('label').addClass('required');

--- a/src/system/ZAuthModule/Validator/Constraints/ValidAntiSpamAnswerValidator.php
+++ b/src/system/ZAuthModule/Validator/Constraints/ValidAntiSpamAnswerValidator.php
@@ -60,7 +60,7 @@ class ValidAntiSpamAnswerValidator extends ConstraintValidator
                 'message' => $this->translator->trans('You did not provide the correct answer for the security question. Try %answer%!', ['%answer%' => $correctAnswer], 'validators')
             ])
         ]);
-        if (count($errors) > 0) {
+        if (0 < count($errors)) {
             foreach ($errors as $error) {
                 // this method forces the error to appear at the form input location instead of at the top of the form
                 $this->context->buildViolation($error->getMessage())->addViolation();

--- a/src/system/ZAuthModule/Validator/Constraints/ValidUserFieldsValidator.php
+++ b/src/system/ZAuthModule/Validator/Constraints/ValidUserFieldsValidator.php
@@ -67,7 +67,7 @@ class ValidUserFieldsValidator extends ConstraintValidator
         }
         // Ensure unique uname.
         $qb = $this->mappingRepository->createQueryBuilder('m');
-        $qb->select('count(m.uid)')
+        $qb->select('COUNT(m.uid)')
             ->where($qb->expr()->eq('LOWER(m.uname)', ':uname'))
             ->setParameter('uname', $userName);
         // when updating an existing User, the existing Uid must be excluded.
@@ -84,7 +84,7 @@ class ValidUserFieldsValidator extends ConstraintValidator
 
         // Ensure unique email from both mapping and verification entities if authenticationMethod = native_email or native_either.
         $qb = $this->mappingRepository->createQueryBuilder('m')
-            ->select('count(m.uid)')
+            ->select('COUNT(m.uid)')
             ->where('m.email = :email')
             ->andWhere('m.method IN (:methods)')
             ->setParameter('email', $emailAddress)
@@ -98,7 +98,7 @@ class ValidUserFieldsValidator extends ConstraintValidator
         $uCount = (int)$qb->getQuery()->getSingleScalarResult();
 
         $query = $this->userVerificationRepository->createQueryBuilder('v')
-            ->select('count(v.uid)')
+            ->select('COUNT(v.uid)')
             ->where('v.newemail = :email')
             ->andWhere('v.changetype = :chgtype')
             ->setParameter('email', $emailAddress)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixed #4395 
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

- Corrected wrong field reference in JS to update input field required states depending on the "set password" toggle
- Allow calling the `setPass` method with `null` value, but do not assign these to avoid overriding existing passwords
  - Otherwise submitting the form without having a new password set results in `Expected argument of type "string", "null" given at property path "pass".`
