### PR TITLE
fix for textareas

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -16,6 +16,7 @@
   - [CoreInstallerBundle] Fix upgrade procedure (#4406).
   - [CoreInstallerBundle] Remove blocks with properties that cannot be unserialized on upgrade.
   - [CoreInstallerBundle] Remove legacy modvars beginning with 'systemplugin'.
+  - [FormExtensionBundle] Fix textarea width problem (#4421).
   - [HookBundle] Add missing argument for assigning object ID to `FormAwareHook` constructor.
   - [HookBundle] Avoid JS error when editing hook provider which is not a subscriber, too.
   - [Admin] Fix error when extension is not categorized.

--- a/src/Zikula/FormExtensionBundle/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Zikula/FormExtensionBundle/Resources/views/Form/form_div_layout.html.twig
@@ -21,5 +21,6 @@
 
 {# overrides textarea_widget to catch array to string conversion issues when a form returns with errors #}
 {%- block textarea_widget -%}
+    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
     <textarea {{ block('widget_attributes') }}>{{ value is iterable ? value|join("\n") : value }}</textarea>
 {%- endblock textarea_widget -%}

--- a/src/system/AdminModule/Resources/public/css/style.css
+++ b/src/system/AdminModule/Resources/public/css/style.css
@@ -15,13 +15,6 @@ body div.z-admin-content .navbar {
     margin: 0.5em 0;
 }
 
-body div.z-admin-content textarea {
-    width: 100%;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-}
-
 /******************************************************************************
 * Styling for all general headers in the entire admin box.
 ******************************************************************************/

--- a/src/system/AdminModule/Resources/public/css/style.css
+++ b/src/system/AdminModule/Resources/public/css/style.css
@@ -15,6 +15,13 @@ body div.z-admin-content .navbar {
     margin: 0.5em 0;
 }
 
+body div.z-admin-content textarea {
+    width: 100%;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
 /******************************************************************************
 * Styling for all general headers in the entire admin box.
 ******************************************************************************/


### PR DESCRIPTION
trying to fix minor layout issue for textareas. I am surprised bootstrap does not already solve this. 

before:

![Screen Shot 2020-07-24 at 11 09 35 AM](https://user-images.githubusercontent.com/350048/88407395-0de82300-cda0-11ea-8190-d86e8620c998.png)

after:

![Screen Shot 2020-07-24 at 11 23 28 AM](https://user-images.githubusercontent.com/350048/88407433-1b051200-cda0-11ea-8e74-cb60581e729b.png)
