### PR TITLE
add opcache clear to our normal clearcache operation.

### DIFF
--- a/src/Zikula/CoreBundle/CacheClearer.php
+++ b/src/Zikula/CoreBundle/CacheClearer.php
@@ -140,6 +140,14 @@ class CacheClearer
                 $this->logger->notice(sprintf('Cache cleared: %s', $cacheType));
             }
         }
+        if (function_exists('opcache_reset') && filter_var(ini_get('opcache.enable'), FILTER_VALIDATE_BOOLEAN)) {
+            // This is a brute force clear of _all_ the cached files
+            // because simply clearing the files in $this->cachesToClear isn't enough.
+            // Perhaps if we could discern exactly which files to invalidate, we could
+            // take a more precise approach with @opcache_invalidate($file, true).
+            @opcache_reset();
+            $this->logger->notice('OPCache cleared!');
+        }
         // the cache must be warmed after deleting files
         $this->warmer->warmUp($this->cacheDir);
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes?
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #4495
| Refs tickets      | -
| License           | MIT
| Changelog updated | [yes/no]

## Description

clear the opcache if in use when clearing symfony cache

## Todos

- [ ] Changelog
