### PR TITLE
Use request constant for POST method

### DIFF
--- a/src/system/BlocksModule/Controller/AdminController.php
+++ b/src/system/BlocksModule/Controller/AdminController.php
@@ -63,7 +63,7 @@ class AdminController extends AbstractController
         $currentSortDirection = $request->query->get('sort-direction', $sessionFilterData['sort-direction'] ?? Column::DIRECTION_ASCENDING);
         $filterForm = $this->createForm(AdminViewFilterType::class, $sessionFilterData, [
             'action' => $this->generateUrl('zikulablocksmodule_admin_view'),
-            'method' => 'POST',
+            'method' => Request::METHOD_POST,
             'moduleChoices' => array_flip($blockApi->getModulesContainingBlocks()),
             'positionChoices' => array_flip($positionRepository->getPositionChoiceArray()),
             'localeChoices' => $localeApi->getSupportedLocaleNames(null, $request->getLocale())

--- a/src/system/GroupsModule/Controller/MembershipController.php
+++ b/src/system/GroupsModule/Controller/MembershipController.php
@@ -182,7 +182,7 @@ class MembershipController extends AbstractController
         int $gid = 0,
         int $uid = 0
     ) {
-        if ($request->isMethod('POST')) {
+        if ($request->isMethod(Request::METHOD_POST)) {
             $postVars = $request->request->get('zikulagroupsmodule_removeuser');
             $gid = $postVars['gid'] ?? 0;
             $uid = $postVars['uid'] ?? 0;

--- a/src/system/SecurityCenterModule/Controller/ConfigController.php
+++ b/src/system/SecurityCenterModule/Controller/ConfigController.php
@@ -268,7 +268,7 @@ class ConfigController extends AbstractController
         CacheClearer $cacheClearer,
         string $reset = null
     ) {
-        if ('POST' === $request->getMethod()) {
+        if (Request::METHOD_POST === $request->getMethod()) {
             // Load HTMLPurifier Classes
             $purifier = $purifierHelper->getPurifier();
 
@@ -475,7 +475,7 @@ class ConfigController extends AbstractController
     ) {
         $htmlTags = $htmlTagsHelper->getTagsWithLinks();
 
-        if ('POST' === $request->getMethod()) {
+        if (Request::METHOD_POST === $request->getMethod()) {
             $htmlEntities = $request->request->getInt('htmlentities', 0);
             $variableApi->set(VariableApi::CONFIG, 'htmlentities', $htmlEntities);
 

--- a/src/system/UsersModule/Controller/AccessController.php
+++ b/src/system/UsersModule/Controller/AccessController.php
@@ -115,7 +115,7 @@ class AccessController extends AbstractController
             }
         } elseif ($authenticationMethod instanceof ReEntrantAuthenticationMethodInterface) {
             // provide temp value for uid until form gives real value.
-            $uid = 'POST' === $request->getMethod() ? Constant::USER_ID_ANONYMOUS : $authenticationMethod->authenticate();
+            $uid = Request::METHOD_POST === $request->getMethod() ? Constant::USER_ID_ANONYMOUS : $authenticationMethod->authenticate();
             $hasListeners = $eventDispatcher->hasListeners(LoginFormPostCreatedEvent::class);
             $hookBindings = $hookDispatcher->getBindingsFor('subscriber.users.ui_hooks.login_screen');
             if ($hasListeners || count($hookBindings) > 0) {

--- a/src/system/UsersModule/Controller/UserAdministrationController.php
+++ b/src/system/UsersModule/Controller/UserAdministrationController.php
@@ -291,7 +291,7 @@ class UserAdministrationController extends AbstractController
         UserEntity $user = null
     ) {
         $uids = [];
-        if (!isset($user) && 'POST' === $request->getMethod() && $request->request->has('zikulausersmodule_delete')) {
+        if (!isset($user) && Request::METHOD_POST === $request->getMethod() && $request->request->has('zikulausersmodule_delete')) {
             $deletionData = $request->request->get('zikulausersmodule_delete');
             if (isset($deletionData['users']) && !empty($deletionData['users'])) {
                 $uids = $deletionData['users'];


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR ensures that a constant from the Request class is used instead of hardcoded strings.
