### PR TITLE
added missing argument to FormAwareHook constructor

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -13,6 +13,7 @@
   - [CoreInstallerBundle] Fix invalid access to obsolete parameter when upgrading from 3.0 to a newer version.
   - [CoreInstallerBundle] Fix invalid reset of start controller settings when upgrading from 3.0 to a newer version.
   - [CoreInstallerBundle] Fix wrong link to upgrade docs in the upgrader (#4364).
+  - [HookBundle] Add missing argument for assigning object ID to `FormAwareHook` constructor.
   - [Blocks] Include jQuery-UI in the block position editing template (#4400).
   - [Extensions] Fix outputting invalid html in modulelinks navbar (e.g. `<li icon="foo-bar"...`)
   - [Extensions] Fix too strict requirement of URL field for theme extensions (#4353).

--- a/src/Zikula/HookBundle/FormAwareHook/FormAwareHook.php
+++ b/src/Zikula/HookBundle/FormAwareHook/FormAwareHook.php
@@ -29,9 +29,10 @@ class FormAwareHook extends Hook
      */
     private $templates = [];
 
-    public function __construct(FormInterface $form)
+    public function __construct(FormInterface $form, ?int $subjectId = null)
     {
         $this->form = $form;
+        $this->id = $subjectId;
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

Allow that also form aware hooks can assign an object identifier.
