### PR TITLE
avoid exception by potential autoloader closure

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,6 +6,7 @@
   - _there should be none_
 
 - Fixes:
+  - [CoreBundle] More robust autoloader detection.
   - [Menu] Fix error during creation of new menus.
 
 - Features:

--- a/src/Zikula/CoreBundle/HttpKernel/ZikulaKernel.php
+++ b/src/Zikula/CoreBundle/HttpKernel/ZikulaKernel.php
@@ -190,15 +190,21 @@ abstract class ZikulaKernel extends Kernel implements ZikulaHttpKernelInterface
     {
         if (null === $this->autoloader) {
             $loaders = spl_autoload_functions();
-            if ($loaders[0][0] instanceof DebugClassLoader) {
-                $classLoader = $loaders[0][0]->getClassLoader();
-                if (is_callable($classLoader) && is_object($classLoader[0])) {
-                    $this->autoloader = $classLoader[0];
-                } elseif (is_object($classLoader)) {
-                    $this->autoloader = $classLoader;
+            foreach ($loaders as $loader) {
+                if ($loader[0] instanceof DebugClassLoader) {
+                    $classLoader = $loader[0]->getClassLoader();
+                    if ($classLoader instanceof Closure) {
+                        // skip unwanted autoloaders ("Cannot use object of type Closure as array")
+                        continue;
+                    }
+                    if (is_callable($classLoader) && is_object($classLoader[0])) {
+                        $this->autoloader = $classLoader[0];
+                    } elseif (is_object($classLoader)) {
+                        $this->autoloader = $classLoader;
+                    }
+                } else {
+                    $this->autoloader = $loader[0];
                 }
-            } else {
-                $this->autoloader = $loaders[0][0];
             }
         }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

This PR avoids that additional vendors that contribute own autoloaders may cause a problem in our kernel if these autoloaders are closures and hide (shadow) the autoloader from composer.
