### PR TITLE
Use brackets for inlined env variables

### DIFF
--- a/src/Zikula/CoreBundle/Tests/Helper/LocalDotEnvHelperTest.php
+++ b/src/Zikula/CoreBundle/Tests/Helper/LocalDotEnvHelperTest.php
@@ -72,13 +72,13 @@ class LocalDotEnvHelperTest extends TestCase
         ];
         $vars = [
             'DATABASE_URL' => '!' . $data['database_driver']
-                . '://$DATABASE_USER:$DATABASE_PWD'
+                . '://${DATABASE_USER}:${DATABASE_PWD}'
                 . '@' . $data['database_host'] . (!empty($data['database_port']) ? ':' . $data['database_port'] : '')
                 . '/' . $data['database_name']
                 . '?serverVersion=5.7' // any value will work (bypasses DBALException)
         ];
         $helper->writeLocalEnvVars($vars, true);
-        $expected = 'DATABASE_URL=mysql://$DATABASE_USER:$DATABASE_PWD@localhost/foo?serverVersion=5.7';
+        $expected = 'DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PWD}@localhost/foo?serverVersion=5.7';
         $this->assertEquals($expected, $this->getFileContents());
     }
 

--- a/src/Zikula/CoreInstallerBundle/Helper/DbCredsHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/DbCredsHelper.php
@@ -39,9 +39,9 @@ class DbCredsHelper
             'DATABASE_PWD' => $data['database_password'],
             'DATABASE_NAME' => $data['database_name'],
             'DATABASE_URL' => '!' . $data['database_driver']
-                . '://$DATABASE_USER:$DATABASE_PWD'
+                . '://${DATABASE_USER}:${DATABASE_PWD}'
                 . '@' . $data['database_host'] . (!empty($data['database_port']) ? ':' . $data['database_port'] : '')
-                . '/$DATABASE_NAME?serverVersion=' . ($data['database_server_version'] ?? '5.7') // any value for serverVersion will work (bypasses DBALException)
+                . '/${DATABASE_NAME}?serverVersion=' . ($data['database_server_version'] ?? '5.7') // any value for serverVersion will work (bypasses DBALException)
         ];
 
         try {

--- a/src/system/MailerModule/Helper/MailTransportHelper.php
+++ b/src/system/MailerModule/Helper/MailTransportHelper.php
@@ -34,14 +34,14 @@ class MailTransportHelper
             throw new \InvalidArgumentException('Transport must be set.');
         }
         $transportStrings = [
-            'smtp' => 'smtp://$MAILER_ID:$MAILER_KEY@',
+            'smtp' => 'smtp://${MAILER_ID}:${MAILER_KEY}@',
             'sendmail' => 'sendmail+smtp://default',
-            'amazon' => 'ses://$MAILER_ID:$MAILER_KEY@default',
-            'gmail' => 'gmail://$MAILER_ID:$MAILER_KEY@default',
-            'mailchimp' => 'mandrill://$MAILER_ID:$MAILER_KEY@default',
-            'mailgun' => 'mailgun://$MAILER_ID:$MAILER_KEY@default',
-            'postmark' => 'postmark://$MAILER_ID:$MAILER_KEY@default',
-            'sendgrid' => 'sendgrid://apikey:$MAILER_KEY@default', // unclear if 'apikey' is supposed to be literal, or replaced
+            'amazon' => 'ses://${MAILER_ID}:${MAILER_KEY}@default',
+            'gmail' => 'gmail://${MAILER_ID}:${MAILER_KEY}@default',
+            'mailchimp' => 'mandrill://${MAILER_ID}:${MAILER_KEY}@default',
+            'mailgun' => 'mailgun://${MAILER_ID}:${MAILER_KEY}@default',
+            'postmark' => 'postmark://${MAILER_ID}:${MAILER_KEY}@default',
+            'sendgrid' => 'sendgrid://apikey:${MAILER_KEY}@default', // unclear if 'apikey' is supposed to be literal, or replaced
             'test' => 'null://null',
         ];
         try {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR makes evaluation of inlined variables more robust by marking them using brackets, as shown in https://symfony.com/doc/current/configuration.html#env-file-syntax
