### PR TITLE
remove action suffix from controller methods

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -21,6 +21,6 @@
 
 - Deprecated:
   - [General] Controller methods should not have an `Action` suffix in their names anymore.
-  - [CoreBundle] `Zikula/CoreBundle/YamlDumper` use `Configurator` as needed.
+  - [CoreBundle] `Zikula/CoreBundle/YamlDumper` is deprecated. Please use `Configurator` as needed.
   - [BlocksModule] Content-providing blocks (FincludeBlock, HtmlBlock, TextBlock, XsltBlock) use StaticContentModule instead.
   - [BootstrapTheme] The entire theme is deprecated. Please see DefaultTheme for replacement.

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -20,6 +20,7 @@
     - This looks the same as ZikulaBootstrapTheme but improves the templates in a way that is not BC.
 
 - Deprecated:
+  - [General] Controller methods should not have an `Action` suffix in their names anymore.
   - [CoreBundle] `Zikula/CoreBundle/YamlDumper` use `Configurator` as needed.
   - [BlocksModule] Content-providing blocks (FincludeBlock, HtmlBlock, TextBlock, XsltBlock) use StaticContentModule instead.
   - [BootstrapTheme] The entire theme is deprecated. Please see DefaultTheme for replacement.

--- a/src/Zikula/CoreBundle/Controller/MainController.php
+++ b/src/Zikula/CoreBundle/Controller/MainController.php
@@ -46,7 +46,7 @@ class MainController
      * This controller action is designed for the "/" route (home).
      * The route definition is set in `CoreBundle/Resources/config/routing.xml`
      */
-    public function homeAction(Request $request): Response
+    public function home(Request $request): Response
     {
         $startPageInfo = $this->variableApi->getSystemVar('startController');
         if (!is_array($startPageInfo) || !isset($startPageInfo['controller']) || empty($startPageInfo['controller'])) {

--- a/src/Zikula/CoreInstallerBundle/Controller/AjaxInstallController.php
+++ b/src/Zikula/CoreInstallerBundle/Controller/AjaxInstallController.php
@@ -29,7 +29,7 @@ class AjaxInstallController
         $this->stageHelper = $stageHelper;
     }
 
-    public function ajaxAction(Request $request): JsonResponse
+    public function ajax(Request $request): JsonResponse
     {
         $stage = $request->request->get('stage');
         $status = $this->stageHelper->executeStage($stage);

--- a/src/Zikula/CoreInstallerBundle/Controller/AjaxUpgradeController.php
+++ b/src/Zikula/CoreInstallerBundle/Controller/AjaxUpgradeController.php
@@ -37,7 +37,7 @@ class AjaxUpgradeController
         $this->stageHelper = $stageHelper;
     }
 
-    public function ajaxAction(Request $request): JsonResponse
+    public function ajax(Request $request): JsonResponse
     {
         $stage = $request->request->get('stage');
         $this->yamlHelper->setParameter('upgrading', true);

--- a/src/Zikula/CoreInstallerBundle/Controller/InstallerController.php
+++ b/src/Zikula/CoreInstallerBundle/Controller/InstallerController.php
@@ -52,7 +52,7 @@ class InstallerController
         $this->installed = '0.0.0' !== $installed;
     }
 
-    public function installAction(Request $request, string $stage): Response
+    public function install(Request $request, string $stage): Response
     {
         // already installed?
         if ('complete' !== $stage && $this->installed) {

--- a/src/Zikula/CoreInstallerBundle/Controller/MigrationController.php
+++ b/src/Zikula/CoreInstallerBundle/Controller/MigrationController.php
@@ -29,7 +29,7 @@ class MigrationController
         $this->migrationHelper = $migrationHelper;
     }
 
-    public function migrateAction(Request $request): JsonResponse
+    public function migrate(Request $request): JsonResponse
     {
         $percentComplete = 0;
         if ($request->hasSession() && ($session = $request->getSession())) {

--- a/src/Zikula/CoreInstallerBundle/Controller/UpgraderController.php
+++ b/src/Zikula/CoreInstallerBundle/Controller/UpgraderController.php
@@ -72,7 +72,7 @@ class UpgraderController
         $this->locale = $locale;
     }
 
-    public function upgradeAction(Request $request, $stage): Response
+    public function upgrade(Request $request, $stage): Response
     {
         if (version_compare($this->installed, ZikulaKernel::VERSION, '=')) {
             $stage = 'complete';

--- a/src/Zikula/HookBundle/Controller/HookController.php
+++ b/src/Zikula/HookBundle/Controller/HookController.php
@@ -50,7 +50,7 @@ class HookController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have admin permissions over the module
      */
-    public function editAction(
+    public function edit(
         RequestStack $requestStack,
         PermissionApiInterface $permissionApi,
         HookCollectorInterface $collector,
@@ -149,7 +149,7 @@ class HookController extends AbstractController
      * @throws RuntimeException Thrown if either the subscriber or provider module isn't available
      * @throws AccessDeniedException Thrown if the user doesn't have admin access to either the subscriber or provider modules
      */
-    public function toggleSubscribeAreaStatusAction(
+    public function toggleSubscribeAreaStatus(
         Request $request,
         ZikulaHttpKernelInterface $kernel,
         TranslatorInterface $translator,
@@ -233,7 +233,7 @@ class HookController extends AbstractController
      * @throws RuntimeException Thrown if the subscriber module isn't available
      * @throws AccessDeniedException Thrown if the user doesn't have admin access to the subscriber module
      */
-    public function changeProviderAreaOrderAction(
+    public function changeProviderAreaOrder(
         Request $request,
         ZikulaHttpKernelInterface $kernel,
         TranslatorInterface $translator,

--- a/src/Zikula/WorkflowBundle/Controller/EditorController.php
+++ b/src/Zikula/WorkflowBundle/Controller/EditorController.php
@@ -46,7 +46,7 @@ class EditorController extends AbstractController
      *
      * @throws NotFoundHttpException Thrown if the desired workflow could not be found
      */
-    public function indexAction(
+    public function index(
         Request $request,
         Registry $workflowRegistry,
         TranslatorInterface $translator,

--- a/src/system/AdminModule/Controller/AdminController.php
+++ b/src/system/AdminModule/Controller/AdminController.php
@@ -47,7 +47,7 @@ class AdminController extends AbstractController
      *
      * The main administration function.
      */
-    public function indexAction(): RedirectResponse
+    public function index(): RedirectResponse
     {
         // Security check will be done in view()
         return $this->redirectToRoute('zikulaadminmodule_admin_view');
@@ -61,7 +61,7 @@ class AdminController extends AbstractController
      *
      * Views all admin categories.
      */
-    public function viewAction(AdminCategoryRepositoryInterface $repository, int $page = 1): array
+    public function view(AdminCategoryRepositoryInterface $repository, int $page = 1): array
     {
         $pageSize = $this->getVar('itemsperpage');
 
@@ -84,7 +84,7 @@ class AdminController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function newcatAction(Request $request)
+    public function create(Request $request)
     {
         $form = $this->createForm(AdminCategoryType::class, new AdminCategoryEntity());
         $form->handleRequest($request);
@@ -116,7 +116,7 @@ class AdminController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user doesn't have permission to edit a category
      */
-    public function modifyAction(Request $request, AdminCategoryEntity $category)
+    public function modify(Request $request, AdminCategoryEntity $category)
     {
         if (!$this->hasPermission('ZikulaAdminModule::Category', $category['name'] . '::' . $category->getCid(), ACCESS_EDIT)) {
             throw new AccessDeniedException();
@@ -154,7 +154,7 @@ class AdminController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user doesn't have permission to edit a category
      */
-    public function deleteAction(Request $request, AdminCategoryEntity $category)
+    public function delete(Request $request, AdminCategoryEntity $category)
     {
         if (!$this->hasPermission('ZikulaAdminModule::Category', $category->getName() . '::' . $category->getCid(), ACCESS_DELETE)) {
             throw new AccessDeniedException();
@@ -192,7 +192,7 @@ class AdminController extends AbstractController
      * @return array|Response
      * @throws AccessDeniedException Thrown if the user doesn't have edit permission for the module
      */
-    public function adminpanelAction(
+    public function adminpanel(
         ZikulaHttpKernelInterface $kernel,
         AdminCategoryRepositoryInterface $adminCategoryRepository,
         AdminModuleRepositoryInterface $adminModuleRepository,
@@ -308,7 +308,7 @@ class AdminController extends AbstractController
      *
      * Displays main category menu.
      */
-    public function categorymenuAction(
+    public function categorymenu(
         AdminCategoryRepositoryInterface $adminCategoryRepository,
         AdminModuleRepositoryInterface $adminModuleRepository,
         CapabilityApiInterface $capabilityApi,

--- a/src/system/AdminModule/Controller/AdminInterfaceController.php
+++ b/src/system/AdminModule/Controller/AdminInterfaceController.php
@@ -43,7 +43,7 @@ class AdminInterfaceController extends AbstractController
      *
      * Open the admin container
      */
-    public function headerAction(RequestStack $requestStack): Response
+    public function header(RequestStack $requestStack): Response
     {
         return $this->render('@ZikulaAdminModule/AdminInterface/header.html.twig', [
             'caller' => $requestStack->getMasterRequest()->attributes->all()
@@ -55,7 +55,7 @@ class AdminInterfaceController extends AbstractController
      *
      * Close the admin container
      */
-    public function footerAction(
+    public function footer(
         RequestStack $requestStack,
         ExtensionRepositoryInterface $extensionRepository
     ): Response {
@@ -75,7 +75,7 @@ class AdminInterfaceController extends AbstractController
      *
      * Admin breadcrumbs
      */
-    public function breadcrumbsAction(
+    public function breadcrumbs(
         RequestStack $requestStack,
         ExtensionRepositoryInterface $extensionRepository,
         AdminModuleRepositoryInterface $adminModuleRepository,
@@ -108,7 +108,7 @@ class AdminInterfaceController extends AbstractController
      *
      * Display security analyzer
      */
-    public function securityanalyzerAction(
+    public function securityanalyzer(
         Request $request,
         ZikulaHttpKernelInterface $kernel,
         VariableApiInterface $variableApi
@@ -132,7 +132,7 @@ class AdminInterfaceController extends AbstractController
      *
      * Display update check
      */
-    public function updatecheckAction(
+    public function updatecheck(
         RequestStack $requestStack,
         ZikulaHttpKernelInterface $kernel,
         UpdateCheckHelper $updateCheckHelper
@@ -155,7 +155,7 @@ class AdminInterfaceController extends AbstractController
      *
      * Display admin menu
      */
-    public function menuAction(
+    public function menu(
         RequestStack $requestStack,
         RouterInterface $router,
         ExtensionRepositoryInterface $extensionRepository,

--- a/src/system/AdminModule/Controller/AjaxController.php
+++ b/src/system/AdminModule/Controller/AjaxController.php
@@ -39,7 +39,7 @@ class AjaxController extends AbstractController
      *
      * Change the category a module belongs to by ajax.
      */
-    public function changeModuleCategoryAction(
+    public function changeModuleCategory(
         Request $request,
         RouterInterface $router,
         ExtensionRepositoryInterface $extensionRepository,
@@ -91,7 +91,7 @@ class AjaxController extends AbstractController
      *
      * Add a new admin category by ajax.
      */
-    public function addCategoryAction(
+    public function addCategory(
         Request $request,
         RouterInterface $router,
         AdminCategoryRepositoryInterface $adminCategoryRepository
@@ -141,7 +141,7 @@ class AjaxController extends AbstractController
      *
      * Delete an admin category by ajax.
      */
-    public function deleteCategoryAction(
+    public function deleteCategory(
         Request $request,
         AdminCategoryRepositoryInterface $adminCategoryRepository,
         AdminModuleRepositoryInterface $adminModuleRepository
@@ -194,7 +194,7 @@ class AjaxController extends AbstractController
      *
      * Edit an admin category by ajax.
      */
-    public function editCategoryAction(
+    public function editCategory(
         Request $request,
         AdminCategoryRepositoryInterface $adminCategoryRepository
     ): JsonResponse {
@@ -264,7 +264,7 @@ class AjaxController extends AbstractController
      *
      * Make a category the initially selected one (by ajax).
      */
-    public function defaultCategoryAction(
+    public function defaultCategory(
         Request $request,
         AdminCategoryRepositoryInterface $adminCategoryRepository,
         VariableApiInterface $variableApi
@@ -301,7 +301,7 @@ class AjaxController extends AbstractController
      *
      * Sort the admin categories.
      */
-    public function sortCategoriesAction(
+    public function sortCategories(
         Request $request,
         AdminCategoryRepositoryInterface $adminCategoryRepository
     ): JsonResponse {
@@ -328,7 +328,7 @@ class AjaxController extends AbstractController
      *
      * Sort the modules.
      */
-    public function sortModulesAction(
+    public function sortModules(
         Request $request,
         AdminModuleRepositoryInterface $adminModuleRepository
     ): JsonResponse {

--- a/src/system/AdminModule/Controller/ConfigController.php
+++ b/src/system/AdminModule/Controller/ConfigController.php
@@ -43,7 +43,7 @@ class ConfigController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function configAction(
+    public function config(
         Request $request,
         AdminCategoryRepositoryInterface $adminCategoryRepository,
         AdminModuleRepositoryInterface $adminModuleRepository,

--- a/src/system/BlocksModule/Controller/AdminController.php
+++ b/src/system/BlocksModule/Controller/AdminController.php
@@ -44,7 +44,7 @@ class AdminController extends AbstractController
      *
      * View all blocks.
      */
-    public function viewAction(
+    public function view(
         Request $request,
         BlockRepositoryInterface $blockRepository,
         BlockPositionRepositoryInterface $positionRepository,

--- a/src/system/BlocksModule/Controller/BlockController.php
+++ b/src/system/BlocksModule/Controller/BlockController.php
@@ -45,7 +45,7 @@ class BlockController extends AbstractController
      *
      * Choose type for creating a new block.
      */
-    public function newAction(Request $request, BlockApiInterface $blockApi): Response
+    public function create(Request $request, BlockApiInterface $blockApi): Response
     {
         $form = $this->createForm(NewBlockType::class);
         $form->handleRequest($request);
@@ -68,7 +68,7 @@ class BlockController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have permissions for creating new blocks or editing a given one
      */
-    public function editAction(
+    public function edit(
         Request $request,
         BlockApiInterface $blockApi,
         ExtensionRepositoryInterface $extensionRepository,
@@ -154,7 +154,7 @@ class BlockController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have delete permissions for the block
      */
-    public function deleteAction(Request $request, BlockEntity $blockEntity): Response
+    public function delete(Request $request, BlockEntity $blockEntity): Response
     {
         if (!$this->hasPermission('ZikulaBlocksModule::', $blockEntity->getBkey() . ':' . $blockEntity->getTitle() . ':' . $blockEntity->getBid(), ACCESS_DELETE)) {
             throw new AccessDeniedException();
@@ -189,7 +189,7 @@ class BlockController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have admin permissions for the module
      */
-    public function toggleblockAction(Request $request): JsonResponse
+    public function toggleblock(Request $request): JsonResponse
     {
         $bid = $request->request->getInt('bid', -1);
         if (-1 === $bid) {
@@ -210,7 +210,7 @@ class BlockController extends AbstractController
      *
      * Display a block.
      */
-    public function viewAction(BlockEntity $blockEntity = null): response
+    public function view(BlockEntity $blockEntity = null): response
     {
         return $this->render('@ZikulaBlocksModule/Admin/blockview.html.twig', [
             'block' => $blockEntity,

--- a/src/system/BlocksModule/Controller/ConfigController.php
+++ b/src/system/BlocksModule/Controller/ConfigController.php
@@ -37,7 +37,7 @@ class ConfigController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function configAction(Request $request)
+    public function config(Request $request)
     {
         $form = $this->createForm(ConfigType::class, $this->getVars());
         $form->handleRequest($request);

--- a/src/system/BlocksModule/Controller/PlacementController.php
+++ b/src/system/BlocksModule/Controller/PlacementController.php
@@ -41,7 +41,7 @@ class PlacementController extends AbstractController
      *
      * Create a new placement or edit an existing placement.
      */
-    public function editAction(
+    public function edit(
         BlockPositionEntity $positionEntity,
         BlockRepositoryInterface $blockRepository,
         BlockPositionRepositoryInterface $positionRepository
@@ -71,7 +71,7 @@ class PlacementController extends AbstractController
      *
      * Change the block order.
      */
-    public function changeBlockOrderAction(Request $request): JsonResponse
+    public function changeBlockOrder(Request $request): JsonResponse
     {
         $blockOrder = $request->request->get('blockorder', null); // [7, 1]
         if (null === $blockOrder) {

--- a/src/system/BlocksModule/Controller/PositionController.php
+++ b/src/system/BlocksModule/Controller/PositionController.php
@@ -42,7 +42,7 @@ class PositionController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user doesn't have edit permissions for the position
      */
-    public function editAction(Request $request, BlockPositionEntity $positionEntity = null)
+    public function edit(Request $request, BlockPositionEntity $positionEntity = null)
     {
         $permParam = (null !== $positionEntity) ? $positionEntity->getName() : 'position';
         if (!$this->hasPermission('ZikulaBlocksModule::' . $permParam, '::', ACCESS_EDIT)) {
@@ -84,7 +84,7 @@ class PositionController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user doesn't have delete permissions for the position
      */
-    public function deleteAction(Request $request, BlockPositionEntity $positionEntity)
+    public function delete(Request $request, BlockPositionEntity $positionEntity)
     {
         if (!$this->hasPermission('ZikulaBlocksModule::position', $positionEntity->getName() . '::' . $positionEntity->getPid(), ACCESS_DELETE)) {
             throw new AccessDeniedException();

--- a/src/system/BootstrapTheme/Controller/AjaxController.php
+++ b/src/system/BootstrapTheme/Controller/AjaxController.php
@@ -31,7 +31,7 @@ class AjaxController extends AbstractController
     /**
      * @Route("/changeUserStyle", methods = {"POST"}, options={"expose"=true})
      */
-    public function changeUserStyleAction(
+    public function changeUserStyle(
         Request $request,
         ZikulaHttpKernelInterface $kernel
     ): JsonResponse {

--- a/src/system/CategoriesModule/Controller/CategoryController.php
+++ b/src/system/CategoriesModule/Controller/CategoryController.php
@@ -41,7 +41,7 @@ class CategoryController extends AbstractController
      * @see https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/tree.md
      * @throws AccessDeniedException Thrown if the user doesn't have edit permission for the module
      */
-    public function listAction(
+    public function listCategories(
         Request $request,
         CategoryEntity $category,
         CategoryRepository $categoryRepository

--- a/src/system/CategoriesModule/Controller/NodeController.php
+++ b/src/system/CategoriesModule/Controller/NodeController.php
@@ -41,7 +41,7 @@ class NodeController extends AbstractController
     /**
      * @Route("/contextMenu/{action}/{id}", options={"expose"=true}, defaults={"id" = null})
      */
-    public function contextMenuAction(
+    public function contextMenu(
         Request $request,
         CategoryRepository $categoryRepository,
         CategoryProcessingHelper $processingHelper,
@@ -194,7 +194,7 @@ class NodeController extends AbstractController
      * Ajax function for use on drag and drop of nodes.
      * @Route("/move", options={"expose"=true})
      */
-    public function moveAction(
+    public function move(
         Request $request,
         CategoryRepository $categoryRepository,
         CategoryProcessingHelper $processingHelper

--- a/src/system/CategoriesModule/Controller/RegistryController.php
+++ b/src/system/CategoriesModule/Controller/RegistryController.php
@@ -45,7 +45,7 @@ class RegistryController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function editAction(
+    public function edit(
         Request $request,
         EntityManagerInterface $entityManager,
         CapabilityApiInterface $capabilityApi,
@@ -99,7 +99,7 @@ class RegistryController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function deleteAction(
+    public function delete(
         Request $request,
         EntityManagerInterface $entityManager,
         CategoryRegistryEntity $registry

--- a/src/system/DefaultTheme/Controller/AjaxController.php
+++ b/src/system/DefaultTheme/Controller/AjaxController.php
@@ -29,7 +29,7 @@ class AjaxController extends AbstractController
     /**
      * @Route("/changeUserStyle", methods = {"POST"}, options={"expose"=true})
      */
-    public function changeUserStyleAction(
+    public function changeUserStyle(
         Request $request,
         ZikulaHttpKernelInterface $kernel
     ): JsonResponse {

--- a/src/system/ExtensionsModule/Controller/ConfigController.php
+++ b/src/system/ExtensionsModule/Controller/ConfigController.php
@@ -39,7 +39,7 @@ class ConfigController extends AbstractController
      *
      * @return array|Response
      */
-    public function configAction(
+    public function config(
         Request $request,
         BundleSyncHelper $bundleSyncHelper,
         CacheClearer $cacheClearer

--- a/src/system/ExtensionsModule/Controller/ExtensionController.php
+++ b/src/system/ExtensionsModule/Controller/ExtensionController.php
@@ -58,7 +58,7 @@ class ExtensionController extends AbstractController
      * @Theme("admin")
      * @Template("@ZikulaExtensionsModule/Extension/list.html.twig")
      */
-    public function listAction(
+    public function listExtensions(
         Request $request,
         EventDispatcherInterface $eventDispatcher,
         ExtensionRepositoryInterface $extensionRepository,
@@ -107,7 +107,7 @@ class ExtensionController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the CSRF token is invalid
      */
-    public function activateAction(
+    public function activate(
         int $id,
         string $token,
         ExtensionRepositoryInterface $extensionRepository,
@@ -139,7 +139,7 @@ class ExtensionController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the CSRF token is invalid
      */
-    public function deactivateAction(
+    public function deactivate(
         int $id,
         string $token,
         ExtensionRepositoryInterface $extensionRepository,
@@ -180,7 +180,7 @@ class ExtensionController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user doesn't have admin permissions for modifying the extension
      */
-    public function modifyAction(
+    public function modify(
         Request $request,
         ZikulaHttpKernelInterface $kernel,
         ExtensionEntity $extension,
@@ -241,7 +241,7 @@ class ExtensionController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have admin permission to the requested module
      */
-    public function compatibilityAction(ExtensionEntity $extension): array
+    public function compatibility(ExtensionEntity $extension): array
     {
         if (!$this->hasPermission('ZikulaExtensionsModule::', $extension->getName() . '::' . $extension->getId(), ACCESS_ADMIN)) {
             throw new AccessDeniedException();
@@ -260,7 +260,7 @@ class ExtensionController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the CSRF token is invalid
      */
-    public function upgradeAction(
+    public function upgrade(
         ExtensionEntity $extension,
         $token,
         ExtensionHelper $extensionHelper
@@ -290,7 +290,7 @@ class ExtensionController extends AbstractController
      * @return array|Response|RedirectResponse
      * @throws AccessDeniedException Thrown if the CSRF token is invalid
      */
-    public function uninstallAction(
+    public function uninstall(
         Request $request,
         ExtensionEntity $extension,
         string $token,
@@ -358,7 +358,7 @@ class ExtensionController extends AbstractController
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function postUninstallAction(CacheClearer $cacheClearer)
+    public function postUninstall(CacheClearer $cacheClearer)
     {
         $cacheClearer->clear('symfony');
 
@@ -369,7 +369,7 @@ class ExtensionController extends AbstractController
      * @Route("/theme-preview/{themeName}")
      * @PermissionCheck("admin")
      */
-    public function previewAction(Engine $engine, string $themeName): Response
+    public function preview(Engine $engine, string $themeName): Response
     {
         $engine->setActiveTheme($themeName);
         $this->addFlash('warning', 'Please note that blocks may appear out of place or even missing in a theme preview because position names are not consistent from theme to theme.');

--- a/src/system/GroupsModule/Controller/ApplicationController.php
+++ b/src/system/GroupsModule/Controller/ApplicationController.php
@@ -50,7 +50,7 @@ class ApplicationController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function adminAction(
+    public function admin(
         Request $request,
         string $action,
         GroupApplicationEntity $groupApplicationEntity,
@@ -105,7 +105,7 @@ class ApplicationController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user isn't logged in
      */
-    public function createAction(
+    public function create(
         Request $request,
         GroupEntity $group,
         EventDispatcherInterface $eventDispatcher,

--- a/src/system/GroupsModule/Controller/ConfigController.php
+++ b/src/system/GroupsModule/Controller/ConfigController.php
@@ -38,7 +38,7 @@ class ConfigController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function configAction(Request $request, GroupRepositoryInterface $groupRepository)
+    public function config(Request $request, GroupRepositoryInterface $groupRepository)
     {
         // build a groups array suitable for the form choices
         $groupsList = [];

--- a/src/system/GroupsModule/Controller/GroupController.php
+++ b/src/system/GroupsModule/Controller/GroupController.php
@@ -43,7 +43,7 @@ class GroupController extends AbstractController
      *
      * View a list of all groups (user view).
      */
-    public function listAction(GroupRepositoryInterface $groupRepository, int $page = 1): array
+    public function listGroups(GroupRepositoryInterface $groupRepository, int $page = 1): array
     {
         $pageSize = $this->getVar('itemsperpage', 25);
         $groupsCommon = new CommonHelper($this->getTranslator());
@@ -72,7 +72,7 @@ class GroupController extends AbstractController
      *
      * View a list of all groups (admin view).
      */
-    public function adminListAction(
+    public function adminList(
         GroupRepositoryInterface $groupRepository,
         GroupApplicationRepository $applicationRepository,
         int $page = 1
@@ -100,7 +100,7 @@ class GroupController extends AbstractController
      *
      * Display a form to add a new group.
      */
-    public function createAction(
+    public function create(
         Request $request,
         EventDispatcherInterface $eventDispatcher
     ) {
@@ -133,7 +133,7 @@ class GroupController extends AbstractController
      *
      * Modify a group.
      */
-    public function editAction(
+    public function edit(
         Request $request,
         GroupEntity $groupEntity,
         EventDispatcherInterface $eventDispatcher
@@ -168,7 +168,7 @@ class GroupController extends AbstractController
      *
      * Deletes a group.
      */
-    public function removeAction(
+    public function remove(
         Request $request,
         GroupEntity $groupEntity,
         EventDispatcherInterface $eventDispatcher

--- a/src/system/GroupsModule/Controller/MembershipController.php
+++ b/src/system/GroupsModule/Controller/MembershipController.php
@@ -53,7 +53,7 @@ class MembershipController extends AbstractController
      *
      * Display all members of a group to a user.
      */
-    public function listAction(
+    public function listMemberships(
         GroupEntity $group,
         VariableApiInterface $variableApi,
         UserSessionRepositoryInterface $userSessionRepository,
@@ -81,7 +81,7 @@ class MembershipController extends AbstractController
      *
      * Display all members of a group to an admin.
      */
-    public function adminListAction(
+    public function adminList(
         GroupEntity $group,
         string $letter = '*',
         int $page = 1
@@ -99,7 +99,7 @@ class MembershipController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the CSRF token is invalid
      */
-    public function addAction(
+    public function add(
         UserEntity $userEntity,
         GroupEntity $group,
         string $token,
@@ -130,7 +130,7 @@ class MembershipController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user isn't logged in
      */
-    public function joinAction(
+    public function join(
         GroupEntity $group,
         EventDispatcherInterface $eventDispatcher,
         CurrentUserApiInterface $currentUserApi,
@@ -174,7 +174,7 @@ class MembershipController extends AbstractController
      *
      * @throws InvalidArgumentException
      */
-    public function removeAction(
+    public function remove(
         Request $request,
         EventDispatcherInterface $eventDispatcher,
         GroupRepositoryInterface $groupRepository,
@@ -232,7 +232,7 @@ class MembershipController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user isn't logged in
      */
-    public function leaveAction(
+    public function leave(
         GroupEntity $group,
         EventDispatcherInterface $eventDispatcher,
         CurrentUserApiInterface $currentUserApi,
@@ -258,8 +258,10 @@ class MembershipController extends AbstractController
      * Called from UsersModule/Resources/public/js/Zikula.Users.Admin.View.js
      * to populate a username search
      */
-    public function getUsersByFragmentAsTableAction(Request $request, UserRepositoryInterface $userRepository): Response
-    {
+    public function getUsersByFragmentAsTable(
+        Request $request,
+        UserRepositoryInterface $userRepository
+    ): Response {
         if (!$this->hasPermission('ZikulaGroupsodule', '::', ACCESS_EDIT)) {
             return new PlainResponse('');
         }

--- a/src/system/MailerModule/Controller/ConfigController.php
+++ b/src/system/MailerModule/Controller/ConfigController.php
@@ -43,7 +43,7 @@ class ConfigController extends AbstractController
      * @Theme("admin")
      * @Template("@ZikulaMailerModule/Config/config.html.twig")
      */
-    public function configAction(
+    public function config(
         Request $request,
         MailTransportHelper $mailTransportHelper
     ): array {
@@ -94,7 +94,7 @@ class ConfigController extends AbstractController
      *
      * This function displays a form to send a test mail.
      */
-    public function testAction(
+    public function test(
         Request $request,
         VariableApiInterface $variableApi,
         MailerInterface $mailer,

--- a/src/system/MenuModule/Controller/ConfigController.php
+++ b/src/system/MenuModule/Controller/ConfigController.php
@@ -26,7 +26,7 @@ use Zikula\PermissionsModule\Annotation\PermissionCheck;
  */
 class ConfigController extends AbstractController
 {
-    public function configAction(Request $request): void
+    public function config(Request $request): void
     {
         // do nothing
     }

--- a/src/system/MenuModule/Controller/MenuController.php
+++ b/src/system/MenuModule/Controller/MenuController.php
@@ -46,7 +46,7 @@ class MenuController extends AbstractController
      * @Template("@ZikulaMenuModule/Menu/list.html.twig")
      * @Theme("admin")
      */
-    public function listAction(
+    public function listMenus(
         MenuItemRepository $menuItemRepository
     ): array {
         return [
@@ -63,7 +63,7 @@ class MenuController extends AbstractController
      * @see https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/tree.md
      * @throws AccessDeniedException Thrown if the menu item is not a root item
      */
-    public function viewAction(
+    public function view(
         MenuItemRepository $menuItemRepository,
         MenuItemEntity $menuItemEntity
     ): array {
@@ -95,7 +95,7 @@ class MenuController extends AbstractController
      * @Route("/edit/{id}", defaults={"id" = null})
      * @Theme("admin")
      */
-    public function editAction(
+    public function edit(
         Request $request,
         MenuItemRepository $menuItemRepository,
         MenuItemEntity $menuItemEntity = null
@@ -150,7 +150,7 @@ class MenuController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function deleteAction(Request $request, MenuItemEntity $menuItemEntity)
+    public function delete(Request $request, MenuItemEntity $menuItemEntity)
     {
         $form = $this->createForm(DeleteMenuItemType::class, [
             'entity' => $menuItemEntity

--- a/src/system/MenuModule/Controller/NodeController.php
+++ b/src/system/MenuModule/Controller/NodeController.php
@@ -37,7 +37,7 @@ class NodeController extends AbstractController
     /**
      * @Route("/contextMenu/{action}/{id}", options={"expose"=true, "i18n"=false})
      */
-    public function contextMenuAction(
+    public function contextMenu(
         Request $request,
         MenuItemRepository $menuItemRepository,
         string $action = 'edit',
@@ -117,7 +117,7 @@ class NodeController extends AbstractController
      * Ajax function for use on drag and drop of nodes.
      * @Route("/move", options={"expose"=true})
      */
-    public function moveAction(
+    public function move(
         Request $request,
         MenuItemRepository $menuItemRepository
     ): JsonResponse {

--- a/src/system/PermissionsModule/Controller/ConfigController.php
+++ b/src/system/PermissionsModule/Controller/ConfigController.php
@@ -39,7 +39,7 @@ class ConfigController extends AbstractController
      *
      * @return array|Response
      */
-    public function configAction(
+    public function config(
         Request $request,
         VariableApiInterface $variableApi,
         PermissionRepositoryInterface $permissionRepository

--- a/src/system/PermissionsModule/Controller/PermissionController.php
+++ b/src/system/PermissionsModule/Controller/PermissionController.php
@@ -44,7 +44,7 @@ class PermissionController extends AbstractController
      *
      * View permissions.
      */
-    public function listAction(
+    public function listPermissions(
         GroupRepositoryInterface $groupsRepository,
         PermissionRepositoryInterface $permissionRepository,
         PermissionApiInterface $permissionApi,
@@ -81,7 +81,7 @@ class PermissionController extends AbstractController
     /**
      * @Route("/edit/{pid}", options={"expose"=true})
      */
-    public function editAction(
+    public function edit(
         Request $request,
         GroupRepositoryInterface $groupsRepository,
         PermissionRepositoryInterface $permissionRepository,
@@ -140,7 +140,7 @@ class PermissionController extends AbstractController
      *
      * Change the order of a permission rule.
      */
-    public function changeOrderAction(
+    public function changeOrder(
         Request $request,
         PermissionRepositoryInterface $permissionRepository
     ): JsonResponse {
@@ -163,7 +163,7 @@ class PermissionController extends AbstractController
      * @throws FatalError Thrown if the requested permission rule is the default admin rule
      *                           or if the permission rule couldn't be deleted
      */
-    public function deleteAction(
+    public function delete(
         PermissionEntity $permissionEntity,
         PermissionRepositoryInterface $permissionRepository
     ): JsonResponse {
@@ -192,7 +192,7 @@ class PermissionController extends AbstractController
      *
      * Test a permission rule for a given username.
      */
-    public function testAction(
+    public function test(
         Request $request,
         PermissionApiInterface $permissionApi,
         UserRepositoryInterface $userRepository

--- a/src/system/RoutesModule/Controller/AjaxController.php
+++ b/src/system/RoutesModule/Controller/AjaxController.php
@@ -31,11 +31,11 @@ class AjaxController extends AbstractAjaxController
     /**
      * @Route("/updateSortPositions", methods = {"POST"}, options={"expose"=true})
      */
-    public function updateSortPositionsAction(
+    public function updateSortPositions(
         Request $request,
         EntityFactory $entityFactory
     ): JsonResponse {
-        return parent::updateSortPositionsAction(
+        return parent::updateSortPositions(
             $request,
             $entityFactory
         );

--- a/src/system/RoutesModule/Controller/Base/AbstractAjaxController.php
+++ b/src/system/RoutesModule/Controller/Base/AbstractAjaxController.php
@@ -32,7 +32,7 @@ abstract class AbstractAjaxController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have required permissions
      */
-    public function updateSortPositionsAction(
+    public function updateSortPositions(
         Request $request,
         EntityFactory $entityFactory
     ): JsonResponse {

--- a/src/system/RoutesModule/Controller/Base/AbstractConfigController.php
+++ b/src/system/RoutesModule/Controller/Base/AbstractConfigController.php
@@ -34,7 +34,7 @@ abstract class AbstractConfigController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have required permissions
      */
-    public function configAction(
+    public function config(
         Request $request,
         PermissionHelper $permissionHelper,
         AppSettings $appSettings,

--- a/src/system/RoutesModule/Controller/ConfigController.php
+++ b/src/system/RoutesModule/Controller/ConfigController.php
@@ -37,14 +37,14 @@ class ConfigController extends AbstractConfigController
      * )
      * @Theme("admin")
      */
-    public function configAction(
+    public function config(
         Request $request,
         PermissionHelper $permissionHelper,
         AppSettings $appSettings,
         LoggerInterface $logger,
         CurrentUserApiInterface $currentUserApi
     ): Response {
-        return parent::configAction($request, $permissionHelper, $appSettings, $logger, $currentUserApi);
+        return parent::config($request, $permissionHelper, $appSettings, $logger, $currentUserApi);
     }
 
     // feel free to add your own config controller methods here

--- a/src/system/RoutesModule/Controller/RouteController.php
+++ b/src/system/RoutesModule/Controller/RouteController.php
@@ -43,7 +43,7 @@ class RouteController extends AbstractRouteController
      * )
      * @Theme("admin")
      */
-    public function adminIndexAction(
+    public function adminIndex(
         Request $request,
         PermissionHelper $permissionHelper
     ): Response {
@@ -60,7 +60,7 @@ class RouteController extends AbstractRouteController
      *        methods = {"GET"}
      * )
      */
-    public function indexAction(
+    public function index(
         Request $request,
         PermissionHelper $permissionHelper
     ): Response {
@@ -80,7 +80,7 @@ class RouteController extends AbstractRouteController
      * )
      * @Theme("admin")
      */
-    public function adminViewAction(
+    public function adminView(
         Request $request,
         RouterInterface $router,
         PermissionHelper $permissionHelper,
@@ -113,7 +113,7 @@ class RouteController extends AbstractRouteController
      *        methods = {"GET"}
      * )
      */
-    public function viewAction(
+    public function view(
         Request $request,
         RouterInterface $router,
         PermissionHelper $permissionHelper,
@@ -147,7 +147,7 @@ class RouteController extends AbstractRouteController
      * )
      * @Theme("admin")
      */
-    public function adminDisplayAction(
+    public function adminDisplay(
         Request $request,
         PermissionHelper $permissionHelper,
         ControllerHelper $controllerHelper,
@@ -176,7 +176,7 @@ class RouteController extends AbstractRouteController
      *        methods = {"GET"}
      * )
      */
-    public function displayAction(
+    public function display(
         Request $request,
         PermissionHelper $permissionHelper,
         ControllerHelper $controllerHelper,
@@ -206,7 +206,7 @@ class RouteController extends AbstractRouteController
      * )
      * @Theme("admin")
      */
-    public function adminEditAction(
+    public function adminEdit(
         Request $request,
         PermissionHelper $permissionHelper,
         ControllerHelper $controllerHelper,
@@ -231,7 +231,7 @@ class RouteController extends AbstractRouteController
      *        methods = {"GET", "POST"}
      * )
      */
-    public function editAction(
+    public function edit(
         Request $request,
         PermissionHelper $permissionHelper,
         ControllerHelper $controllerHelper,
@@ -256,7 +256,7 @@ class RouteController extends AbstractRouteController
      * )
      * @Theme("admin")
      */
-    public function adminHandleSelectedEntriesAction(
+    public function adminHandleSelectedEntries(
         Request $request,
         LoggerInterface $logger,
         EntityFactory $entityFactory,
@@ -280,7 +280,7 @@ class RouteController extends AbstractRouteController
      *        methods = {"POST"}
      * )
      */
-    public function handleSelectedEntriesAction(
+    public function handleSelectedEntries(
         Request $request,
         LoggerInterface $logger,
         EntityFactory $entityFactory,

--- a/src/system/RoutesModule/Controller/UpdateController.php
+++ b/src/system/RoutesModule/Controller/UpdateController.php
@@ -38,7 +38,7 @@ class UpdateController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have required permissions
      */
-    public function reloadAction(
+    public function reload(
         PermissionHelper $permissionHelper,
         CacheClearer $cacheClearer,
         RouteDumperHelper $routeDumperHelper
@@ -67,7 +67,7 @@ class UpdateController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have required permissions
      */
-    public function renewAction(
+    public function renew(
         PermissionHelper $permissionHelper,
         MultilingualRoutingHelper $multilingualRoutingHelper
     ): Response {
@@ -94,7 +94,7 @@ class UpdateController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user doesn't have required permissions
      */
-    public function dumpJsRoutesAction(
+    public function dumpJsRoutes(
         PermissionHelper $permissionHelper,
         RouteDumperHelper $routeDumperHelper,
         string $lang = null

--- a/src/system/RoutesModule/Controller/UpdateController.php
+++ b/src/system/RoutesModule/Controller/UpdateController.php
@@ -52,7 +52,7 @@ class UpdateController extends AbstractController
         $this->addFlash('status', 'Done! Routes reloaded.');
 
         // reload **all** JS routes
-        $this->dumpJsRoutes($routeDumperHelper);
+        $this->dumpJsRoutesInternal($routeDumperHelper);
 
         return $this->redirectToRoute('zikularoutesmodule_route_adminview');
     }
@@ -103,7 +103,7 @@ class UpdateController extends AbstractController
             throw new AccessDeniedException();
         }
 
-        $this->dumpJsRoutes($routeDumperHelper, $lang);
+        $this->dumpJsRoutesInternal($routeDumperHelper, $lang);
 
         return $this->redirectToRoute('zikularoutesmodule_route_adminview');
     }
@@ -111,7 +111,7 @@ class UpdateController extends AbstractController
     /**
      * Dumps exposed JS routes to '/public/js/fos_js_routes.js'.
      */
-    private function dumpJsRoutes(RouteDumperHelper $routeDumperHelper, string $lang = null): void
+    private function dumpJsRoutesInternal(RouteDumperHelper $routeDumperHelper, string $lang = null): void
     {
         $result = $routeDumperHelper->dumpJsRoutes($lang);
 

--- a/src/system/SearchModule/Controller/ConfigController.php
+++ b/src/system/SearchModule/Controller/ConfigController.php
@@ -36,7 +36,7 @@ class ConfigController extends AbstractController
      * @Theme("admin")
      * @Template("@ZikulaSearchModule/Config/config.html.twig")
      */
-    public function configAction(
+    public function config(
         Request $request,
         ZikulaHttpKernelInterface $kernel,
         SearchableModuleCollector $collector

--- a/src/system/SearchModule/Controller/SearchController.php
+++ b/src/system/SearchModule/Controller/SearchController.php
@@ -43,7 +43,7 @@ class SearchController extends AbstractController
      *
      * @return array|Response
      */
-    public function executeAction(
+    public function execute(
         Request $request,
         RouterInterface $router,
         FormFactoryInterface $formFactory,
@@ -134,7 +134,7 @@ class SearchController extends AbstractController
      *
      * Display a list of recent searches.
      */
-    public function recentAction(
+    public function recent(
         Request $request,
         SearchStatRepositoryInterface $searchStatRepository,
         int $page = 1
@@ -153,7 +153,7 @@ class SearchController extends AbstractController
      *
      * Generate xml for opensearch syndication.
      */
-    public function opensearchAction(
+    public function opensearch(
         SiteDefinitionInterface $site,
         VariableApiInterface $variableApi
     ): PlainResponse {

--- a/src/system/SecurityCenterModule/Controller/ConfigController.php
+++ b/src/system/SecurityCenterModule/Controller/ConfigController.php
@@ -52,7 +52,7 @@ class ConfigController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function configAction(
+    public function config(
         ZikulaSecurityCenterModule $securityCenterModule,
         Request $request,
         RouterInterface $router,
@@ -257,7 +257,7 @@ class ConfigController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function purifierconfigAction(
+    public function purifierconfig(
         Request $request,
         PurifierHelper $purifierHelper,
         CacheClearer $cacheClearer,
@@ -461,7 +461,7 @@ class ConfigController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function allowedhtmlAction(
+    public function allowedhtml(
         Request $request,
         RouterInterface $router,
         VariableApiInterface $variableApi,

--- a/src/system/SecurityCenterModule/Controller/IdsLogController.php
+++ b/src/system/SecurityCenterModule/Controller/IdsLogController.php
@@ -48,7 +48,7 @@ class IdsLogController extends AbstractController
      *
      * Function to view ids log events.
      */
-    public function viewAction(
+    public function viewLog(
         Request $request,
         IntrusionRepository $repository,
         RouterInterface $router,
@@ -127,7 +127,7 @@ class IdsLogController extends AbstractController
      *
      * @return array|Response
      */
-    public function exportAction(Request $request, IntrusionRepository $repository)
+    public function export(Request $request, IntrusionRepository $repository)
     {
         $form = $this->createForm(IdsLogExportType::class, []);
         $form->handleRequest($request);
@@ -234,7 +234,7 @@ class IdsLogController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function purgeAction(Request $request, IntrusionRepository $repository)
+    public function purge(Request $request, IntrusionRepository $repository)
     {
         $form = $this->createForm(DeletionType::class);
         $form->handleRequest($request);
@@ -265,7 +265,7 @@ class IdsLogController extends AbstractController
      * @throws AccessDeniedException Thrown if the CSRF token is invalid
      * @throws InvalidArgumentException Thrown if the object id is not numeric or if
      */
-    public function deleteentryAction(Request $request, IntrusionRepository $repository): RedirectResponse
+    public function deleteEntry(Request $request, IntrusionRepository $repository): RedirectResponse
     {
         if (!$this->isCsrfTokenValid('delete-idsentry', $request->query->get('token'))) {
             throw new AccessDeniedException();

--- a/src/system/SettingsModule/Controller/SettingsController.php
+++ b/src/system/SettingsModule/Controller/SettingsController.php
@@ -44,7 +44,7 @@ class SettingsController extends AbstractController
      *
      * Settings for entire site.
      */
-    public function mainAction(
+    public function mainSettings(
         Request $request,
         LocaleApiInterface $localeApi,
         VariableApiInterface $variableApi,
@@ -97,7 +97,7 @@ class SettingsController extends AbstractController
      *
      * Locale settings for entire site.
      */
-    public function localeAction(
+    public function localeSettings(
         Request $request,
         LocaleApiInterface $localeApi,
         VariableApiInterface $variableApi
@@ -157,7 +157,7 @@ class SettingsController extends AbstractController
      *
      * Displays the content of {@see phpinfo()}.
      */
-    public function phpinfoAction(): array
+    public function phpinfo(): array
     {
         ob_start();
         phpinfo();
@@ -179,7 +179,7 @@ class SettingsController extends AbstractController
      *
      * Toggles the "Edit in place" translation functionality.
      */
-    public function toggleEditInPlaceAction(
+    public function toggleEditInPlace(
         Request $request,
         EditInPlaceActivator $activator
     ): RedirectResponse {

--- a/src/system/ThemeModule/Controller/CombinedAssetController.php
+++ b/src/system/ThemeModule/Controller/CombinedAssetController.php
@@ -26,7 +26,7 @@ class CombinedAssetController extends AbstractController
     /**
      * @Route("/combined_asset/{type}/{key}", options={"i18n"=false})
      */
-    public function assetAction(
+    public function asset(
         ZikulaHttpKernelInterface $kernel,
         string $type,
         string $key

--- a/src/system/ThemeModule/Controller/ConfigController.php
+++ b/src/system/ThemeModule/Controller/ConfigController.php
@@ -41,7 +41,7 @@ class ConfigController extends AbstractController
      * @Theme("admin")
      * @Template("@ZikulaThemeModule/Config/config.html.twig")
      */
-    public function configAction(
+    public function config(
         Request $request,
         VariableApiInterface $variableApi,
         CacheClearer $cacheClearer,

--- a/src/system/ThemeModule/Controller/VarController.php
+++ b/src/system/ThemeModule/Controller/VarController.php
@@ -44,7 +44,7 @@ class VarController extends AbstractController
      *
      * @throws InvalidArgumentException if theme type is not twig-based
      */
-    public function varAction(
+    public function variables(
         Request $request,
         VariableApiInterface $variableApi,
         ZikulaHttpKernelInterface $kernel,

--- a/src/system/UsersModule/Controller/AccessController.php
+++ b/src/system/UsersModule/Controller/AccessController.php
@@ -48,7 +48,7 @@ class AccessController extends AbstractController
      *
      * @throws InvalidAuthenticationMethodLoginFormException
      */
-    public function loginAction(
+    public function login(
         Request $request,
         CurrentUserApiInterface $currentUserApi,
         UserRepositoryInterface $userRepository,
@@ -190,7 +190,7 @@ class AccessController extends AbstractController
     /**
      * @Route("/logout/{returnUrl}", options={"zkNoBundlePrefix"=1})
      */
-    public function logoutAction(
+    public function logout(
         Request $request,
         CurrentUserApiInterface $currentUserApi,
         UserRepositoryInterface $userRepository,

--- a/src/system/UsersModule/Controller/AccountController.php
+++ b/src/system/UsersModule/Controller/AccountController.php
@@ -52,7 +52,7 @@ class AccountController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user isn't logged in
      */
-    public function menuAction(
+    public function menu(
         ExtensionMenuCollector $extensionMenuCollector,
         VariableApiInterface $variableApi
     ): array {
@@ -82,7 +82,7 @@ class AccountController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user isn't logged in
      */
-    public function changeLanguageAction(
+    public function changeLanguage(
         Request $request,
         CurrentUserApiInterface $currentUserApi,
         UserRepositoryInterface $userRepository
@@ -129,7 +129,7 @@ class AccountController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user isn't logged in
      */
-    public function deleteMyAccountAction(
+    public function deleteMyAccount(
         Request $request,
         CurrentUserApiInterface $currentUserApi,
         UserRepositoryInterface $userRepository,

--- a/src/system/UsersModule/Controller/ConfigController.php
+++ b/src/system/UsersModule/Controller/ConfigController.php
@@ -40,7 +40,7 @@ class ConfigController extends AbstractController
      * @Theme("admin")
      * @Template("@ZikulaUsersModule/Config/config.html.twig")
      */
-    public function configAction(
+    public function config(
         Request $request,
         EventDispatcherInterface $eventDispatcher
     ): array {
@@ -69,7 +69,7 @@ class ConfigController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function authenticationMethodsAction(
+    public function authenticationMethods(
         Request $request,
         VariableApiInterface $variableApi,
         AuthenticationMethodCollector $authenticationMethodCollector,

--- a/src/system/UsersModule/Controller/FileIOController.php
+++ b/src/system/UsersModule/Controller/FileIOController.php
@@ -39,7 +39,7 @@ class FileIOController extends AbstractController
      *
      * @return array|StreamedResponse
      */
-    public function exportAction(Request $request, UserRepositoryInterface $userRepository)
+    public function export(Request $request, UserRepositoryInterface $userRepository)
     {
         $form = $this->createForm(ExportUsersType::class, []);
         $form->handleRequest($request);

--- a/src/system/UsersModule/Controller/LiveSearchController.php
+++ b/src/system/UsersModule/Controller/LiveSearchController.php
@@ -32,7 +32,7 @@ class LiveSearchController extends AbstractController
      * @Route("/getUsers", methods = {"GET"}, options={"expose"=true})
      * @PermissionCheck({"$_zkModule::LiveSearch", "::", "edit"})
      */
-    public function getUsersAction(
+    public function getUsers(
         Request $request,
         UserRepositoryInterface $userRepository,
         ProfileModuleCollector $profileModuleCollector

--- a/src/system/UsersModule/Controller/RegistrationController.php
+++ b/src/system/UsersModule/Controller/RegistrationController.php
@@ -63,7 +63,7 @@ class RegistrationController extends AbstractController
      * @throws InvalidAuthenticationMethodRegistrationFormException
      * @throws Exception
      */
-    public function registerAction(
+    public function register(
         Request $request,
         CurrentUserApiInterface $currentUserApi,
         UserRepositoryInterface $userRepository,

--- a/src/system/UsersModule/Controller/UserAdministrationController.php
+++ b/src/system/UsersModule/Controller/UserAdministrationController.php
@@ -74,7 +74,7 @@ class UserAdministrationController extends AbstractController
      * @Theme("admin")
      * @Template("@ZikulaUsersModule/UserAdministration/list.html.twig")
      */
-    public function listAction(
+    public function listUsers(
         Request $request,
         UserRepositoryInterface $userRepository,
         RouterInterface $router,
@@ -122,7 +122,7 @@ class UserAdministrationController extends AbstractController
      *
      * @Route("/getusersbyfragmentastable", methods = {"POST"}, options={"expose"=true, "i18n"=false})
      */
-    public function getUsersByFragmentAsTableAction(
+    public function getUsersByFragmentAsTable(
         Request $request,
         UserRepositoryInterface $userRepository,
         AdministrationActionsHelper $actionsHelper
@@ -154,7 +154,7 @@ class UserAdministrationController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user hasn't edit permissions for the user record
      */
-    public function modifyAction(
+    public function modify(
         Request $request,
         UserEntity $user,
         CurrentUserApiInterface $currentUserApi,
@@ -217,7 +217,7 @@ class UserAdministrationController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function approveAction(
+    public function approve(
         Request $request,
         UserEntity $user,
         RegistrationHelper $registrationHelper,
@@ -281,7 +281,7 @@ class UserAdministrationController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function deleteAction(
+    public function delete(
         Request $request,
         CurrentUserApiInterface $currentUserApi,
         UserRepositoryInterface $userRepository,
@@ -373,7 +373,7 @@ class UserAdministrationController extends AbstractController
      *
      * @return array|Response
      */
-    public function searchAction(
+    public function search(
         Request $request,
         UserRepositoryInterface $userRepository,
         VariableApiInterface $variableApi,
@@ -402,7 +402,7 @@ class UserAdministrationController extends AbstractController
      * @Route("/mail")
      * @PermissionCheck({"$_zkModule::MailUsers", "::", "comment"})
      */
-    public function mailUsersAction(
+    public function mailUsers(
         Request $request,
         UserRepositoryInterface $userRepository,
         VariableApiInterface $variableApi,

--- a/src/system/ZAuthModule/Controller/AccountController.php
+++ b/src/system/ZAuthModule/Controller/AccountController.php
@@ -1,4 +1,4 @@
-<?php
+// <?php
 
 declare(strict_types=1);
 
@@ -54,7 +54,7 @@ class AccountController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function lostUserNameAction(
+    public function lostUserName(
         Request $request,
         RouterInterface $router,
         CurrentUserApiInterface $currentUserApi,
@@ -105,7 +105,7 @@ class AccountController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function lostPasswordAction(
+    public function lostPassword(
         Request $request,
         RouterInterface $router,
         CurrentUserApiInterface $currentUserApi,
@@ -196,7 +196,7 @@ class AccountController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function lostPasswordResetAction(
+    public function lostPasswordReset(
         Request $request,
         CurrentUserApiInterface $currentUserApi,
         UserRepositoryInterface $userRepository,
@@ -289,7 +289,7 @@ class AccountController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user is not logged in
      */
-    public function changeEmailAction(
+    public function changeEmail(
         Request $request,
         RouterInterface $router,
         CurrentUserApiInterface $currentUserApi,
@@ -335,7 +335,7 @@ class AccountController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user is not logged in
      */
-    public function confirmChangedEmailAction(
+    public function confirmChangedEmail(
         CurrentUserApiInterface $currentUserApi,
         UserRepositoryInterface $userRepository,
         AuthenticationMappingRepositoryInterface $authenticationMappingRepository,
@@ -393,7 +393,7 @@ class AccountController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function changePasswordAction(
+    public function changePassword(
         Request $request,
         CurrentUserApiInterface $currentUserApi,
         UserRepositoryInterface $userRepository,

--- a/src/system/ZAuthModule/Controller/AccountController.php
+++ b/src/system/ZAuthModule/Controller/AccountController.php
@@ -1,4 +1,4 @@
-// <?php
+<?php
 
 declare(strict_types=1);
 

--- a/src/system/ZAuthModule/Controller/ConfigController.php
+++ b/src/system/ZAuthModule/Controller/ConfigController.php
@@ -33,7 +33,7 @@ class ConfigController extends AbstractController
      * @Theme("admin")
      * @Template("@ZikulaZAuthModule/Config/config.html.twig")
      */
-    public function configAction(Request $request): array
+    public function config(Request $request): array
     {
         $form = $this->createForm(ConfigType::class, $this->getVars());
         $form->handleRequest($request);

--- a/src/system/ZAuthModule/Controller/FileIOController.php
+++ b/src/system/ZAuthModule/Controller/FileIOController.php
@@ -38,7 +38,7 @@ class FileIOController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function importAction(
+    public function import(
         Request $request,
         VariableApiInterface $variableApi,
         GroupRepositoryInterface $groupRepository,

--- a/src/system/ZAuthModule/Controller/RegistrationController.php
+++ b/src/system/ZAuthModule/Controller/RegistrationController.php
@@ -57,7 +57,7 @@ class RegistrationController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function verifyAction(
+    public function verify(
         Request $request,
         ValidatorInterface $validator,
         VariableApiInterface $variableApi,

--- a/src/system/ZAuthModule/Controller/UserAdministrationController.php
+++ b/src/system/ZAuthModule/Controller/UserAdministrationController.php
@@ -73,7 +73,7 @@ class UserAdministrationController extends AbstractController
      * @Theme("admin")
      * @Template("@ZikulaZAuthModule/UserAdministration/list.html.twig")
      */
-    public function listAction(
+    public function listMappings(
         Request $request,
         AuthenticationMappingRepositoryInterface $authenticationMappingRepository,
         RouterInterface $router,
@@ -119,7 +119,7 @@ class UserAdministrationController extends AbstractController
      *
      * @Route("/getusersbyfragmentastable", methods = {"POST"}, options={"expose"=true, "i18n"=false})
      */
-    public function getUsersByFragmentAsTableAction(
+    public function getUsersByFragmentAsTable(
         Request $request,
         AuthenticationMappingRepositoryInterface $authenticationMappingRepository,
         AdministrationActionsHelper $actionsHelper
@@ -147,7 +147,7 @@ class UserAdministrationController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function createAction(
+    public function create(
         Request $request,
         VariableApiInterface $variableApi,
         AuthenticationMethodCollector $authenticationMethodCollector,
@@ -240,7 +240,7 @@ class UserAdministrationController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user hasn't edit permissions for the mapping record
      */
-    public function modifyAction(
+    public function modify(
         Request $request,
         AuthenticationMappingEntity $mapping,
         VariableApiInterface $variableApi,
@@ -313,7 +313,7 @@ class UserAdministrationController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function verifyAction(
+    public function verify(
         Request $request,
         AuthenticationMappingEntity $mapping,
         AuthenticationMappingRepositoryInterface $authenticationMappingRepository,
@@ -353,7 +353,7 @@ class UserAdministrationController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user hasn't moderate permissions for the mapping record
      */
-    public function sendConfirmationAction(
+    public function sendConfirmation(
         AuthenticationMappingEntity $mapping,
         LostPasswordVerificationHelper $lostPasswordVerificationHelper,
         MailHelper $mailHelper
@@ -381,7 +381,7 @@ class UserAdministrationController extends AbstractController
      *
      * @throws AccessDeniedException Thrown if the user hasn't moderate permissions for the mapping record
      */
-    public function sendUserNameAction(
+    public function sendUserName(
         AuthenticationMappingEntity $mapping,
         MailHelper $mailHelper
     ): RedirectResponse {
@@ -410,7 +410,7 @@ class UserAdministrationController extends AbstractController
      * @return array|RedirectResponse
      * @throws AccessDeniedException Thrown if the user hasn't moderate permissions for the user record
      */
-    public function togglePasswordChangeAction(Request $request, UserEntity $user)
+    public function togglePasswordChange(Request $request, UserEntity $user)
     {
         if (!$this->hasPermission('ZikulaZAuthModule', $user->getUname() . '::' . $user->getUid(), ACCESS_MODERATE)) {
             throw new AccessDeniedException();
@@ -458,7 +458,7 @@ class UserAdministrationController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function batchForcePasswordChangeAction(
+    public function batchForcePasswordChange(
         BatchPasswordChangeHelper $batchPasswordChangeHelper,
         Request $request
     ) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | yes
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

This PR removes the `Action` suffix from controller method names, because this is neither required nor recommended anymore.

From https://symfony.com/doc/4.2/best_practices/controllers.html#controller-action-naming :

> Don’t add the `Action` suffix to the methods of the controller actions.

> The first Symfony versions required that controller method names ended in `Action` (e.g. `newAction()`, `showAction()`). This suffix became optional when annotations were introduced for controllers. In modern Symfony applications this suffix is neither required nor recommended, so you can safely remove it.

