### PR TITLE
first usages of String component

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,6 +3,7 @@ risky: true
 
 enabled:
   - alpha_ordered_imports
+  - cast_spaces
   - combine_consecutive_issets
   - combine_consecutive_unsets
   - concat_with_spaces

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
             "Zikula\\Bundle\\": ["src/Zikula/"],
             "Zikula\\": ["src/system/"]
         },
-        "files": ["src/Kernel.php"]
+        "files": ["src/Kernel.php", "vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php"]
     },
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -189,16 +189,16 @@
         },
         {
             "name": "components/font-awesome",
-            "version": "5.15.0",
+            "version": "5.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/components/font-awesome.git",
-                "reference": "f1b1fe6b3c7b76038290fd8e48716df90abeeeb6"
+                "reference": "6943708effe6d823d40255bcdbe9ee021312c880"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/components/font-awesome/zipball/f1b1fe6b3c7b76038290fd8e48716df90abeeeb6",
-                "reference": "f1b1fe6b3c7b76038290fd8e48716df90abeeeb6",
+                "url": "https://api.github.com/repos/components/font-awesome/zipball/6943708effe6d823d40255bcdbe9ee021312c880",
+                "reference": "6943708effe6d823d40255bcdbe9ee021312c880",
                 "shasum": ""
             },
             "type": "component",
@@ -220,7 +220,7 @@
                 "OFL-1.1"
             ],
             "description": "Font Awesome, the iconic SVG, font, and CSS framework.",
-            "time": "2020-09-30T05:54:44+00:00"
+            "time": "2020-10-06T06:45:49+00:00"
         },
         {
             "name": "components/jquery",
@@ -2239,11 +2239,11 @@
         },
         {
             "name": "frdh/mmenu.js",
-            "version": "8.5.17",
+            "version": "8.5.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FrDH/mmenu-js",
-                "reference": "bb91b99e205b4abcbe2f5ce6cda4a8e8df3c55e7"
+                "reference": "66ed172849b1f8b514f1bea30933ccc5aefa4ba2"
             },
             "type": "library",
             "license": [
@@ -2273,7 +2273,7 @@
                 "panels",
                 "submenu"
             ],
-            "time": "2020-09-21T18:31:48+00:00"
+            "time": "2020-10-03T20:38:45+00:00"
         },
         {
             "name": "friendsofsymfony/jsrouting-bundle",
@@ -3407,16 +3407,16 @@
         },
         {
             "name": "league/oauth2-facebook",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-facebook.git",
-                "reference": "c482a851c93a6cb718270773635d6a0c8384b560"
+                "reference": "093cf588b9d508ee426c71d6bc68f138fe914ddc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-facebook/zipball/c482a851c93a6cb718270773635d6a0c8384b560",
-                "reference": "c482a851c93a6cb718270773635d6a0c8384b560",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-facebook/zipball/093cf588b9d508ee426c71d6bc68f138fe914ddc",
+                "reference": "093cf588b9d508ee426c71d6bc68f138fe914ddc",
                 "shasum": ""
             },
             "require": {
@@ -3455,7 +3455,7 @@
                 "oauth",
                 "oauth2"
             ],
-            "time": "2020-07-25T13:30:06+00:00"
+            "time": "2020-10-01T15:22:47+00:00"
         },
         {
             "name": "league/oauth2-github",
@@ -5184,16 +5184,16 @@
         },
         {
             "name": "symfony/contracts",
-            "version": "v2.2.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/contracts.git",
-                "reference": "be3a8c232b594e48774fe3aca1ed732f34f47d5f"
+                "reference": "571c933d161fd0985e37b9504878a125aa098591"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/contracts/zipball/be3a8c232b594e48774fe3aca1ed732f34f47d5f",
-                "reference": "be3a8c232b594e48774fe3aca1ed732f34f47d5f",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/571c933d161fd0985e37b9504878a125aa098591",
+                "reference": "571c933d161fd0985e37b9504878a125aa098591",
                 "shasum": ""
             },
             "require": {
@@ -5223,7 +5223,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -5275,7 +5275,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2020-09-29T22:43:35+00:00"
         },
         {
             "name": "symfony/maker-bundle",
@@ -5362,16 +5362,16 @@
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "v3.5.0",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bundle.git",
-                "reference": "dd80460fcfe1fa2050a7103ad818e9d0686ce6fd"
+                "reference": "e495f5c7e4e672ffef4357d4a4d85f010802f940"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/dd80460fcfe1fa2050a7103ad818e9d0686ce6fd",
-                "reference": "dd80460fcfe1fa2050a7103ad818e9d0686ce6fd",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/e495f5c7e4e672ffef4357d4a4d85f010802f940",
+                "reference": "e495f5c7e4e672ffef4357d4a4d85f010802f940",
                 "shasum": ""
             },
             "require": {
@@ -5384,7 +5384,7 @@
             },
             "require-dev": {
                 "symfony/console": "~3.4 || ~4.0 || ^5.0",
-                "symfony/phpunit-bridge": "^3.4.19 || ^4.0 || ^5.0",
+                "symfony/phpunit-bridge": "^4.4 || ^5.0",
                 "symfony/yaml": "~3.4 || ~4.0 || ^5.0"
             },
             "type": "symfony-bundle",
@@ -5421,7 +5421,21 @@
                 "log",
                 "logging"
             ],
-            "time": "2019-11-13T13:11:14+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-06T15:12:11+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -6465,16 +6479,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v5.1.6",
+            "version": "v5.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "c54f3c05013854b99cbca06282f187a76a8792e4"
+                "reference": "ccdb43327902ecdfa497c47fa6e165b5ae32fb43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/c54f3c05013854b99cbca06282f187a76a8792e4",
-                "reference": "c54f3c05013854b99cbca06282f187a76a8792e4",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/ccdb43327902ecdfa497c47fa6e165b5ae32fb43",
+                "reference": "ccdb43327902ecdfa497c47fa6e165b5ae32fb43",
                 "shasum": ""
             },
             "require": {
@@ -6658,7 +6672,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-27T04:33:37+00:00"
+            "time": "2020-10-04T07:57:45+00:00"
         },
         {
             "name": "thomaspark/bootswatch",
@@ -7944,16 +7958,16 @@
     "packages-dev": [
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v5.1.6",
+            "version": "v5.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "6753ea4cb2dab705e819b1ddd8833a5c98338650"
+                "reference": "150aeb91dd9dafe13ec8416abd62e435330ca12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/6753ea4cb2dab705e819b1ddd8833a5c98338650",
-                "reference": "6753ea4cb2dab705e819b1ddd8833a5c98338650",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/150aeb91dd9dafe13ec8416abd62e435330ca12d",
+                "reference": "150aeb91dd9dafe13ec8416abd62e435330ca12d",
                 "shasum": ""
             },
             "require": {
@@ -8022,7 +8036,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-18T14:27:32+00:00"
+            "time": "2020-10-02T12:57:56+00:00"
         }
     ],
     "aliases": [],

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,6 +17,9 @@ use Zikula\Bundle\CoreInstallerBundle\Util\RequirementChecker;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
+// remove again after #4352 has been done
+require dirname(__DIR__) . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
+
 if (!class_exists(Dotenv::class)) {
     throw new LogicException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 }

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,9 +17,6 @@ use Zikula\Bundle\CoreInstallerBundle\Util\RequirementChecker;
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-// remove again after #4352 has been done
-require_once dirname(__DIR__) . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
-
 if (!class_exists(Dotenv::class)) {
     throw new LogicException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 }

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -15,10 +15,10 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\Dotenv\Dotenv;
 use Zikula\Bundle\CoreInstallerBundle\Util\RequirementChecker;
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 // remove again after #4352 has been done
-require dirname(__DIR__) . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
+require_once dirname(__DIR__) . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
 
 if (!class_exists(Dotenv::class)) {
     throw new LogicException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -32,6 +32,9 @@ class Kernel extends ZikulaKernel
         parent::__construct($environment, $debug);
 
         $this->databaseUrl = $databaseUrl;
+
+        // remove again after #4352 has been done
+        require_once $this->getProjectDir() . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
     }
 
     public function registerBundles(): iterable

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -32,9 +32,6 @@ class Kernel extends ZikulaKernel
         parent::__construct($environment, $debug);
 
         $this->databaseUrl = $databaseUrl;
-
-        // remove again after #4352 has been done
-        require_once $this->getProjectDir() . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
     }
 
     public function registerBundles(): iterable

--- a/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
+++ b/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
@@ -133,7 +133,7 @@ EOT
         $this->verified = in_array((int) $input->getOption('verified'), [0, 1, 2]) ? (int) $input->getOption('verified') : 1;
         $regDate = $input->getOption('regdate') ?? $this->nowUTC;
         $this->range = is_string($regDate) && '>' === $regDate[0];
-        $this->regDate = $this->range ? (string) s($regDate)->slice(1) : $regDate;
+        $this->regDate = $this->range ? s($regDate)->slice(1)->__toString() : $regDate;
 
         $io->title('User generation utility');
         $io->text('Generating users...');

--- a/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
+++ b/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
@@ -133,7 +133,7 @@ EOT
         $this->verified = in_array((int) $input->getOption('verified'), [0, 1, 2]) ? (int) $input->getOption('verified') : 1;
         $regDate = $input->getOption('regdate') ?? $this->nowUTC;
         $this->range = is_string($regDate) && '>' === $regDate[0];
-        $this->regDate = $this->range ? s($regDate)->slice(1)->__toString() : $regDate;
+        $this->regDate = $this->range ? s($regDate)->slice(1)->toString() : $regDate;
 
         $io->title('User generation utility');
         $io->text('Generating users...');

--- a/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
+++ b/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
@@ -133,7 +133,7 @@ EOT
         $this->verified = in_array((int) $input->getOption('verified'), [0, 1, 2]) ? (int) $input->getOption('verified') : 1;
         $regDate = $input->getOption('regdate') ?? $this->nowUTC;
         $this->range = is_string($regDate) && '>' === $regDate[0];
-        $this->regDate = $this->range ? (string)s($regDate)->slice(1) : $regDate;
+        $this->regDate = $this->range ? (string) s($regDate)->slice(1) : $regDate;
 
         $io->title('User generation utility');
         $io->text('Generating users...');

--- a/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
+++ b/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
@@ -15,6 +15,7 @@ namespace Zikula\Bundle\CoreBundle\Command;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
+use function Symfony\Component\String\s;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -132,7 +133,7 @@ EOT
         $this->verified = in_array((int) $input->getOption('verified'), [0, 1, 2]) ? (int) $input->getOption('verified') : 1;
         $regDate = $input->getOption('regdate') ?? $this->nowUTC;
         $this->range = is_string($regDate) && '>' === $regDate[0];
-        $this->regDate = $this->range ? mb_substr($regDate, 1) : $regDate;
+        $this->regDate = $this->range ? (string)s($regDate)->slice(1) : $regDate;
 
         $io->title('User generation utility');
         $io->text('Generating users...');

--- a/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
+++ b/src/Zikula/CoreBundle/Command/GenerateTestUsersCommand.php
@@ -15,13 +15,13 @@ namespace Zikula\Bundle\CoreBundle\Command;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
-use function Symfony\Component\String\s;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function Symfony\Component\String\s;
 use Zikula\UsersModule\Constant as UsersConstant;
 use Zikula\ZAuthModule\ZAuthConstant;
 

--- a/src/Zikula/CoreBundle/Composer/MetaData.php
+++ b/src/Zikula/CoreBundle/Composer/MetaData.php
@@ -89,7 +89,7 @@ class MetaData implements ArrayAccess
         $this->dependencies = $this->formatDependencies($json);
         $this->shortName = $json['extra']['zikula']['short-name'];
         $this->class = $json['extra']['zikula']['class'];
-        $this->namespace = s($this->class)->beforeLast('\\', true)->__toString();
+        $this->namespace = s($this->class)->beforeLast('\\', true)->toString();
         $this->autoload = $json['autoload'];
         $this->displayName = $json['extra']['zikula']['displayname'] ?? '';
         $this->url = $json['extra']['zikula']['url'] ?? '';

--- a/src/Zikula/CoreBundle/Composer/MetaData.php
+++ b/src/Zikula/CoreBundle/Composer/MetaData.php
@@ -15,6 +15,7 @@ namespace Zikula\Bundle\CoreBundle\Composer;
 
 use ArrayAccess;
 use Exception;
+use function Symfony\Component\String\s;
 use Symfony\Component\HttpKernel\Exception\PreconditionRequiredHttpException;
 use Translation\Extractor\Annotation\Ignore;
 use Zikula\Bundle\CoreBundle\Translation\TranslatorTrait;
@@ -88,7 +89,7 @@ class MetaData implements ArrayAccess
         $this->dependencies = $this->formatDependencies($json);
         $this->shortName = $json['extra']['zikula']['short-name'];
         $this->class = $json['extra']['zikula']['class'];
-        $this->namespace = mb_substr($this->class, 0, mb_strrpos($this->class, '\\') + 1);
+        $this->namespace = (string) s($this->class)->beforeLast('\\', true);
         $this->autoload = $json['autoload'];
         $this->displayName = $json['extra']['zikula']['displayname'] ?? '';
         $this->url = $json['extra']['zikula']['url'] ?? '';

--- a/src/Zikula/CoreBundle/Composer/MetaData.php
+++ b/src/Zikula/CoreBundle/Composer/MetaData.php
@@ -15,8 +15,8 @@ namespace Zikula\Bundle\CoreBundle\Composer;
 
 use ArrayAccess;
 use Exception;
-use function Symfony\Component\String\s;
 use Symfony\Component\HttpKernel\Exception\PreconditionRequiredHttpException;
+use function Symfony\Component\String\s;
 use Translation\Extractor\Annotation\Ignore;
 use Zikula\Bundle\CoreBundle\Translation\TranslatorTrait;
 

--- a/src/Zikula/CoreBundle/Composer/MetaData.php
+++ b/src/Zikula/CoreBundle/Composer/MetaData.php
@@ -89,7 +89,7 @@ class MetaData implements ArrayAccess
         $this->dependencies = $this->formatDependencies($json);
         $this->shortName = $json['extra']['zikula']['short-name'];
         $this->class = $json['extra']['zikula']['class'];
-        $this->namespace = (string) s($this->class)->beforeLast('\\', true);
+        $this->namespace = s($this->class)->beforeLast('\\', true)->__toString();
         $this->autoload = $json['autoload'];
         $this->displayName = $json['extra']['zikula']['displayname'] ?? '';
         $this->url = $json['extra']['zikula']['url'] ?? '';

--- a/src/Zikula/CoreBundle/Composer/Scanner.php
+++ b/src/Zikula/CoreBundle/Composer/Scanner.php
@@ -74,7 +74,7 @@ class Scanner
     {
         $base = str_replace('\\', '/', dirname($jsonFilePath));
         $srcPath = dirname(__DIR__, 4) . '/src/';
-        $base = s($base)->slice(mb_strlen($srcPath));
+        $base = s($base)->slice(mb_strlen($srcPath))->toString();
 
         $json = json_decode(file_get_contents($jsonFilePath), true);
         if (JSON_ERROR_NONE === json_last_error()) {

--- a/src/Zikula/CoreBundle/Composer/Scanner.php
+++ b/src/Zikula/CoreBundle/Composer/Scanner.php
@@ -80,12 +80,12 @@ class Scanner
         if (JSON_ERROR_NONE === json_last_error()) {
             // calculate PSR-4 autoloading path for this namespace
             $class = $json['extra']['zikula']['class'];
-            $ns = (string) s($class)->beforeLast('\\', true);
+            $ns = s($class)->beforeLast('\\', true)->__toString();
             if (false === isset($json['autoload']['psr-4'][$ns])) {
                 return false;
             }
             $json['autoload']['psr-4'][$ns] = $base;
-            $json['extra']['zikula']['short-name'] = (string) s($class)->afterLast('\\');
+            $json['extra']['zikula']['short-name'] = s($class)->afterLast('\\')->__toString();
             $json['extensionType'] = $this->computeExtensionType($json);
 
             return $json;

--- a/src/Zikula/CoreBundle/Composer/Scanner.php
+++ b/src/Zikula/CoreBundle/Composer/Scanner.php
@@ -80,12 +80,12 @@ class Scanner
         if (JSON_ERROR_NONE === json_last_error()) {
             // calculate PSR-4 autoloading path for this namespace
             $class = $json['extra']['zikula']['class'];
-            $ns = s($class)->beforeLast('\\', true)->__toString();
+            $ns = s($class)->beforeLast('\\', true)->toString();
             if (false === isset($json['autoload']['psr-4'][$ns])) {
                 return false;
             }
             $json['autoload']['psr-4'][$ns] = $base;
-            $json['extra']['zikula']['short-name'] = s($class)->afterLast('\\')->__toString();
+            $json['extra']['zikula']['short-name'] = s($class)->afterLast('\\')->toString();
             $json['extensionType'] = $this->computeExtensionType($json);
 
             return $json;

--- a/src/Zikula/CoreBundle/Composer/Scanner.php
+++ b/src/Zikula/CoreBundle/Composer/Scanner.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Zikula\Bundle\CoreBundle\Composer;
 
 use const JSON_ERROR_NONE;
+use function Symfony\Component\String\s;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -73,18 +74,18 @@ class Scanner
     {
         $base = str_replace('\\', '/', dirname($jsonFilePath));
         $srcPath = dirname(__DIR__, 4) . '/src/';
-        $base = mb_substr($base, mb_strlen($srcPath));
+        $base = s($base)->slice(mb_strlen($srcPath));
 
         $json = json_decode(file_get_contents($jsonFilePath), true);
         if (JSON_ERROR_NONE === json_last_error()) {
             // calculate PSR-4 autoloading path for this namespace
             $class = $json['extra']['zikula']['class'];
-            $ns = mb_substr($class, 0, mb_strrpos($class, '\\') + 1);
+            $ns = (string) s($class)->beforeLast('\\', true);
             if (false === isset($json['autoload']['psr-4'][$ns])) {
                 return false;
             }
             $json['autoload']['psr-4'][$ns] = $base;
-            $json['extra']['zikula']['short-name'] = mb_substr($class, mb_strrpos($class, '\\') + 1, mb_strlen($class));
+            $json['extra']['zikula']['short-name'] = (string) s($class)->afterLast('\\');
             $json['extensionType'] = $this->computeExtensionType($json);
 
             return $json;

--- a/src/Zikula/CoreBundle/Composer/Scanner.php
+++ b/src/Zikula/CoreBundle/Composer/Scanner.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Zikula\Bundle\CoreBundle\Composer;
 
 use const JSON_ERROR_NONE;
-use function Symfony\Component\String\s;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
+use function Symfony\Component\String\s;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class Scanner

--- a/src/Zikula/CoreBundle/Doctrine/WhereFromFilterTrait.php
+++ b/src/Zikula/CoreBundle/Doctrine/WhereFromFilterTrait.php
@@ -54,7 +54,7 @@ trait WhereFromFilterTrait
                 } elseif (is_int($value['operand']) || is_array($value['operand']) || $value['operand'] instanceof DateTime) {
                     $dbValue = $value['operand'];
                 } else {
-                    $dbValue = (string)$value['operand'];
+                    $dbValue = (string) $value['operand'];
                 }
                 $methodMap = [
                     '=' => 'eq',

--- a/src/Zikula/CoreBundle/Event/GenericEvent.php
+++ b/src/Zikula/CoreBundle/Event/GenericEvent.php
@@ -110,7 +110,7 @@ class GenericEvent extends SymfonyGenericEvent implements \ArrayAccess, \Iterato
 
     public function hasException(): bool
     {
-        return (bool)$this->exception;
+        return (bool) $this->exception;
     }
 
     public function getSubject()

--- a/src/Zikula/CoreBundle/EventListener/SiteOffListener.php
+++ b/src/Zikula/CoreBundle/EventListener/SiteOffListener.php
@@ -109,7 +109,7 @@ class SiteOffListener implements EventSubscriberInterface
             return;
         }
 
-        $siteOff = (bool)$this->variableApi->getSystemVar('siteoff');
+        $siteOff = (bool) $this->variableApi->getSystemVar('siteoff');
         $hasAdminPerms = $this->permissionApi->hasPermission('ZikulaSettingsModule::', 'SiteOff::', ACCESS_ADMIN);
 
         // Check for site closed

--- a/src/Zikula/CoreBundle/Helper/BundlesSchemaHelper.php
+++ b/src/Zikula/CoreBundle/Helper/BundlesSchemaHelper.php
@@ -98,7 +98,7 @@ class BundlesSchemaHelper
         $res = $qb->execute();
         foreach ($res->fetchAll() as $row) {
             if (!array_key_exists($row['bundlename'], $fileExtensions)) {
-                $this->removeById((int)$row['id']);
+                $this->removeById((int) $row['id']);
             }
         }
     }

--- a/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
+++ b/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
@@ -62,11 +62,11 @@ class LocalDotEnvHelper
         foreach ($vars as $key => $value) {
             $value = s((string) $value);
             if ($value->startsWith('!')) {
-                $value = $value->trimStart('!')->__toString();
+                $value = $value->trimStart('!')->toString();
             } else {
                 $quote = $value->startsWith('\'') || $value->startsWith('"') ? '\'' : '';
                 $value = !empty($quote) ? $value->trim('\'')->trim('"') : $value;
-                $value = $quote . urlencode($value->__toString()) . $quote;
+                $value = $quote . urlencode($value->toString()) . $quote;
             }
             $lines[] = $key . '=' . $value;
         }

--- a/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
+++ b/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
@@ -60,15 +60,15 @@ class LocalDotEnvHelper
     {
         $lines = [];
         foreach ($vars as $key => $value) {
-            $value = s((string) $value);
+            $value = s($value);
             if ($value->startsWith('!')) {
                 $value = $value->trimStart('!');
             } else {
                 $quote = $value->startsWith('\'') || $value->startsWith('"') ? '\'' : '';
                 $value = !empty($quote) ? $value->trim('\'')->trim('"') : $value;
-                $value = $quote . urlencode((string) $value) . $quote;
+                $value = $quote . urlencode($value) . $quote;
             }
-            $lines[] = $key . '=' . (string) $value;
+            $lines[] = $key . '=' . $value->__toString();
         }
 
         return trim(implode("\n", $lines));

--- a/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
+++ b/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreBundle\Helper;
 
+use function Symfony\Component\String\s;
 use Symfony\Component\Filesystem\Filesystem;
 
 class LocalDotEnvHelper
@@ -59,14 +60,15 @@ class LocalDotEnvHelper
     {
         $lines = [];
         foreach ($vars as $key => $value) {
-            if ('!' === mb_substr((string) $value, 0, 1)) {
-                $value = mb_substr((string) $value, 1);
+            $value = s((string) $value);
+            if ($value->startsWith('!')) {
+                $value = $value->trimStart('!');
             } else {
-                $quote = in_array(mb_substr((string) $value, 0, 1), ['\'', '"']) ? '\'' : '';
-                $value = !empty($quote) ? trim((string) $value, '\'"') : (string) $value;
-                $value =  $quote . urlencode($value) . $quote;
+                $quote = $value->startsWith('\'') || $value->startsWith('"') ? '\'' : '';
+                $value = !empty($quote) ? $value->trim('\'')->trim('"') : $value;
+                $value = $quote . urlencode($value) . $quote;
             }
-            $lines[] = $key . '=' . $value;
+            $lines[] = $key . '=' . (string)$value;
         }
 
         return trim(implode("\n", $lines));

--- a/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
+++ b/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
@@ -66,7 +66,7 @@ class LocalDotEnvHelper
             } else {
                 $quote = $value->startsWith('\'') || $value->startsWith('"') ? '\'' : '';
                 $value = !empty($quote) ? $value->trim('\'')->trim('"') : $value;
-                $value = $quote . urlencode($value) . $quote;
+                $value = $quote . urlencode($value->__toString()) . $quote;
             }
             $lines[] = $key . '=' . $value->__toString();
         }

--- a/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
+++ b/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
@@ -62,13 +62,13 @@ class LocalDotEnvHelper
         foreach ($vars as $key => $value) {
             $value = s($value);
             if ($value->startsWith('!')) {
-                $value = $value->trimStart('!');
+                $value = $value->trimStart('!')->__toString();
             } else {
                 $quote = $value->startsWith('\'') || $value->startsWith('"') ? '\'' : '';
                 $value = !empty($quote) ? $value->trim('\'')->trim('"') : $value;
                 $value = $quote . urlencode($value->__toString()) . $quote;
             }
-            $lines[] = $key . '=' . $value->__toString();
+            $lines[] = $key . '=' . $value;
         }
 
         return trim(implode("\n", $lines));

--- a/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
+++ b/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
@@ -66,9 +66,9 @@ class LocalDotEnvHelper
             } else {
                 $quote = $value->startsWith('\'') || $value->startsWith('"') ? '\'' : '';
                 $value = !empty($quote) ? $value->trim('\'')->trim('"') : $value;
-                $value = $quote . urlencode((string)$value) . $quote;
+                $value = $quote . urlencode((string) $value) . $quote;
             }
-            $lines[] = $key . '=' . (string)$value;
+            $lines[] = $key . '=' . (string) $value;
         }
 
         return trim(implode("\n", $lines));

--- a/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
+++ b/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
@@ -66,7 +66,7 @@ class LocalDotEnvHelper
             } else {
                 $quote = $value->startsWith('\'') || $value->startsWith('"') ? '\'' : '';
                 $value = !empty($quote) ? $value->trim('\'')->trim('"') : $value;
-                $value = $quote . urlencode($value) . $quote;
+                $value = $quote . urlencode((string)$value) . $quote;
             }
             $lines[] = $key . '=' . (string)$value;
         }

--- a/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
+++ b/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreBundle\Helper;
 
-use function Symfony\Component\String\s;
 use Symfony\Component\Filesystem\Filesystem;
+use function Symfony\Component\String\s;
 
 class LocalDotEnvHelper
 {

--- a/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
+++ b/src/Zikula/CoreBundle/Helper/LocalDotEnvHelper.php
@@ -60,7 +60,7 @@ class LocalDotEnvHelper
     {
         $lines = [];
         foreach ($vars as $key => $value) {
-            $value = s($value);
+            $value = s((string) $value);
             if ($value->startsWith('!')) {
                 $value = $value->trimStart('!')->__toString();
             } else {

--- a/src/Zikula/CoreBundle/Helper/PersistedBundleHelper.php
+++ b/src/Zikula/CoreBundle/Helper/PersistedBundleHelper.php
@@ -111,8 +111,8 @@ class PersistedBundleHelper
             ');
             foreach ($rows as $row) {
                 $this->extensionStateMap[$row['name']] = [
-                    'state' => (int)$row['state'],
-                    'id'    => (int)$row['id'],
+                    'state' => (int) $row['state'],
+                    'id' => (int) $row['id'],
                 ];
             }
 

--- a/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
+++ b/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreBundle\Maker;
 
+use function Symfony\Component\String\s;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\FileManager;
@@ -164,7 +165,7 @@ class ExtensionMaker extends AbstractMaker
                     'namespace' => $namespace . $type,
                     'type' => $type,
                     'name' => $bundleClassNameDetails->getShortName(),
-                    'vendor' => mb_substr($namespace, 0, mb_strpos($namespace, '\\'))
+                    'vendor' => (string)s($namespace)->before('\\'),
                 ]
             );
         }
@@ -191,9 +192,9 @@ class ExtensionMaker extends AbstractMaker
                 [
                     'namespace' => $namespace . $type,
                     'type' => $type,
-                    'vendor' => mb_substr($namespace, 0, mb_strpos($namespace, '\\')),
-                    'name' => mb_substr($namespace, mb_strpos($namespace, '\\') + 1),
-                    'bundleClass' => $bundleClass
+                    'vendor' => (string)s($namespace)->before('\\'),
+                    'name' => (string)s($namespace)->after('\\'),
+                    'bundleClass' => $bundleClass,
                 ]
             );
         }

--- a/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
+++ b/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
@@ -165,7 +165,7 @@ class ExtensionMaker extends AbstractMaker
                     'namespace' => $namespace . $type,
                     'type' => $type,
                     'name' => $bundleClassNameDetails->getShortName(),
-                    'vendor' => s($namespace)->before('\\')->__toString(),
+                    'vendor' => s($namespace)->before('\\')->toString(),
                 ]
             );
         }
@@ -192,8 +192,8 @@ class ExtensionMaker extends AbstractMaker
                 [
                     'namespace' => $namespace . $type,
                     'type' => $type,
-                    'vendor' => s($namespace)->before('\\')->__toString(),
-                    'name' => s($namespace)->after('\\')->__toString(),
+                    'vendor' => s($namespace)->before('\\')->toString(),
+                    'name' => s($namespace)->after('\\')->toString(),
                     'bundleClass' => $bundleClass,
                 ]
             );

--- a/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
+++ b/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreBundle\Maker;
 
-use function Symfony\Component\String\s;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\FileManager;
@@ -26,6 +25,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Filesystem\Filesystem;
+use function Symfony\Component\String\s;
 use Zikula\Bundle\CoreBundle\Configurator;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 

--- a/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
+++ b/src/Zikula/CoreBundle/Maker/ExtensionMaker.php
@@ -165,7 +165,7 @@ class ExtensionMaker extends AbstractMaker
                     'namespace' => $namespace . $type,
                     'type' => $type,
                     'name' => $bundleClassNameDetails->getShortName(),
-                    'vendor' => (string)s($namespace)->before('\\'),
+                    'vendor' => s($namespace)->before('\\')->__toString(),
                 ]
             );
         }
@@ -192,8 +192,8 @@ class ExtensionMaker extends AbstractMaker
                 [
                     'namespace' => $namespace . $type,
                     'type' => $type,
-                    'vendor' => (string)s($namespace)->before('\\'),
-                    'name' => (string)s($namespace)->after('\\'),
+                    'vendor' => s($namespace)->before('\\')->__toString(),
+                    'name' => s($namespace)->after('\\')->__toString(),
                     'bundleClass' => $bundleClass,
                 ]
             );

--- a/src/Zikula/CoreBundle/Maker/Validators.php
+++ b/src/Zikula/CoreBundle/Maker/Validators.php
@@ -21,7 +21,7 @@ class Validators
 {
     public static function validateBundleNamespace(InputInterface $input, $allowSuffix = false): string
     {
-        $namespace = (string)s($input->getArgument('namespace'))->replace('/', '\\')->trim();
+        $namespace = s($input->getArgument('namespace'))->replace('/', '\\')->trim()->__toString();
         if (!preg_match('/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\\?)+$/', $namespace)) {
             throw new InvalidArgumentException('The namespace contains invalid characters.');
         }
@@ -29,7 +29,7 @@ class Validators
         // validate reserved keywords
         $reserved = self::getReservedWords();
         foreach (explode('\\', $namespace) as $word) {
-            if (in_array((string)s($word)->lower(), $reserved, true)) {
+            if (in_array(s($word)->lower()->__toString(), $reserved, true)) {
                 throw new InvalidArgumentException(sprintf('The namespace cannot contain reserved words ("%s").', $word));
             }
         }

--- a/src/Zikula/CoreBundle/Maker/Validators.php
+++ b/src/Zikula/CoreBundle/Maker/Validators.php
@@ -21,7 +21,7 @@ class Validators
 {
     public static function validateBundleNamespace(InputInterface $input, $allowSuffix = false): string
     {
-        $namespace = s($input->getArgument('namespace'))->replace('/', '\\')->trim()->__toString();
+        $namespace = s($input->getArgument('namespace'))->replace('/', '\\')->trim()->toString();
         if (!preg_match('/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\\?)+$/', $namespace)) {
             throw new InvalidArgumentException('The namespace contains invalid characters.');
         }
@@ -29,7 +29,7 @@ class Validators
         // validate reserved keywords
         $reserved = self::getReservedWords();
         foreach (explode('\\', $namespace) as $word) {
-            if (in_array(s($word)->lower()->__toString(), $reserved, true)) {
+            if (in_array(s($word)->lower()->toString(), $reserved, true)) {
                 throw new InvalidArgumentException(sprintf('The namespace cannot contain reserved words ("%s").', $word));
             }
         }

--- a/src/Zikula/CoreBundle/Maker/Validators.php
+++ b/src/Zikula/CoreBundle/Maker/Validators.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreBundle\Maker;
 
-use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
+use function Symfony\Component\String\s;
 
 class Validators
 {

--- a/src/Zikula/CoreBundle/Site/SiteDefinition.php
+++ b/src/Zikula/CoreBundle/Site/SiteDefinition.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreBundle\Site;
 
-use function Symfony\Component\String\s;
 use Symfony\Component\HttpFoundation\RequestStack;
+use function Symfony\Component\String\s;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Zikula\Bundle\CoreBundle\Translation\TranslatorTrait;
 use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;

--- a/src/Zikula/CoreBundle/Site/SiteDefinition.php
+++ b/src/Zikula/CoreBundle/Site/SiteDefinition.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreBundle\Site;
 
+use function Symfony\Component\String\s;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Zikula\Bundle\CoreBundle\Translation\TranslatorTrait;
@@ -83,8 +84,8 @@ class SiteDefinition implements SiteDefinitionInterface
             $request = $this->requestStack->getCurrentRequest();
             if (null !== $request && null !== $request->attributes->get('_controller')) {
                 $controllerNameParts = explode('\\', $request->attributes->get('_controller'));
-                $extensionName = count($controllerNameParts) > 1 ? $controllerNameParts[0] . $controllerNameParts[1] : '';
-                if ('Module' === mb_substr($extensionName, -6)) {
+                $extensionName = 1 < count($controllerNameParts) ? $controllerNameParts[0] . $controllerNameParts[1] : '';
+                if (s($extensionName)->endsWith('Module')) {
                     $module = $this->extensionRepository->get($extensionName);
                     if (null !== $module) {
                         $moduleDisplayName = $module->getDisplayName();

--- a/src/Zikula/CoreBundle/Tests/Bundle/MetaDataTest.php
+++ b/src/Zikula/CoreBundle/Tests/Bundle/MetaDataTest.php
@@ -17,6 +17,9 @@ use PHPUnit\Framework\TestCase;
 use Zikula\AdminModule\ZikulaAdminModule;
 use Zikula\Bundle\CoreBundle\Composer\MetaData;
 
+// remove again after #4352 has been done
+require_once dirname(__DIR__, 5) . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
+
 class MetaDataTest extends TestCase
 {
     /**

--- a/src/Zikula/CoreBundle/Tests/Bundle/MetaDataTest.php
+++ b/src/Zikula/CoreBundle/Tests/Bundle/MetaDataTest.php
@@ -17,9 +17,6 @@ use PHPUnit\Framework\TestCase;
 use Zikula\AdminModule\ZikulaAdminModule;
 use Zikula\Bundle\CoreBundle\Composer\MetaData;
 
-// remove again after #4352 has been done
-require_once dirname(__DIR__, 5) . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
-
 class MetaDataTest extends TestCase
 {
     /**

--- a/src/Zikula/CoreBundle/Translation/Extractor/Visitor/Php/Zikula/FormTypeInputGroup.php
+++ b/src/Zikula/CoreBundle/Translation/Extractor/Visitor/Php/Zikula/FormTypeInputGroup.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreBundle\Translation\Extractor\Visitor\Php\Zikula;
 
-use function Symfony\Component\String\s;
 use PhpParser\Node;
 use PhpParser\NodeVisitor;
+use function Symfony\Component\String\s;
 use Translation\Extractor\Visitor\Php\Symfony\AbstractFormType;
 use Translation\Extractor\Visitor\Php\Symfony\FormTrait;
 

--- a/src/Zikula/CoreBundle/Translation/Extractor/Visitor/Php/Zikula/FormTypeInputGroup.php
+++ b/src/Zikula/CoreBundle/Translation/Extractor/Visitor/Php/Zikula/FormTypeInputGroup.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreBundle\Translation\Extractor\Visitor\Php\Zikula;
 
+use function Symfony\Component\String\s;
 use PhpParser\Node;
 use PhpParser\NodeVisitor;
 use Translation\Extractor\Visitor\Php\Symfony\AbstractFormType;
@@ -71,17 +72,17 @@ final class FormTypeInputGroup extends AbstractFormType implements NodeVisitor
                     $this->addError($inputGroupNode, 'Form input group value is not a scalar string');
                     continue;
                 }
-                $value = $inputGroupAddOn->value->value;
-                if ('<i' === mb_substr($value, 0, 2) && '</i>' === mb_substr($value, -4)) {
+                $value = s($inputGroupAddOn->value->value);
+                if ($value->startsWith('<i') && $value->endsWith('</i>')) {
                     // do not add FA icons
                     continue;
                 }
-                if ('<span' === mb_substr($value, 0, 5) && '</span>' === mb_substr($value, -7)) {
+                if ($value->startsWith('<span') && $value->endsWith('</span>')) {
                     // skip
                     continue;
                 }
                 $line = $inputGroupAddOn->value->getAttribute('startLine');
-                if (null !== $location = $this->getLocation($value, $line, $inputGroupAddOn, ['domain' => $domain])) {
+                if (null !== $location = $this->getLocation((string) $value, $line, $inputGroupAddOn, ['domain' => $domain])) {
                     $this->lateCollect($location);
                 }
             }

--- a/src/Zikula/CoreBundle/Twig/Extension/CoreExtension.php
+++ b/src/Zikula/CoreBundle/Twig/Extension/CoreExtension.php
@@ -72,7 +72,7 @@ class CoreExtension extends AbstractExtension
             return $string;
         }
 
-        return (bool)$string ? $this->translator->trans('Yes') : $this->translator->trans('No');
+        return (bool) $string ? $this->translator->trans('Yes') : $this->translator->trans('No');
     }
 
     /**

--- a/src/Zikula/CoreBundle/Twig/TokenParser/SwitchTokenParser.php
+++ b/src/Zikula/CoreBundle/Twig/TokenParser/SwitchTokenParser.php
@@ -55,7 +55,7 @@ class SwitchTokenParser extends AbstractTokenParser
                     $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
                     $body = $this->parser->subparse([$this, 'decideCaseFork']);
 
-                    $cases->setNode((string)$i, new Node([
+                    $cases->setNode((string) $i, new Node([
                         'expression' => $expr,
                         'body' => $body,
                     ]));
@@ -75,8 +75,8 @@ class SwitchTokenParser extends AbstractTokenParser
                     $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
                     $this->parser->subparse([$this, 'decideCaseFork']);
 
-                    if ($cases->hasNode((string)$i)) {
-                        $cases->getNode((string)$i)->setAttribute('break', true);
+                    if ($cases->hasNode((string) $i)) {
+                        $cases->getNode((string) $i)->setAttribute('break', true);
                     }
 
                     break;

--- a/src/Zikula/CoreBundle/bin/console
+++ b/src/Zikula/CoreBundle/bin/console
@@ -20,9 +20,9 @@ $possibleRootDirectories = [
 foreach ($possibleRootDirectories as $directory) {
     $file = $directory . 'vendor/autoload.php';
     if (file_exists($file)) {
-        require $file;
+        require_once $file;
         // remove again after #4352 has been done
-        require $directory . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
+        require_once $directory . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
         break;
     }
 }

--- a/src/Zikula/CoreBundle/bin/console
+++ b/src/Zikula/CoreBundle/bin/console
@@ -21,6 +21,8 @@ foreach ($possibleRootDirectories as $directory) {
     $file = $directory . 'vendor/autoload.php';
     if (file_exists($file)) {
         require $file;
+        // remove again after #4352 has been done
+        require $directory . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
         break;
     }
 }

--- a/src/Zikula/CoreBundle/bin/console
+++ b/src/Zikula/CoreBundle/bin/console
@@ -21,8 +21,6 @@ foreach ($possibleRootDirectories as $directory) {
     $file = $directory . 'vendor/autoload.php';
     if (file_exists($file)) {
         require_once $file;
-        // remove again after #4352 has been done
-        require_once $directory . '/vendor/symfony/symfony/src/Symfony/Component/String/Resources/functions.php';
         break;
     }
 }

--- a/src/Zikula/CoreInstallerBundle/Command/UpgradeCommand.php
+++ b/src/Zikula/CoreInstallerBundle/Command/UpgradeCommand.php
@@ -174,7 +174,7 @@ class UpgradeCommand extends AbstractCoreInstallerCommand
             if ($input->isInteractive()) {
                 $io->text($this->translator->trans('Beginning user migration...'));
             }
-            $userMigrationMaxuid = (int)$this->migrationHelper->getMaxUnMigratedUid();
+            $userMigrationMaxuid = (int) $this->migrationHelper->getMaxUnMigratedUid();
             if ($input->isInteractive()) {
                 $progressBar = new ProgressBar($output, (int) ceil($count / MigrationHelper::BATCH_LIMIT));
                 $progressBar->start();

--- a/src/Zikula/CoreInstallerBundle/Helper/PreCore3UpgradeHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/PreCore3UpgradeHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreInstallerBundle\Helper;
 
+use function Symfony\Component\String\s;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Zikula\Bundle\CoreBundle\Configurator;
 use Zikula\Bundle\CoreBundle\DependencyInjection\Configuration;
@@ -47,7 +48,7 @@ class PreCore3UpgradeHelper
         $yamlHelper = new YamlDumper($this->projectDir . '/config', 'services_custom.yaml');
         $params = $yamlHelper->getParameters();
         if (isset($params['core_installed_version']) && version_compare($params['core_installed_version'], '3.0.0', '<')) {
-            $params['database_driver'] = mb_substr($params['database_driver'], 4); // remove pdo_ prefix
+            $params['database_driver'] = (string)s($params['database_driver'])->trimStart('pdo_');
             (new DbCredsHelper($this->projectDir))->writeDatabaseDsn($params);
             (new LocalDotEnvHelper($this->projectDir))->writeLocalEnvVars(['ZIKULA_INSTALLED' => $params['core_installed_version']]);
             unset($params['core_installed_version']);

--- a/src/Zikula/CoreInstallerBundle/Helper/PreCore3UpgradeHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/PreCore3UpgradeHelper.php
@@ -48,7 +48,7 @@ class PreCore3UpgradeHelper
         $yamlHelper = new YamlDumper($this->projectDir . '/config', 'services_custom.yaml');
         $params = $yamlHelper->getParameters();
         if (isset($params['core_installed_version']) && version_compare($params['core_installed_version'], '3.0.0', '<')) {
-            $params['database_driver'] = s($params['database_driver'])->trimStart('pdo_')->__toString();
+            $params['database_driver'] = s($params['database_driver'])->trimStart('pdo_')->toString();
             (new DbCredsHelper($this->projectDir))->writeDatabaseDsn($params);
             (new LocalDotEnvHelper($this->projectDir))->writeLocalEnvVars(['ZIKULA_INSTALLED' => $params['core_installed_version']]);
             unset($params['core_installed_version']);

--- a/src/Zikula/CoreInstallerBundle/Helper/PreCore3UpgradeHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/PreCore3UpgradeHelper.php
@@ -48,7 +48,7 @@ class PreCore3UpgradeHelper
         $yamlHelper = new YamlDumper($this->projectDir . '/config', 'services_custom.yaml');
         $params = $yamlHelper->getParameters();
         if (isset($params['core_installed_version']) && version_compare($params['core_installed_version'], '3.0.0', '<')) {
-            $params['database_driver'] = (string)s($params['database_driver'])->trimStart('pdo_');
+            $params['database_driver'] = s($params['database_driver'])->trimStart('pdo_')->__toString();
             (new DbCredsHelper($this->projectDir))->writeDatabaseDsn($params);
             (new LocalDotEnvHelper($this->projectDir))->writeLocalEnvVars(['ZIKULA_INSTALLED' => $params['core_installed_version']]);
             unset($params['core_installed_version']);

--- a/src/Zikula/CoreInstallerBundle/Helper/PreCore3UpgradeHelper.php
+++ b/src/Zikula/CoreInstallerBundle/Helper/PreCore3UpgradeHelper.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\CoreInstallerBundle\Helper;
 
-use function Symfony\Component\String\s;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+use function Symfony\Component\String\s;
 use Zikula\Bundle\CoreBundle\Configurator;
 use Zikula\Bundle\CoreBundle\DependencyInjection\Configuration;
 use Zikula\Bundle\CoreBundle\Helper\LocalDotEnvHelper;

--- a/src/Zikula/HookBundle/Collector/HookCollector.php
+++ b/src/Zikula/HookBundle/Collector/HookCollector.php
@@ -137,7 +137,7 @@ class HookCollector implements HookCollectorInterface
         if (self::HOOK_SUBSCRIBE_OWN === $type) {
             return $this->containsSelfAllowedProvider($moduleName);
         }
-        $variable = (string)s($type)->slice(5)->append('sByOwner');
+        $variable = s($type)->slice(5)->append('sByOwner')->__toString();
         $array = $this->{$variable};
 
         return isset($array[$moduleName]);
@@ -148,7 +148,7 @@ class HookCollector implements HookCollectorInterface
         if (!in_array($type, [self::HOOK_SUBSCRIBER, self::HOOK_PROVIDER], true)) {
             throw new InvalidArgumentException('Only hook_provider and hook_subscriber are valid values.');
         }
-        $variable = (string)s($type)->slice(5)->append('sByOwner');
+        $variable = s($type)->slice(5)->append('sByOwner')->__toString();
         $array = $this->{$variable};
 
         return array_keys($array);

--- a/src/Zikula/HookBundle/Collector/HookCollector.php
+++ b/src/Zikula/HookBundle/Collector/HookCollector.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\HookBundle\Collector;
 
-use function Symfony\Component\String\s;
 use InvalidArgumentException;
+use function Symfony\Component\String\s;
 use Zikula\Bundle\HookBundle\HookProviderInterface;
 use Zikula\Bundle\HookBundle\HookSelfAllowedProviderInterface;
 use Zikula\Bundle\HookBundle\HookSubscriberInterface;

--- a/src/Zikula/HookBundle/Collector/HookCollector.php
+++ b/src/Zikula/HookBundle/Collector/HookCollector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\HookBundle\Collector;
 
+use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use Zikula\Bundle\HookBundle\HookProviderInterface;
 use Zikula\Bundle\HookBundle\HookSelfAllowedProviderInterface;
@@ -136,7 +137,7 @@ class HookCollector implements HookCollectorInterface
         if (self::HOOK_SUBSCRIBE_OWN === $type) {
             return $this->containsSelfAllowedProvider($moduleName);
         }
-        $variable = mb_substr($type, 5) . 'sByOwner';
+        $variable = (string)s($type)->slice(5)->append('sByOwner');
         $array = $this->{$variable};
 
         return isset($array[$moduleName]);
@@ -147,7 +148,7 @@ class HookCollector implements HookCollectorInterface
         if (!in_array($type, [self::HOOK_SUBSCRIBER, self::HOOK_PROVIDER], true)) {
             throw new InvalidArgumentException('Only hook_provider and hook_subscriber are valid values.');
         }
-        $variable = mb_substr($type, 5) . 'sByOwner';
+        $variable = (string)s($type)->slice(5)->append('sByOwner');
         $array = $this->{$variable};
 
         return array_keys($array);
@@ -158,11 +159,13 @@ class HookCollector implements HookCollectorInterface
      */
     private function containsSelfAllowedProvider(string $moduleName): bool
     {
-        if (isset($this->providersByOwner[$moduleName])) {
-            foreach ($this->providersByOwner[$moduleName] as $provider) {
-                if ($provider instanceof HookSelfAllowedProviderInterface) {
-                    return true;
-                }
+        if (!isset($this->providersByOwner[$moduleName])) {
+            return false;
+        }
+
+        foreach ($this->providersByOwner[$moduleName] as $provider) {
+            if ($provider instanceof HookSelfAllowedProviderInterface) {
+                return true;
             }
         }
 

--- a/src/Zikula/HookBundle/Collector/HookCollector.php
+++ b/src/Zikula/HookBundle/Collector/HookCollector.php
@@ -137,7 +137,7 @@ class HookCollector implements HookCollectorInterface
         if (self::HOOK_SUBSCRIBE_OWN === $type) {
             return $this->containsSelfAllowedProvider($moduleName);
         }
-        $variable = s($type)->slice(5)->append('sByOwner')->__toString();
+        $variable = s($type)->slice(5)->append('sByOwner')->toString();
         $array = $this->{$variable};
 
         return isset($array[$moduleName]);
@@ -148,7 +148,7 @@ class HookCollector implements HookCollectorInterface
         if (!in_array($type, [self::HOOK_SUBSCRIBER, self::HOOK_PROVIDER], true)) {
             throw new InvalidArgumentException('Only hook_provider and hook_subscriber are valid values.');
         }
-        $variable = s($type)->slice(5)->append('sByOwner')->__toString();
+        $variable = s($type)->slice(5)->append('sByOwner')->toString();
         $array = $this->{$variable};
 
         return array_keys($array);

--- a/src/Zikula/HookBundle/Hook/ValidationResponse.php
+++ b/src/Zikula/HookBundle/Hook/ValidationResponse.php
@@ -75,6 +75,6 @@ class ValidationResponse
 
     public function hasErrors(): bool
     {
-        return (bool)$this->errors;
+        return (bool) $this->errors;
     }
 }

--- a/src/Zikula/WorkflowBundle/DependencyInjection/ZikulaWorkflowExtension.php
+++ b/src/Zikula/WorkflowBundle/DependencyInjection/ZikulaWorkflowExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\WorkflowBundle\DependencyInjection;
 
+use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -40,7 +41,7 @@ class ZikulaWorkflowExtension extends Extension implements PrependExtensionInter
         // modules may define their workflows in: <bundlePath>/Resources/workflows/
         $bundleMetaData = $container->getParameter('kernel.bundles_metadata');
         foreach ($bundleMetaData as $bundleName => $metaData) {
-            if ('Module' !== mb_substr($bundleName, -6)) {
+            if (!s($bundleName)->endsWith('Module')) {
                 continue;
             }
 

--- a/src/Zikula/WorkflowBundle/DependencyInjection/ZikulaWorkflowExtension.php
+++ b/src/Zikula/WorkflowBundle/DependencyInjection/ZikulaWorkflowExtension.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Zikula\Bundle\WorkflowBundle\DependencyInjection;
 
-use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,6 +21,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use function Symfony\Component\String\s;
 
 /**
  * Class ZikulaWorkflowExtension

--- a/src/system/AdminModule/Controller/AdminController.php
+++ b/src/system/AdminModule/Controller/AdminController.php
@@ -245,7 +245,7 @@ class AdminController extends AbstractController
                 continue;
             }
 
-            $moduleId = (int)$adminModule['id'];
+            $moduleId = (int) $adminModule['id'];
             $moduleCategory = $adminCategoryRepository->getModuleCategory($moduleId);
             $catid = null !== $moduleCategory ? $moduleCategory['cid'] : 0;
 
@@ -278,7 +278,7 @@ class AdminController extends AbstractController
                     $menuText .= ' (<i class="fas fa-exclamation-triangle"></i> ' . $this->trans('invalid route') . ')';
                 }
 
-                $moduleName = (string)$adminModule['name'];
+                $moduleName = (string) $adminModule['name'];
                 /** @var \Knp\Menu\ItemInterface $extensionMenu */
                 $extensionMenu = $extensionMenuCollector->get($moduleName, ExtensionMenuInterface::TYPE_ADMIN);
                 if (isset($extensionMenu)) {
@@ -347,7 +347,7 @@ class AdminController extends AbstractController
                 $menuText .= ' (<i class="fas fa-exclamation-triangle"></i> ' . $this->trans('invalid route') . ')';
             }
 
-            $moduleId = (int)$adminModule['id'];
+            $moduleId = (int) $adminModule['id'];
             $moduleCategory = $adminCategoryRepository->getModuleCategory($moduleId);
             $catid = null !== $moduleCategory ? $moduleCategory['cid'] : 0;
 
@@ -410,7 +410,7 @@ class AdminController extends AbstractController
         // empty and we are not admin
         if (false === $permission) {
             // show the first category
-            $acid = !empty($possibleCategoryIds) ? (int)$possibleCategoryIds[0] : null;
+            $acid = !empty($possibleCategoryIds) ? (int) $possibleCategoryIds[0] : null;
         }
 
         return $this->render('@ZikulaAdminModule/Admin/categoryMenu.html.twig', [

--- a/src/system/AdminModule/Controller/AdminInterfaceController.php
+++ b/src/system/AdminModule/Controller/AdminInterfaceController.php
@@ -234,7 +234,7 @@ class AdminInterfaceController extends AbstractController
                 $menuText .= ' (<i class="fas fa-exclamation-triangle"></i> ' . $this->trans('invalid route') . ')';
             }
 
-            $moduleName = (string)$adminModule['name'];
+            $moduleName = (string) $adminModule['name'];
             $extensionMenu = $extensionMenuCollector->get($moduleName, ExtensionMenuInterface::TYPE_ADMIN);
             if (isset($extensionMenu) && 'modules' === $mode && 'tabs' === $template) {
                 $extensionMenu->setChildrenAttribute('class', 'dropdown-menu');

--- a/src/system/AdminModule/Controller/ConfigController.php
+++ b/src/system/AdminModule/Controller/ConfigController.php
@@ -66,8 +66,8 @@ class ConfigController extends AbstractController
 
         $modVars = $variableApi->getAll('ZikulaAdminModule');
         $dataValues = $modVars;
-        $dataValues['ignoreinstallercheck'] = (bool)$dataValues['ignoreinstallercheck'];
-        $dataValues['admingraphic'] = (bool)$dataValues['admingraphic'];
+        $dataValues['ignoreinstallercheck'] = (bool) $dataValues['ignoreinstallercheck'];
+        $dataValues['admingraphic'] = (bool) $dataValues['admingraphic'];
 
         $modules = [];
         foreach ($adminModules as $adminModule) {

--- a/src/system/AdminModule/Entity/Repository/AdminCategoryRepository.php
+++ b/src/system/AdminModule/Entity/Repository/AdminCategoryRepository.php
@@ -34,7 +34,7 @@ class AdminCategoryRepository extends ServiceEntityRepository implements AdminCa
             ->select('COUNT(c.cid)')
             ->getQuery();
 
-        return (int)$query->getSingleScalarResult();
+        return (int) $query->getSingleScalarResult();
     }
 
     public function getModuleCategory(int $moduleId): ?AdminCategoryEntity

--- a/src/system/AdminModule/Entity/Repository/AdminModuleRepository.php
+++ b/src/system/AdminModule/Entity/Repository/AdminModuleRepository.php
@@ -41,7 +41,7 @@ class AdminModuleRepository extends ServiceEntityRepository implements AdminModu
             ->setParameter('cid', $cid)
             ->getQuery();
 
-        return (int)$query->getSingleScalarResult();
+        return (int) $query->getSingleScalarResult();
     }
 
     public function setModuleCategory(ExtensionEntity $moduleEntity, AdminCategoryEntity $adminCategoryEntity): void

--- a/src/system/AdminModule/Helper/AdminLinksHelper.php
+++ b/src/system/AdminModule/Helper/AdminLinksHelper.php
@@ -21,13 +21,13 @@ class AdminLinksHelper
     public function sortAdminModsByOrder(array $adminLinks = []): array
     {
         usort($adminLinks, function (array $a, array $b) {
-            if ((int)$a['order'] === (int)$b['order']) {
+            if ((int) $a['order'] === (int) $b['order']) {
                 return strcmp($a['moduleName'], $b['moduleName']);
             }
-            if ((int)$a['order'] > (int)$b['order']) {
+            if ((int) $a['order'] > (int) $b['order']) {
                 return 1;
             }
-            if ((int)$a['order'] < (int)$b['order']) {
+            if ((int) $a['order'] < (int) $b['order']) {
                 return -1;
             }
 

--- a/src/system/AdminModule/Helper/UpdateCheckHelper.php
+++ b/src/system/AdminModule/Helper/UpdateCheckHelper.php
@@ -73,13 +73,13 @@ class UpdateCheckHelper
     {
         $this->variableApi = $variableApi;
 
-        $this->enabled = (bool)$variableApi->getSystemVar('updatecheck');
+        $this->enabled = (bool) $variableApi->getSystemVar('updatecheck');
         $this->currentVersion = ZikulaKernel::VERSION;
-        $this->lastChecked = (int)$variableApi->getSystemVar('updatelastchecked');
-        $this->checkInterval = (int)$variableApi->getSystemVar('updatefrequency');
+        $this->lastChecked = (int) $variableApi->getSystemVar('updatelastchecked');
+        $this->checkInterval = (int) $variableApi->getSystemVar('updatefrequency');
         $this->updateversion = $variableApi->getSystemVar('updateversion');
 
-        $this->force = (bool)$requestStack->getMasterRequest()->query->get('forceupdatecheck');
+        $this->force = (bool) $requestStack->getMasterRequest()->query->get('forceupdatecheck');
         $this->checked = false;
         $this->releases = false;
 
@@ -147,9 +147,9 @@ class UpdateCheckHelper
         }
 
         if (true === $this->checked && '' !== $this->updateversion) {
-            $this->variableApi->set(VariableApi::CONFIG, 'updatelastchecked', (int)time());
+            $this->variableApi->set(VariableApi::CONFIG, 'updatelastchecked', (int) time());
             $this->variableApi->set(VariableApi::CONFIG, 'updateversion', $this->updateversion);
-            $this->lastChecked = (int)$this->variableApi->getSystemVar('updatelastchecked');
+            $this->lastChecked = (int) $this->variableApi->getSystemVar('updatelastchecked');
         }
     }
 

--- a/src/system/BlocksModule/AbstractBlockHandler.php
+++ b/src/system/BlocksModule/AbstractBlockHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\BlocksModule;
 
+use function Symfony\Component\String\s;
 use LogicException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -107,10 +108,7 @@ abstract class AbstractBlockHandler implements BlockHandlerInterface
     {
         // default to the ClassName without the `Block` suffix
         // note: This string is intentionally left untranslated.
-        $fqCn = static::class;
-        $pos = mb_strrpos($fqCn, '\\');
-
-        return mb_substr($fqCn, $pos + 1, -5);
+        return (string)s(static::class)->afterLast('\\')->trimEnd('Block');
     }
 
     /**

--- a/src/system/BlocksModule/AbstractBlockHandler.php
+++ b/src/system/BlocksModule/AbstractBlockHandler.php
@@ -108,7 +108,7 @@ abstract class AbstractBlockHandler implements BlockHandlerInterface
     {
         // default to the ClassName without the `Block` suffix
         // note: This string is intentionally left untranslated.
-        return s(static::class)->afterLast('\\')->trimEnd('Block')->__toString();
+        return s(static::class)->afterLast('\\')->trimEnd('Block')->toString();
     }
 
     /**

--- a/src/system/BlocksModule/AbstractBlockHandler.php
+++ b/src/system/BlocksModule/AbstractBlockHandler.php
@@ -108,7 +108,7 @@ abstract class AbstractBlockHandler implements BlockHandlerInterface
     {
         // default to the ClassName without the `Block` suffix
         // note: This string is intentionally left untranslated.
-        return (string)s(static::class)->afterLast('\\')->trimEnd('Block');
+        return s(static::class)->afterLast('\\')->trimEnd('Block')->__toString();
     }
 
     /**

--- a/src/system/BlocksModule/AbstractBlockHandler.php
+++ b/src/system/BlocksModule/AbstractBlockHandler.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Zikula\BlocksModule;
 
-use function Symfony\Component\String\s;
 use LogicException;
 use Symfony\Component\HttpFoundation\RequestStack;
+use function Symfony\Component\String\s;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Zikula\Bundle\CoreBundle\Translation\TranslatorTrait;

--- a/src/system/BlocksModule/Api/BlockFactoryApi.php
+++ b/src/system/BlocksModule/Api/BlockFactoryApi.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\BlocksModule\Api;
 
+use function Symfony\Component\String\s;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -53,9 +54,7 @@ class BlockFactoryApi implements BlockFactoryApiInterface
             throw new RuntimeException(sprintf('Block class %s must implement Zikula\BlocksModule\BlockHandlerInterface.', $blockClassName));
         }
 
-        if (0 === mb_strpos($blockClassName, '\\')) {
-            $blockClassName = mb_substr($blockClassName, 1);
-        }
+        $blockClassName = (string)s($blockClassName)->trimStart('\\');
 
         if (!$this->container->has($blockClassName)) {
             throw new RuntimeException($this->translator->trans('Block class %className% not found in container.', ['%className%' => $blockClassName]));

--- a/src/system/BlocksModule/Api/BlockFactoryApi.php
+++ b/src/system/BlocksModule/Api/BlockFactoryApi.php
@@ -54,7 +54,7 @@ class BlockFactoryApi implements BlockFactoryApiInterface
             throw new RuntimeException(sprintf('Block class %s must implement Zikula\BlocksModule\BlockHandlerInterface.', $blockClassName));
         }
 
-        $blockClassName = (string)s($blockClassName)->trimStart('\\');
+        $blockClassName = s($blockClassName)->trimStart('\\')->__toString();
 
         if (!$this->container->has($blockClassName)) {
             throw new RuntimeException($this->translator->trans('Block class %className% not found in container.', ['%className%' => $blockClassName]));

--- a/src/system/BlocksModule/Api/BlockFactoryApi.php
+++ b/src/system/BlocksModule/Api/BlockFactoryApi.php
@@ -54,7 +54,7 @@ class BlockFactoryApi implements BlockFactoryApiInterface
             throw new RuntimeException(sprintf('Block class %s must implement Zikula\BlocksModule\BlockHandlerInterface.', $blockClassName));
         }
 
-        $blockClassName = s($blockClassName)->trimStart('\\')->__toString();
+        $blockClassName = s($blockClassName)->trimStart('\\')->toString();
 
         if (!$this->container->has($blockClassName)) {
             throw new RuntimeException($this->translator->trans('Block class %className% not found in container.', ['%className%' => $blockClassName]));

--- a/src/system/BlocksModule/Api/BlockFactoryApi.php
+++ b/src/system/BlocksModule/Api/BlockFactoryApi.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Zikula\BlocksModule\Api;
 
-use function Symfony\Component\String\s;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
+use function Symfony\Component\String\s;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Zikula\BlocksModule\Api\ApiInterface\BlockFactoryApiInterface;
 use Zikula\BlocksModule\BlockHandlerInterface;

--- a/src/system/BlocksModule/Controller/PlacementController.php
+++ b/src/system/BlocksModule/Controller/PlacementController.php
@@ -91,7 +91,7 @@ class PlacementController extends AbstractController
         $query->getResult();
 
         // add new block positions
-        foreach ((array)$blockOrder as $order => $bid) {
+        foreach ((array) $blockOrder as $order => $bid) {
             $placement = new BlockPlacementEntity();
             $placement->setPosition($em->getReference('ZikulaBlocksModule:BlockPositionEntity', $position));
             $placement->setBlock($em->getReference('ZikulaBlocksModule:BlockEntity', $bid));

--- a/src/system/CategoriesModule/Controller/NodeController.php
+++ b/src/system/CategoriesModule/Controller/NodeController.php
@@ -208,9 +208,9 @@ class NodeController extends AbstractController
         }
 
         $oldParent = $request->request->get('old_parent');
-        $oldPosition = (int)$request->request->get('old_position');
+        $oldPosition = (int) $request->request->get('old_position');
         $parent = $request->request->get('parent');
-        $position = (int)$request->request->get('position');
+        $position = (int) $request->request->get('position');
         if ($oldParent === $parent) {
             $diff = $oldPosition - $position; // if $diff is positive, then node moved up
             $methodName = $diff > 0 ? 'moveUp' : 'moveDown';

--- a/src/system/CategoriesModule/Entity/Repository/CategoryRepository.php
+++ b/src/system/CategoriesModule/Entity/Repository/CategoryRepository.php
@@ -62,7 +62,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
 
         $query = $qb->getQuery();
 
-        return (int)$query->getSingleScalarResult();
+        return (int) $query->getSingleScalarResult();
     }
 
     public function getLastByParent(int $parentId = 0): ?CategoryEntity

--- a/src/system/CategoriesModule/Form/DataTransformer/CategoriesCollectionTransformer.php
+++ b/src/system/CategoriesModule/Form/DataTransformer/CategoriesCollectionTransformer.php
@@ -47,7 +47,7 @@ class CategoriesCollectionTransformer implements DataTransformerInterface
             throw new InvalidConfigurationException("Option 'entityCategoryClass' must extend Zikula\\CategoriesModule\\Entity\\AbstractCategoryAssignment");
         }
         $this->entityCategoryClass = (string) $options['entityCategoryClass'];
-        $this->multiple = (bool)($options['multiple'] ?? false);
+        $this->multiple = (bool) ($options['multiple'] ?? false);
         $this->entityManager = $options['em'];
     }
 
@@ -57,7 +57,7 @@ class CategoriesCollectionTransformer implements DataTransformerInterface
         $class = $this->entityCategoryClass;
 
         foreach ($value as $regId => $categories) {
-            $regId = (int)mb_substr($regId, mb_strpos($regId, '_') + 1);
+            $regId = (int) mb_substr($regId, mb_strpos($regId, '_') + 1);
             $subCollection = new ArrayCollection();
             if (!is_array($categories) && $categories instanceof CategoryEntity) {
                 $categories = [$categories];

--- a/src/system/CategoriesModule/Form/DataTransformer/CategoriesCollectionTransformer.php
+++ b/src/system/CategoriesModule/Form/DataTransformer/CategoriesCollectionTransformer.php
@@ -46,7 +46,7 @@ class CategoriesCollectionTransformer implements DataTransformerInterface
         if (!in_array(AbstractCategoryAssignment::class, $classParents, true)) {
             throw new InvalidConfigurationException("Option 'entityCategoryClass' must extend Zikula\\CategoriesModule\\Entity\\AbstractCategoryAssignment");
         }
-        $this->entityCategoryClass = (string)$options['entityCategoryClass'];
+        $this->entityCategoryClass = (string) $options['entityCategoryClass'];
         $this->multiple = (bool)($options['multiple'] ?? false);
         $this->entityManager = $options['em'];
     }

--- a/src/system/ExtensionsModule/AbstractExtension.php
+++ b/src/system/ExtensionsModule/AbstractExtension.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Zikula\ExtensionsModule;
 
-use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use LogicException;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use function Symfony\Component\String\s;
 use Zikula\Bundle\CoreBundle\Composer\MetaData;
 use Zikula\Bundle\CoreBundle\Composer\Scanner;
 use Zikula\ExtensionsModule\Helper\MetaDataHelper;

--- a/src/system/ExtensionsModule/AbstractExtension.php
+++ b/src/system/ExtensionsModule/AbstractExtension.php
@@ -31,7 +31,7 @@ abstract class AbstractExtension extends Bundle
     {
         $ns = $this->getNamespace();
         $installerName = s($ns)->afterLast('\\')->append('Installer');
-        $class = $ns . '\\' . (string)$installerName;
+        $class = $ns . '\\' . (string) $installerName;
 
         return $class;
     }
@@ -67,7 +67,7 @@ abstract class AbstractExtension extends Bundle
         $folder = $this->getNameType() . 's/';
         $name = s($this->getName())->trimEnd($this->getNameType());
 
-        return (string)s($folder . $name)->lower();
+        return (string) s($folder . $name)->lower();
     }
 
     public function getNameType(): string

--- a/src/system/ExtensionsModule/AbstractExtension.php
+++ b/src/system/ExtensionsModule/AbstractExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ExtensionsModule;
 
+use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use LogicException;
 use Symfony\Component\DependencyInjection\Container;
@@ -29,7 +30,8 @@ abstract class AbstractExtension extends Bundle
     public function getInstallerClass(): string
     {
         $ns = $this->getNamespace();
-        $class = $ns . '\\' . mb_substr($ns, mb_strrpos($ns, '\\') + 1, mb_strlen($ns)) . 'Installer';
+        $installerName = s($ns)->afterLast('\\')->append('Installer');
+        $class = $ns . '\\' . (string)$installerName;
 
         return $class;
     }
@@ -62,7 +64,10 @@ abstract class AbstractExtension extends Bundle
      */
     public function getRelativeAssetPath(): string
     {
-        return mb_strtolower($this->getNameType() . 's/' . mb_substr($this->getName(), 0, -mb_strlen($this->getNameType())));
+        $folder = $this->getNameType() . 's/';
+        $name = s($this->getName())->trimEnd($this->getNameType());
+
+        return (string)s($folder . $name)->lower();
     }
 
     public function getNameType(): string

--- a/src/system/ExtensionsModule/AbstractExtension.php
+++ b/src/system/ExtensionsModule/AbstractExtension.php
@@ -31,7 +31,7 @@ abstract class AbstractExtension extends Bundle
     {
         $ns = $this->getNamespace();
         $installerName = s($ns)->afterLast('\\')->append('Installer');
-        $class = $ns . '\\' . $installerName->__toString();
+        $class = $ns . '\\' . $installerName->toString();
 
         return $class;
     }
@@ -67,7 +67,7 @@ abstract class AbstractExtension extends Bundle
         $folder = $this->getNameType() . 's/';
         $name = s($this->getName())->trimEnd($this->getNameType());
 
-        return s($folder . $name)->lower()->__toString();
+        return s($folder . $name)->lower()->toString();
     }
 
     public function getNameType(): string

--- a/src/system/ExtensionsModule/AbstractExtension.php
+++ b/src/system/ExtensionsModule/AbstractExtension.php
@@ -31,7 +31,7 @@ abstract class AbstractExtension extends Bundle
     {
         $ns = $this->getNamespace();
         $installerName = s($ns)->afterLast('\\')->append('Installer');
-        $class = $ns . '\\' . (string) $installerName;
+        $class = $ns . '\\' . $installerName->__toString();
 
         return $class;
     }
@@ -67,7 +67,7 @@ abstract class AbstractExtension extends Bundle
         $folder = $this->getNameType() . 's/';
         $name = s($this->getName())->trimEnd($this->getNameType());
 
-        return (string) s($folder . $name)->lower();
+        return s($folder . $name)->lower()->__toString();
     }
 
     public function getNameType(): string

--- a/src/system/ExtensionsModule/Controller/HelpController.php
+++ b/src/system/ExtensionsModule/Controller/HelpController.php
@@ -88,7 +88,7 @@ class HelpController extends AbstractController
                 // local link - rewrite
                 $urlArgs = [
                     'moduleName' => $moduleName,
-                    'page' => (string) $pageName->trimEnd('.md')
+                    'page' => $pageName->trimEnd('.md')->__toString()
                 ];
                 if (1 === $raw) {
                     $urlArgs['raw'] = 1;

--- a/src/system/ExtensionsModule/Controller/HelpController.php
+++ b/src/system/ExtensionsModule/Controller/HelpController.php
@@ -88,7 +88,7 @@ class HelpController extends AbstractController
                 // local link - rewrite
                 $urlArgs = [
                     'moduleName' => $moduleName,
-                    'page' => $pageName->trimEnd('.md')->__toString()
+                    'page' => $pageName->trimEnd('.md')->toString()
                 ];
                 if (1 === $raw) {
                     $urlArgs['raw'] = 1;

--- a/src/system/ExtensionsModule/Controller/HelpController.php
+++ b/src/system/ExtensionsModule/Controller/HelpController.php
@@ -88,7 +88,7 @@ class HelpController extends AbstractController
                 // local link - rewrite
                 $urlArgs = [
                     'moduleName' => $moduleName,
-                    'page' => (string)$pageName->trimEnd('.md')
+                    'page' => (string) $pageName->trimEnd('.md')
                 ];
                 if (1 === $raw) {
                     $urlArgs['raw'] = 1;

--- a/src/system/ExtensionsModule/Controller/HelpController.php
+++ b/src/system/ExtensionsModule/Controller/HelpController.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Zikula\ExtensionsModule\Controller;
 
-use function Symfony\Component\String\s;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\RouterInterface;
+use function Symfony\Component\String\s;
 use Zikula\Bundle\CoreBundle\Controller\AbstractController;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\Bundle\CoreBundle\Response\PlainResponse;

--- a/src/system/ExtensionsModule/Controller/HelpController.php
+++ b/src/system/ExtensionsModule/Controller/HelpController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ExtensionsModule\Controller;
 
+use function Symfony\Component\String\s;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -44,7 +45,7 @@ class HelpController extends AbstractController
         string $moduleName
     ): Response {
         $page = $request->query->get('page', 'README');
-        if (false !== mb_strpos($page, '..')) {
+        if (s($page)->containsAny('..')) {
             throw new \Exception('Invalid page "' . $page . '".');
         }
 
@@ -76,17 +77,18 @@ class HelpController extends AbstractController
         $content = preg_replace_callback(
             '/\[(.*?)\]\((.*?)\)/',
             function ($match) use ($router, $moduleName, $raw) {
+                $pageName = s($match[2]);
                 if (false === mb_strpos($match[2], '.md')) {
                     return $match[0];
                 }
-                if ('http' === mb_substr($match[2], 0, 4)) {
+                if ($pageName->startsWith('http')) {
                     return $match[0];
                 }
 
                 // local link - rewrite
                 $urlArgs = [
                     'moduleName' => $moduleName,
-                    'page' => trim($match[2], '.md')
+                    'page' => (string)$pageName->trimEnd('.md')
                 ];
                 if (1 === $raw) {
                     $urlArgs['raw'] = 1;

--- a/src/system/ExtensionsModule/Entity/Repository/ExtensionVarRepository.php
+++ b/src/system/ExtensionsModule/Entity/Repository/ExtensionVarRepository.php
@@ -47,7 +47,7 @@ class ExtensionVarRepository extends ServiceEntityRepository implements Extensio
             ->getQuery();
         $result = $query->execute();
 
-        return (bool)$result;
+        return (bool) $result;
     }
 
     public function deleteByExtension(string $extensionName): bool
@@ -59,7 +59,7 @@ class ExtensionVarRepository extends ServiceEntityRepository implements Extensio
             ->getQuery();
         $result = $query->execute();
 
-        return (bool)$result;
+        return (bool) $result;
     }
 
     public function updateName(string $oldName, string $newName): bool
@@ -73,6 +73,6 @@ class ExtensionVarRepository extends ServiceEntityRepository implements Extensio
             ->getQuery();
         $result = $query->execute();
 
-        return (bool)$result;
+        return (bool) $result;
     }
 }

--- a/src/system/ExtensionsModule/Helper/BundleSyncHelper.php
+++ b/src/system/ExtensionsModule/Helper/BundleSyncHelper.php
@@ -257,7 +257,7 @@ class BundleSyncHelper
     ): void {
         foreach ($extensionsFromFile as $name => $extensionFromFile) {
             foreach ($extensionsFromDB as $dbname => $extensionFromDB) {
-                if (isset($extensionFromDB['name']) && in_array($extensionFromDB['name'], (array)$extensionFromFile['oldnames'], true)) {
+                if (isset($extensionFromDB['name']) && in_array($extensionFromDB['name'], (array) $extensionFromFile['oldnames'], true)) {
                     // migrate its modvars
                     $this->extensionVarRepository->updateName($dbname, $name);
                     // rename the extension register

--- a/src/system/GroupsModule/Entity/Repository/GroupRepository.php
+++ b/src/system/GroupsModule/Entity/Repository/GroupRepository.php
@@ -56,7 +56,7 @@ class GroupRepository extends ServiceEntityRepository implements GroupRepository
 
         $query = $qb->getQuery();
 
-        return (int)$query->getSingleScalarResult();
+        return (int) $query->getSingleScalarResult();
     }
 
     public function getGroups(

--- a/src/system/GroupsModule/GroupsModuleInstaller.php
+++ b/src/system/GroupsModule/GroupsModuleInstaller.php
@@ -47,8 +47,8 @@ class GroupsModuleInstaller extends AbstractExtensionInstaller
     {
         switch ($oldVersion) {
             case '2.4.0': // shipped with Core-1.4.3
-                $this->setVar('mailwarning', (bool)$this->getVar('mailwarning'));
-                $this->setVar('hideclosed', (bool)$this->getVar('hideclosed'));
+                $this->setVar('mailwarning', (bool) $this->getVar('mailwarning'));
+                $this->setVar('hideclosed', (bool) $this->getVar('hideclosed'));
                 $this->setVar('hidePrivate', false);
                 // no break
             case '2.4.1':

--- a/src/system/GroupsModule/Validator/Constraints/ValidGroupNameValidator.php
+++ b/src/system/GroupsModule/Validator/Constraints/ValidGroupNameValidator.php
@@ -53,7 +53,7 @@ class ValidGroupNameValidator extends ConstraintValidator
                 ->setParameter('excludedGid', $gid);
         }
 
-        if ((int)$qb->getQuery()->getSingleScalarResult() > 0) {
+        if (0 < (int) $qb->getQuery()->getSingleScalarResult()) {
             $this->context->buildViolation(
                 $this->translator->trans(
                     'The group name you entered (%groupName%) does already exist.',

--- a/src/system/MenuModule/Controller/NodeController.php
+++ b/src/system/MenuModule/Controller/NodeController.php
@@ -128,9 +128,9 @@ class NodeController extends AbstractController
         $entityId = str_replace($this->domTreeNodePrefix, '', $node['id']);
         $menuItemEntity = $menuItemRepository->find($entityId);
         $oldParent = $request->request->get('old_parent');
-        $oldPosition = (int)$request->request->get('old_position');
+        $oldPosition = (int) $request->request->get('old_position');
         $parent = $request->request->get('parent');
-        $position = (int)$request->request->get('position');
+        $position = (int) $request->request->get('position');
         if ($oldParent === $parent) {
             $diff = $oldPosition - $position; // if $diff is positive, then node moved up
             $methodName = $diff > 0 ? 'moveUp' : 'moveDown';

--- a/src/system/MenuModule/MenuModuleInstaller.php
+++ b/src/system/MenuModule/MenuModuleInstaller.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\MenuModule;
 
+use function Symfony\Component\String\s;
 use Zikula\ExtensionsModule\Installer\AbstractExtensionInstaller;
 use Zikula\MenuModule\Entity\MenuItemEntity;
 
@@ -48,7 +49,7 @@ class MenuModuleInstaller extends AbstractExtensionInstaller
                 foreach ($menuItems as $menuItem) {
                     if ($menuItem->hasOption('icon')) {
                         $iconClass = (string) $menuItem->getOption('icon');
-                        $menuItem->setOption('icon', 'fas' . mb_substr($iconClass, 3));
+                        $menuItem->setOption('icon', 'fas' . (string)s($iconClass)->slice(3));
                     }
                 }
                 $this->entityManager->flush();

--- a/src/system/MenuModule/MenuModuleInstaller.php
+++ b/src/system/MenuModule/MenuModuleInstaller.php
@@ -49,7 +49,7 @@ class MenuModuleInstaller extends AbstractExtensionInstaller
                 foreach ($menuItems as $menuItem) {
                     if ($menuItem->hasOption('icon')) {
                         $iconClass = (string) $menuItem->getOption('icon');
-                        $menuItem->setOption('icon', 'fas' . (string)s($iconClass)->slice(3));
+                        $menuItem->setOption('icon', 'fas' . s($iconClass)->slice(3)->__toString());
                     }
                 }
                 $this->entityManager->flush();

--- a/src/system/MenuModule/MenuModuleInstaller.php
+++ b/src/system/MenuModule/MenuModuleInstaller.php
@@ -49,7 +49,7 @@ class MenuModuleInstaller extends AbstractExtensionInstaller
                 foreach ($menuItems as $menuItem) {
                     if ($menuItem->hasOption('icon')) {
                         $iconClass = (string) $menuItem->getOption('icon');
-                        $menuItem->setOption('icon', 'fas' . s($iconClass)->slice(3)->__toString());
+                        $menuItem->setOption('icon', 'fas' . s($iconClass)->slice(3)->toString());
                     }
                 }
                 $this->entityManager->flush();

--- a/src/system/PermissionsModule/Api/PermissionApi.php
+++ b/src/system/PermissionsModule/Api/PermissionApi.php
@@ -90,7 +90,7 @@ class PermissionApi implements PermissionApiInterface
     public function hasPermission(string $component = null, string $instance = null, int $level = ACCESS_NONE, int $user = null): bool
     {
         if (!isset($user)) {
-            $user = (int)$this->currentUserApi->get('uid');
+            $user = (int) $this->currentUserApi->get('uid');
         }
         $user = !$user ? Constant::USER_ID_ANONYMOUS : $user;
         if (!isset($this->groupPermsByUser[$user]) || false === $this->groupPermsByUser[$user]) {
@@ -132,7 +132,7 @@ class PermissionApi implements PermissionApiInterface
         foreach ($permsByGroup as $perm) {
             $component = $this->normalizeRegexString($perm['component']);
             $instance = $this->normalizeRegexString($perm['instance']);
-            $level = (int)$perm['level']; // this string must be a numeric and not normalized.
+            $level = (int) $perm['level']; // this string must be a numeric and not normalized.
             $groupPerms[] = [
                 'component' => $component,
                 'instance' => $instance,

--- a/src/system/PermissionsModule/Controller/ConfigController.php
+++ b/src/system/PermissionsModule/Controller/ConfigController.php
@@ -45,8 +45,8 @@ class ConfigController extends AbstractController
         PermissionRepositoryInterface $permissionRepository
     ) {
         $modVars = $variableApi->getAll('ZikulaPermissionsModule');
-        $modVars['lockadmin'] = (bool)$modVars['lockadmin'];
-        $modVars['filter'] = (bool)$modVars['filter'];
+        $modVars['lockadmin'] = (bool) $modVars['lockadmin'];
+        $modVars['filter'] = (bool) $modVars['filter'];
 
         $form = $this->createForm(ConfigType::class, $modVars);
         $form->handleRequest($request);
@@ -56,10 +56,10 @@ class ConfigController extends AbstractController
 
                 $error = false;
 
-                $lockadmin = isset($formData['lockadmin']) ? (bool)$formData['lockadmin'] : false;
+                $lockadmin = isset($formData['lockadmin']) ? (bool) $formData['lockadmin'] : false;
                 $variableApi->set('ZikulaPermissionsModule', 'lockadmin', $lockadmin);
 
-                $adminId = isset($formData['adminid']) ? (int)$formData['adminid'] : 1;
+                $adminId = isset($formData['adminid']) ? (int) $formData['adminid'] : 1;
                 if (0 !== $adminId) {
                     $perm = $permissionRepository->find($adminId);
                     if (!$perm) {
@@ -69,7 +69,7 @@ class ConfigController extends AbstractController
                 }
                 $variableApi->set('ZikulaPermissionsModule', 'adminid', $adminId);
 
-                $filter = isset($formData['filter']) ? (bool)$formData['filter'] : false;
+                $filter = isset($formData['filter']) ? (bool) $formData['filter'] : false;
                 $variableApi->set('ZikulaPermissionsModule', 'filter', $filter);
 
                 if (true === $error) {

--- a/src/system/PermissionsModule/Controller/PermissionController.php
+++ b/src/system/PermissionsModule/Controller/PermissionController.php
@@ -74,7 +74,7 @@ class PermissionController extends AbstractController
             'lockadmin' => $this->getVar('lockadmin', 1) ? 1 : 0,
             'adminId' => $this->getVar('adminid', 1),
             'schema' => $schemaHelper->getAllSchema(),
-            'enableFilter' => (bool)$this->getVar('filter', 1)
+            'enableFilter' => (bool) $this->getVar('filter', 1)
         ];
     }
 

--- a/src/system/PermissionsModule/Entity/Repository/PermissionRepository.php
+++ b/src/system/PermissionsModule/Entity/Repository/PermissionRepository.php
@@ -95,7 +95,7 @@ class PermissionRepository extends ServiceEntityRepository implements Permission
         $query = $qb->select($qb->expr()->max('p.sequence'))
             ->getQuery();
 
-        return (int)$query->getSingleScalarResult();
+        return (int) $query->getSingleScalarResult();
     }
 
     public function updateSequencesFrom(int $value, int $amount = 1): void

--- a/src/system/RoutesModule/Base/AbstractAppSettings.php
+++ b/src/system/RoutesModule/Base/AbstractAppSettings.php
@@ -81,7 +81,7 @@ abstract class AbstractAppSettings
     
     public function setRouteEntriesPerPage(int $routeEntriesPerPage): void
     {
-        if ((int)$this->routeEntriesPerPage !== $routeEntriesPerPage) {
+        if ((int) $this->routeEntriesPerPage !== $routeEntriesPerPage) {
             $this->routeEntriesPerPage = $routeEntriesPerPage;
         }
     }
@@ -93,7 +93,7 @@ abstract class AbstractAppSettings
     
     public function setShowOnlyOwnEntries(bool $showOnlyOwnEntries): void
     {
-        if ((bool)$this->showOnlyOwnEntries !== $showOnlyOwnEntries) {
+        if ((bool) $this->showOnlyOwnEntries !== $showOnlyOwnEntries) {
             $this->showOnlyOwnEntries = $showOnlyOwnEntries;
         }
     }
@@ -105,7 +105,7 @@ abstract class AbstractAppSettings
     
     public function setAllowModerationSpecificCreatorForRoute(bool $allowModerationSpecificCreatorForRoute): void
     {
-        if ((bool)$this->allowModerationSpecificCreatorForRoute !== $allowModerationSpecificCreatorForRoute) {
+        if ((bool) $this->allowModerationSpecificCreatorForRoute !== $allowModerationSpecificCreatorForRoute) {
             $this->allowModerationSpecificCreatorForRoute = $allowModerationSpecificCreatorForRoute;
         }
     }
@@ -117,7 +117,7 @@ abstract class AbstractAppSettings
     
     public function setAllowModerationSpecificCreationDateForRoute(bool $allowModerationSpecificCreationDateForRoute): void
     {
-        if ((bool)$this->allowModerationSpecificCreationDateForRoute !== $allowModerationSpecificCreationDateForRoute) {
+        if ((bool) $this->allowModerationSpecificCreationDateForRoute !== $allowModerationSpecificCreationDateForRoute) {
             $this->allowModerationSpecificCreationDateForRoute = $allowModerationSpecificCreationDateForRoute;
         }
     }

--- a/src/system/RoutesModule/Entity/Base/AbstractRouteEntity.php
+++ b/src/system/RoutesModule/Entity/Base/AbstractRouteEntity.php
@@ -221,7 +221,7 @@ abstract class AbstractRouteEntity extends EntityAccess
     
     public function setId(int $id = null): void
     {
-        if ((int)$this->id !== $id) {
+        if ((int) $this->id !== $id) {
             $this->id = $id;
         }
     }
@@ -329,7 +329,7 @@ abstract class AbstractRouteEntity extends EntityAccess
     
     public function setPrependBundlePrefix(bool $prependBundlePrefix): void
     {
-        if ((bool)$this->prependBundlePrefix !== $prependBundlePrefix) {
+        if ((bool) $this->prependBundlePrefix !== $prependBundlePrefix) {
             $this->prependBundlePrefix = $prependBundlePrefix;
         }
     }
@@ -341,7 +341,7 @@ abstract class AbstractRouteEntity extends EntityAccess
     
     public function setTranslatable(bool $translatable): void
     {
-        if ((bool)$this->translatable !== $translatable) {
+        if ((bool) $this->translatable !== $translatable) {
             $this->translatable = $translatable;
         }
     }
@@ -425,7 +425,7 @@ abstract class AbstractRouteEntity extends EntityAccess
     
     public function setSort(int $sort): void
     {
-        if ((int)$this->sort !== $sort) {
+        if ((int) $this->sort !== $sort) {
             $this->sort = $sort;
         }
     }

--- a/src/system/RoutesModule/Entity/Repository/Base/AbstractRouteRepository.php
+++ b/src/system/RoutesModule/Entity/Repository/Base/AbstractRouteRepository.php
@@ -443,7 +443,7 @@ abstract class AbstractRouteRepository extends SortableRepository
     
         $query = $qb->getQuery();
     
-        return (int)$query->getSingleScalarResult();
+        return (int) $query->getSingleScalarResult();
     }
 
     /**
@@ -461,7 +461,7 @@ abstract class AbstractRouteRepository extends SortableRepository
     
         $query = $qb->getQuery();
     
-        $count = (int)$query->getSingleScalarResult();
+        $count = (int) $query->getSingleScalarResult();
     
         return 1 > $count;
     }

--- a/src/system/RoutesModule/Form/Handler/Route/Base/AbstractEditHandler.php
+++ b/src/system/RoutesModule/Form/Handler/Route/Base/AbstractEditHandler.php
@@ -80,12 +80,12 @@ abstract class AbstractEditHandler extends EditHandler
             'mode' => $this->templateParameters['mode'],
             'actions' => $this->templateParameters['actions'],
             'has_moderate_permission' => $this->permissionHelper->hasEntityPermission($this->entityRef, ACCESS_ADMIN),
-            'allow_moderation_specific_creator' => (bool)$this->variableApi->get(
+            'allow_moderation_specific_creator' => (bool) $this->variableApi->get(
                 'ZikulaRoutesModule',
                 'allowModerationSpecificCreatorFor' . $this->objectTypeCapital,
                 false
             ),
-            'allow_moderation_specific_creation_date' => (bool)$this->variableApi->get(
+            'allow_moderation_specific_creation_date' => (bool) $this->variableApi->get(
                 'ZikulaRoutesModule',
                 'allowModerationSpecificCreationDateFor' . $this->objectTypeCapital,
                 false

--- a/src/system/RoutesModule/Form/Handler/Route/EditHandler.php
+++ b/src/system/RoutesModule/Form/Handler/Route/EditHandler.php
@@ -70,8 +70,8 @@ class EditHandler extends AbstractEditHandler
     {
         $entity = $this->entityRef;
 
-        list($controller,) = $this->sanitizeHelper->sanitizeController((string)$entity['controller']);
-        list($action,) = $this->sanitizeHelper->sanitizeAction((string)$entity['action']);
+        list($controller,) = $this->sanitizeHelper->sanitizeController((string) $entity['controller']);
+        list($action,) = $this->sanitizeHelper->sanitizeAction((string) $entity['action']);
 
         $entity['controller'] = $controller;
         $entity['action'] = $action;

--- a/src/system/RoutesModule/Helper/Base/AbstractCollectionFilterHelper.php
+++ b/src/system/RoutesModule/Helper/Base/AbstractCollectionFilterHelper.php
@@ -55,7 +55,7 @@ abstract class AbstractCollectionFilterHelper
         $this->requestStack = $requestStack;
         $this->permissionHelper = $permissionHelper;
         $this->currentUserApi = $currentUserApi;
-        $this->showOnlyOwnEntries = (bool)$variableApi->get('ZikulaRoutesModule', 'showOnlyOwnEntries');
+        $this->showOnlyOwnEntries = (bool) $variableApi->get('ZikulaRoutesModule', 'showOnlyOwnEntries');
     }
     
     /**
@@ -157,7 +157,7 @@ abstract class AbstractCollectionFilterHelper
     
             // field filter
             if ((!is_numeric($v) && '' !== $v) || (is_numeric($v) && 0 < $v)) {
-                $v = (string)$v;
+                $v = (string) $v;
                 if ('workflowState' === $k && 0 === strpos($v, '!')) {
                     $qb->andWhere('tbl.' . $k . ' != :' . $k)
                        ->setParameter($k, substr($v, 1));
@@ -188,7 +188,7 @@ abstract class AbstractCollectionFilterHelper
             return $qb;
         }
     
-        $showOnlyOwnEntries = (bool)$request->query->getInt('own', (int) $this->showOnlyOwnEntries);
+        $showOnlyOwnEntries = (bool) $request->query->getInt('own', (int) $this->showOnlyOwnEntries);
         if ($showOnlyOwnEntries) {
             $qb = $this->addCreatorFilter($qb);
         }
@@ -264,7 +264,7 @@ abstract class AbstractCollectionFilterHelper
     {
         if (null === $userId) {
             $userId = $this->currentUserApi->isLoggedIn()
-                ? (int)$this->currentUserApi->get('uid')
+                ? (int) $this->currentUserApi->get('uid')
                 : UsersConstant::USER_ID_ANONYMOUS
             ;
         }

--- a/src/system/RoutesModule/Helper/Base/AbstractControllerHelper.php
+++ b/src/system/RoutesModule/Helper/Base/AbstractControllerHelper.php
@@ -138,7 +138,7 @@ abstract class AbstractControllerHelper
         $templateParameters['sortdir'] = strtolower($sortdir);
     
         $templateParameters['all'] = 'csv' === $request->getRequestFormat() ? 1 : $request->query->getInt('all');
-        $showOnlyOwnEntriesSetting = (bool)$request->query->getInt(
+        $showOnlyOwnEntriesSetting = (bool) $request->query->getInt(
             'own',
             (int) $this->variableApi->get('ZikulaRoutesModule', 'showOnlyOwnEntries')
         );

--- a/src/system/RoutesModule/Helper/Base/AbstractPermissionHelper.php
+++ b/src/system/RoutesModule/Helper/Base/AbstractPermissionHelper.php
@@ -178,7 +178,7 @@ abstract class AbstractPermissionHelper
      */
     public function getUserId(): int
     {
-        return (int)$this->currentUserApi->get('uid');
+        return (int) $this->currentUserApi->get('uid');
     }
     
     /**

--- a/src/system/RoutesModule/Helper/RouteDumperHelper.php
+++ b/src/system/RoutesModule/Helper/RouteDumperHelper.php
@@ -83,7 +83,7 @@ class RouteDumperHelper
             // use provided lang if available
             $langs = [$lang];
         } else {
-            $multilingual = (bool)$this->variableApi->getSystemVar('multilingual');
+            $multilingual = (bool) $this->variableApi->getSystemVar('multilingual');
             if ($multilingual) {
                 // get all available locales
                 $langs = $installedLanguages;

--- a/src/system/RoutesModule/Helper/SanitizeHelper.php
+++ b/src/system/RoutesModule/Helper/SanitizeHelper.php
@@ -13,25 +13,23 @@ declare(strict_types=1);
 
 namespace Zikula\RoutesModule\Helper;
 
+use function Symfony\Component\String\s;
+
 /**
  * Helper class for sanitizing route properties.
  */
 class SanitizeHelper
 {
+    const SUFFIX_CONTROLLER = 'Controller';
+    const SUFFIX_ACTION = 'Action';
+
     /**
      * Sanitizes the controller / type parameter.
      */
     public function sanitizeController(string $controllerName): array
     {
-        if ('Controller' !== substr($controllerName, -10)) {
-            $type = $controllerName;
-            $controllerName .= 'Controller';
-        } else {
-            $type = substr($controllerName, 0, -10);
-        }
-
-        $type = strtolower($type);
-        $controllerName = ucfirst($controllerName);
+        $controller = ucfirst((string) s($controllerName)->ensureEnd(self::SUFFIX_CONTROLLER));
+        $type = (string) s($controllerName)->trimEnd(self::SUFFIX_CONTROLLER)->lower();
 
         return [$controllerName, $type];
     }
@@ -41,12 +39,8 @@ class SanitizeHelper
      */
     public function sanitizeAction(string $methodName): array
     {
-        if ('Action' !== substr($methodName, -6)) {
-            $methodName .= 'Action';
-        }
-
-        $methodName = ucfirst($methodName);
-        $func = lcfirst(substr($methodName, 0, -6));
+        $methodName = ucfirst((string) s($methodName)->ensureEnd(self::SUFFIX_ACTION));
+        $func = lcfirst((string) s($methodName)->trimEnd(self::SUFFIX_ACTION));
 
         return [$methodName, $func];
     }

--- a/src/system/RoutesModule/Helper/SanitizeHelper.php
+++ b/src/system/RoutesModule/Helper/SanitizeHelper.php
@@ -31,7 +31,7 @@ class SanitizeHelper
         $controller = ucfirst((string) s($controllerName)->ensureEnd(self::SUFFIX_CONTROLLER));
         $type = (string) s($controllerName)->trimEnd(self::SUFFIX_CONTROLLER)->lower();
 
-        return [$controllerName, $type];
+        return [$controller, $type];
     }
 
     /**

--- a/src/system/RoutesModule/Helper/SanitizeHelper.php
+++ b/src/system/RoutesModule/Helper/SanitizeHelper.php
@@ -28,8 +28,8 @@ class SanitizeHelper
      */
     public function sanitizeController(string $controllerName): array
     {
-        $controller = ucfirst(s($controllerName)->ensureEnd(self::SUFFIX_CONTROLLER)->__toString());
-        $type = s($controllerName)->trimEnd(self::SUFFIX_CONTROLLER)->lower()->__toString();
+        $controller = ucfirst(s($controllerName)->ensureEnd(self::SUFFIX_CONTROLLER)->toString());
+        $type = s($controllerName)->trimEnd(self::SUFFIX_CONTROLLER)->lower()->toString();
 
         return [$controller, $type];
     }
@@ -39,8 +39,8 @@ class SanitizeHelper
      */
     public function sanitizeAction(string $methodName): array
     {
-        $methodName = ucfirst(s($methodName)->ensureEnd(self::SUFFIX_ACTION)->__toString());
-        $func = lcfirst(s($methodName)->trimEnd(self::SUFFIX_ACTION)->__toString());
+        $methodName = ucfirst(s($methodName)->ensureEnd(self::SUFFIX_ACTION)->toString());
+        $func = lcfirst(s($methodName)->trimEnd(self::SUFFIX_ACTION)->toString());
 
         return [$methodName, $func];
     }

--- a/src/system/RoutesModule/Helper/SanitizeHelper.php
+++ b/src/system/RoutesModule/Helper/SanitizeHelper.php
@@ -28,8 +28,8 @@ class SanitizeHelper
      */
     public function sanitizeController(string $controllerName): array
     {
-        $controller = ucfirst((string) s($controllerName)->ensureEnd(self::SUFFIX_CONTROLLER));
-        $type = (string) s($controllerName)->trimEnd(self::SUFFIX_CONTROLLER)->lower();
+        $controller = ucfirst(s($controllerName)->ensureEnd(self::SUFFIX_CONTROLLER)->__toString());
+        $type = s($controllerName)->trimEnd(self::SUFFIX_CONTROLLER)->lower()->__toString();
 
         return [$controller, $type];
     }
@@ -39,8 +39,8 @@ class SanitizeHelper
      */
     public function sanitizeAction(string $methodName): array
     {
-        $methodName = ucfirst((string) s($methodName)->ensureEnd(self::SUFFIX_ACTION));
-        $func = lcfirst((string) s($methodName)->trimEnd(self::SUFFIX_ACTION));
+        $methodName = ucfirst(s($methodName)->ensureEnd(self::SUFFIX_ACTION)->__toString());
+        $func = lcfirst(s($methodName)->trimEnd(self::SUFFIX_ACTION)->__toString());
 
         return [$methodName, $func];
     }

--- a/src/system/RoutesModule/Routing/RouteLoader.php
+++ b/src/system/RoutesModule/Routing/RouteLoader.php
@@ -359,7 +359,7 @@ class RouteLoader extends Loader
             }
         }
 
-        return s($extensionName . $separator . $type . $separator . $func)->lower()->append($suffix)->__toString();
+        return s($extensionName . $separator . $type . $separator . $func)->lower()->append($suffix)->toString();
     }
 
     /**

--- a/src/system/RoutesModule/Routing/RouteLoader.php
+++ b/src/system/RoutesModule/Routing/RouteLoader.php
@@ -359,7 +359,7 @@ class RouteLoader extends Loader
             }
         }
 
-        return (string)s($extensionName . $separator . $type . $separator . $func)->lower() . $suffix;
+        return s($extensionName . $separator . $type . $separator . $func)->lower()->append($suffix)->__toString();
     }
 
     /**

--- a/src/system/RoutesModule/Routing/RouteLoader.php
+++ b/src/system/RoutesModule/Routing/RouteLoader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Zikula\RoutesModule\Routing;
 
 use Exception;
+use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\Config\Loader\Loader;
@@ -346,18 +347,19 @@ class RouteLoader extends Loader
      */
     private function getRouteName(string $oldRouteName, string $extensionName, string $type, string $func): string
     {
+        $separator = '_';
         $suffix = '';
-        $lastHit = strrpos($oldRouteName, '_');
-        if (false !== $lastHit) {
-            $lastPart = substr($oldRouteName, $lastHit);
+        $lastHit = s($oldRouteName)->indexOfLast($separator);
+        if (null !== $lastHit) {
+            $lastPart = s($oldRouteName)->afterLast($separator);
             if (is_numeric($lastPart)) {
                 // If the last part of the old route name is numeric, also append it to the new route name.
                 // This allows multiple routes for the same action.
-                $suffix = '_' . $lastPart;
+                $suffix = $separator . $lastPart;
             }
         }
 
-        return strtolower($extensionName . '_' . $type . '_' . $func) . $suffix;
+        return (string)s($extensionName . $separator . $type . $separator . $func)->lower() . $suffix;
     }
 
     /**

--- a/src/system/RoutesModule/Translation/ConsoleCommandListener.php
+++ b/src/system/RoutesModule/Translation/ConsoleCommandListener.php
@@ -58,7 +58,7 @@ class ConsoleCommandListener implements EventSubscriberInterface
         }
 
         if (null !== $bundle) {
-            $bundle = (string)s($bundle)->trimStart('@');
+            $bundle = s($bundle)->trimStart('@')->__toString();
 
             $this->extractTranslationHelper->setExtensionName($bundle);
         }

--- a/src/system/RoutesModule/Translation/ConsoleCommandListener.php
+++ b/src/system/RoutesModule/Translation/ConsoleCommandListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\RoutesModule\Translation;
 
+use function Symfony\Component\String\s;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -57,9 +58,7 @@ class ConsoleCommandListener implements EventSubscriberInterface
         }
 
         if (null !== $bundle) {
-            if ('@' === $bundle[0]) {
-                $bundle = substr($bundle, 1);
-            }
+            $bundle = (string)s($bundle)->trimStart('@');
 
             $this->extractTranslationHelper->setExtensionName($bundle);
         }

--- a/src/system/RoutesModule/Translation/ConsoleCommandListener.php
+++ b/src/system/RoutesModule/Translation/ConsoleCommandListener.php
@@ -58,7 +58,7 @@ class ConsoleCommandListener implements EventSubscriberInterface
         }
 
         if (null !== $bundle) {
-            $bundle = s($bundle)->trimStart('@')->__toString();
+            $bundle = s($bundle)->trimStart('@')->toString();
 
             $this->extractTranslationHelper->setExtensionName($bundle);
         }

--- a/src/system/SearchModule/Block/SearchBlock.php
+++ b/src/system/SearchModule/Block/SearchBlock.php
@@ -106,7 +106,7 @@ class SearchBlock extends AbstractBlockHandler
         }
         // remove disabled
         foreach ($searchModules as $displayName => $moduleName) {
-            if ((bool)$this->getVar('disable_' . $moduleName)) {
+            if ((bool) $this->getVar('disable_' . $moduleName)) {
                 unset($searchModules[$displayName]);
             }
         }

--- a/src/system/SearchModule/Entity/Repository/SearchStatRepository.php
+++ b/src/system/SearchModule/Entity/Repository/SearchStatRepository.php
@@ -35,7 +35,7 @@ class SearchStatRepository extends ServiceEntityRepository implements SearchStat
 
         $query = $qb->getQuery();
 
-        return (int)$query->getSingleScalarResult();
+        return (int) $query->getSingleScalarResult();
     }
 
     public function getStats(array $filters = [], array $sorting = [], int $page = 1, int $pageSize = 25): PaginatorInterface

--- a/src/system/SecurityCenterModule/Controller/ConfigController.php
+++ b/src/system/SecurityCenterModule/Controller/ConfigController.php
@@ -126,7 +126,7 @@ class ConfigController extends AbstractController
                     $variableApi->set(VariableApi::CONFIG, 'sessionsavepath', $sessionSavePath);
                 }
 
-                if ((bool)$sessionStoreToFile !== (bool)$variableApi->getSystemVar('sessionstoretofile')) {
+                if ((bool) $sessionStoreToFile !== (bool) $variableApi->getSystemVar('sessionstoretofile')) {
                     // logout if going from one storage to another one
                     $causeLogout = true;
                 }

--- a/src/system/SecurityCenterModule/Controller/IdsLogController.php
+++ b/src/system/SecurityCenterModule/Controller/IdsLogController.php
@@ -87,7 +87,7 @@ class IdsLogController extends AbstractController
         $hasFilters = 0 < count($where);
 
         // number of items to show
-        $pageSize = (int)$this->getVar('pagesize', 25);
+        $pageSize = (int) $this->getVar('pagesize', 25);
 
         // get data
         $paginator = $repository->getIntrusions($where, $sorting, $page, $pageSize);

--- a/src/system/SecurityCenterModule/Helper/CacheDirHelper.php
+++ b/src/system/SecurityCenterModule/Helper/CacheDirHelper.php
@@ -58,7 +58,7 @@ class CacheDirHelper
                     // this uses always a fixed environment (e.g. "prod") that is serialized
                     // in purifier configuration
                     // so ensure the main directory exists even if another environment is currently used
-                    $parentDirectory = s($cacheDirectory)->slice(0, -9)->__toString();
+                    $parentDirectory = s($cacheDirectory)->slice(0, -9)->toString();
                     if (!$fs->exists($parentDirectory)) {
                         $fs->mkdir($parentDirectory);
                     }

--- a/src/system/SecurityCenterModule/Helper/CacheDirHelper.php
+++ b/src/system/SecurityCenterModule/Helper/CacheDirHelper.php
@@ -58,7 +58,7 @@ class CacheDirHelper
                     // this uses always a fixed environment (e.g. "prod") that is serialized
                     // in purifier configuration
                     // so ensure the main directory exists even if another environment is currently used
-                    $parentDirectory = (string)s($cacheDirectory)->slice(0, -9);
+                    $parentDirectory = s($cacheDirectory)->slice(0, -9)->__toString();
                     if (!$fs->exists($parentDirectory)) {
                         $fs->mkdir($parentDirectory);
                     }

--- a/src/system/SecurityCenterModule/Helper/CacheDirHelper.php
+++ b/src/system/SecurityCenterModule/Helper/CacheDirHelper.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Zikula\SecurityCenterModule\Helper;
 
-use function Symfony\Component\String\s;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use function Symfony\Component\String\s;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CacheDirHelper

--- a/src/system/SecurityCenterModule/Helper/CacheDirHelper.php
+++ b/src/system/SecurityCenterModule/Helper/CacheDirHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\SecurityCenterModule\Helper;
 
+use function Symfony\Component\String\s;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -57,7 +58,7 @@ class CacheDirHelper
                     // this uses always a fixed environment (e.g. "prod") that is serialized
                     // in purifier configuration
                     // so ensure the main directory exists even if another environment is currently used
-                    $parentDirectory = mb_substr($cacheDirectory, 0, -9);
+                    $parentDirectory = (string)s($cacheDirectory)->slice(0, -9);
                     if (!$fs->exists($parentDirectory)) {
                         $fs->mkdir($parentDirectory);
                     }

--- a/src/system/SettingsModule/Controller/SettingsController.php
+++ b/src/system/SettingsModule/Controller/SettingsController.php
@@ -58,7 +58,7 @@ class SettingsController extends AbstractController
         $messageModules = $messageModuleCollector->getKeys();
 
         $variables = $variableApi->getAll(VariableApi::CONFIG);
-        $variables['UseCompression'] = (bool)$variables['UseCompression'];
+        $variables['UseCompression'] = (bool) $variables['UseCompression'];
         $form = $this->createForm(
             MainSettingsType::class,
             $variables,
@@ -108,9 +108,9 @@ class SettingsController extends AbstractController
         $form = $this->createForm(
             LocaleSettingsType::class,
             [
-                'multilingual' => (bool)$variableApi->getSystemVar('multilingual'),
+                'multilingual' => (bool) $variableApi->getSystemVar('multilingual'),
                 'languageurl' => $variableApi->getSystemVar('languageurl'),
-                'language_detect' => (bool)$variableApi->getSystemVar('language_detect'),
+                'language_detect' => (bool) $variableApi->getSystemVar('language_detect'),
                 'locale' => $variableApi->getSystemVar('locale'),
                 'timezone' => $variableApi->getSystemVar('timezone'),
             ],

--- a/src/system/SettingsModule/Listener/TranslationUiListener.php
+++ b/src/system/SettingsModule/Listener/TranslationUiListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\SettingsModule\Listener;
 
+use function Symfony\Component\String\s;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -64,7 +65,10 @@ class TranslationUiListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
         $routeName = $request->get('_route', '');
-        if ('translation_edit_in_place_update' !== $routeName && 'translation_' !== mb_substr($routeName, 0, 12)) {
+        if (
+            'translation_edit_in_place_update' !== $routeName
+            && !s($routeName)->startsWith('translation_')
+        ) {
             return;
         }
 

--- a/src/system/SettingsModule/Listener/TranslationUiListener.php
+++ b/src/system/SettingsModule/Listener/TranslationUiListener.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Zikula\SettingsModule\Listener;
 
-use function Symfony\Component\String\s;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use function Symfony\Component\String\s;
 use Translation\Bundle\EditInPlace\Activator as EditInPlaceActivator;
 use Zikula\PermissionsModule\Api\ApiInterface\PermissionApiInterface;
 use Zikula\SettingsModule\Api\ApiInterface\LocaleApiInterface;

--- a/src/system/SettingsModule/Menu/ExtensionMenu.php
+++ b/src/system/SettingsModule/Menu/ExtensionMenu.php
@@ -94,7 +94,7 @@ class ExtensionMenu implements ExtensionMenuInterface
             'route' => 'zikulasettingsmodule_settings_localesettings',
         ])->setAttribute('icon', 'fas fa-spell-check');
 
-        if (true === (bool)$this->variableApi->getSystemVar('multilingual')) {
+        if (true === (bool) $this->variableApi->getSystemVar('multilingual')) {
             if ('dev' === $this->kernel->getEnvironment()) {
                 $request = $this->requestStack->getCurrentRequest();
                 if ($request->hasSession() && ($session = $request->getSession())) {

--- a/src/system/SettingsModule/SettingsModuleInstaller.php
+++ b/src/system/SettingsModule/SettingsModuleInstaller.php
@@ -93,7 +93,7 @@ class SettingsModuleInstaller extends AbstractExtensionInstaller
     {
         switch ($oldVersion) {
             case '2.9.11': // shipped with Core-1.4.3
-                $this->setSystemVar('UseCompression', (bool)$this->getSystemVar('UseCompression'));
+                $this->setSystemVar('UseCompression', (bool) $this->getSystemVar('UseCompression'));
                 // no break
             case '2.9.12': // shipped with Core-1.4.4
                 // reconfigure TZ settings

--- a/src/system/ThemeModule/Engine/Asset.php
+++ b/src/system/ThemeModule/Engine/Asset.php
@@ -93,16 +93,16 @@ class Asset
         $path = s($path);
         if (!$path->startsWith('@')) {
             $path = $path->trimStart('/');
-            $publicPath = $this->assetPackages->getUrl($path->__toString());
+            $publicPath = $this->assetPackages->getUrl($path->toString());
             if (false !== realpath($httpRootDir . $publicPath)) {
                 return $publicPath;
             }
             throw new AssetNotFoundException(sprintf('Could not find asset "%s"', $httpRootDir . $publicPath));
         }
 
-        [$bundleName, $relativeAssetPath] = explode(':', $path->__toString());
+        [$bundleName, $relativeAssetPath] = explode(':', $path->toString());
 
-        $bundleNameForAssetPath = s($bundleName)->trimStart('@')->lower()->__toString();
+        $bundleNameForAssetPath = s($bundleName)->trimStart('@')->lower()->toString();
         $bundleAssetPath = $this->getBundleAssetPath($bundleName);
         $themeName = $this->themeEngine->getTheme()->getName();
 
@@ -142,7 +142,7 @@ class Asset
         if (!isset($bundleName)) {
             throw new InvalidArgumentException('No bundle name resolved, must be like "@AcmeBundle"');
         }
-        $bundle = $this->kernel->getBundle(s($bundleName)->trimStart('@')->__toString());
+        $bundle = $this->kernel->getBundle(s($bundleName)->trimStart('@')->toString());
         if (!$bundle instanceof Bundle) {
             throw new InvalidArgumentException('Bundle ' . $bundleName . ' not found.');
         }

--- a/src/system/ThemeModule/Engine/Asset.php
+++ b/src/system/ThemeModule/Engine/Asset.php
@@ -93,16 +93,16 @@ class Asset
         $path = s($path);
         if (!$path->startsWith('@')) {
             $path = $path->trimStart('/');
-            $publicPath = $this->assetPackages->getUrl((string)$path);
+            $publicPath = $this->assetPackages->getUrl((string) $path);
             if (false !== realpath($httpRootDir . $publicPath)) {
                 return $publicPath;
             }
             throw new AssetNotFoundException(sprintf('Could not find asset "%s"', $httpRootDir . $publicPath));
         }
 
-        [$bundleName, $relativeAssetPath] = explode(':', (string)$path);
+        [$bundleName, $relativeAssetPath] = explode(':', (string) $path);
 
-        $bundleNameForAssetPath = (string)s($bundleName)->trimStart('@')->lower();
+        $bundleNameForAssetPath = (string) s($bundleName)->trimStart('@')->lower();
         $bundleAssetPath = $this->getBundleAssetPath($bundleName);
         $themeName = $this->themeEngine->getTheme()->getName();
 
@@ -142,7 +142,7 @@ class Asset
         if (!isset($bundleName)) {
             throw new InvalidArgumentException('No bundle name resolved, must be like "@AcmeBundle"');
         }
-        $bundle = $this->kernel->getBundle((string)s($bundleName)->trimStart('@'));
+        $bundle = $this->kernel->getBundle((string) s($bundleName)->trimStart('@'));
         if (!$bundle instanceof Bundle) {
             throw new InvalidArgumentException('Bundle ' . $bundleName . ' not found.');
         }

--- a/src/system/ThemeModule/Engine/Asset.php
+++ b/src/system/ThemeModule/Engine/Asset.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ThemeModule\Engine;
 
+use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Filesystem\Filesystem;
@@ -89,20 +90,19 @@ class Asset
         $httpRootDir = str_replace($basePath, '', $publicDir);
 
         // return immediately for straight asset paths
-        if ('@' !== $path[0]) {
-            if (0 === mb_strpos($path, '/')) {
-                $path = mb_substr($path, 1);
-            }
-            $publicPath = $this->assetPackages->getUrl($path);
+        $path = s($path);
+        if (!$path->startsWith('@')) {
+            $path = $path->trimStart('/');
+            $publicPath = $this->assetPackages->getUrl((string)$path);
             if (false !== realpath($httpRootDir . $publicPath)) {
                 return $publicPath;
             }
             throw new AssetNotFoundException(sprintf('Could not find asset "%s"', $httpRootDir . $publicPath));
         }
 
-        [$bundleName, $relativeAssetPath] = explode(':', $path);
+        [$bundleName, $relativeAssetPath] = explode(':', (string)$path);
 
-        $bundleNameForAssetPath = mb_strtolower(mb_substr($bundleName, 1));
+        $bundleNameForAssetPath = (string)s($bundleName)->trimStart('@')->lower();
         $bundleAssetPath = $this->getBundleAssetPath($bundleName);
         $themeName = $this->themeEngine->getTheme()->getName();
 
@@ -142,7 +142,7 @@ class Asset
         if (!isset($bundleName)) {
             throw new InvalidArgumentException('No bundle name resolved, must be like "@AcmeBundle"');
         }
-        $bundle = $this->kernel->getBundle(mb_substr($bundleName, 1));
+        $bundle = $this->kernel->getBundle((string)s($bundleName)->trimStart('@'));
         if (!$bundle instanceof Bundle) {
             throw new InvalidArgumentException('Bundle ' . $bundleName . ' not found.');
         }
@@ -151,6 +151,6 @@ class Asset
             return $bundle->getRelativeAssetPath();
         }
 
-        return 'bundles/' . mb_strtolower(mb_substr($bundle->getName(), 0, -mb_strlen('bundle')));
+        return 'bundles/' . s($bundle->getName())->lower()->trimEnd('bundle');
     }
 }

--- a/src/system/ThemeModule/Engine/Asset.php
+++ b/src/system/ThemeModule/Engine/Asset.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Zikula\ThemeModule\Engine;
 
-use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\Routing\RouterInterface;
+use function Symfony\Component\String\s;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\ExtensionsModule\AbstractExtension;
 use Zikula\ThemeModule\Engine\Exception\AssetNotFoundException;

--- a/src/system/ThemeModule/Engine/Asset.php
+++ b/src/system/ThemeModule/Engine/Asset.php
@@ -93,16 +93,16 @@ class Asset
         $path = s($path);
         if (!$path->startsWith('@')) {
             $path = $path->trimStart('/');
-            $publicPath = $this->assetPackages->getUrl((string) $path);
+            $publicPath = $this->assetPackages->getUrl($path->__toString());
             if (false !== realpath($httpRootDir . $publicPath)) {
                 return $publicPath;
             }
             throw new AssetNotFoundException(sprintf('Could not find asset "%s"', $httpRootDir . $publicPath));
         }
 
-        [$bundleName, $relativeAssetPath] = explode(':', (string) $path);
+        [$bundleName, $relativeAssetPath] = explode(':', $path->__toString());
 
-        $bundleNameForAssetPath = (string) s($bundleName)->trimStart('@')->lower();
+        $bundleNameForAssetPath = s($bundleName)->trimStart('@')->lower()->__toString();
         $bundleAssetPath = $this->getBundleAssetPath($bundleName);
         $themeName = $this->themeEngine->getTheme()->getName();
 
@@ -142,7 +142,7 @@ class Asset
         if (!isset($bundleName)) {
             throw new InvalidArgumentException('No bundle name resolved, must be like "@AcmeBundle"');
         }
-        $bundle = $this->kernel->getBundle((string) s($bundleName)->trimStart('@'));
+        $bundle = $this->kernel->getBundle(s($bundleName)->trimStart('@')->__toString());
         if (!$bundle instanceof Bundle) {
             throw new InvalidArgumentException('Bundle ' . $bundleName . ' not found.');
         }

--- a/src/system/ThemeModule/Engine/Asset/JsResolver.php
+++ b/src/system/ThemeModule/Engine/Asset/JsResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ThemeModule\Engine\Asset;
 
+use function Symfony\Component\String\s;
 use Zikula\ThemeModule\Engine\AssetBag;
 
 /**
@@ -73,8 +74,9 @@ class JsResolver implements ResolverInterface
         foreach ($this->getBag()->all() as $source) {
             // if already there, add jquery-ui again to force weight setting is correct
             // jQueryUI must be loaded before Bootstrap, refs #3912
-            if ('jquery-ui.min.js' === mb_substr($source, -16)
-                || 'jquery-ui.js' === mb_substr($source, -12)
+            if (
+                s($source)->endsWith('jquery-ui.min.js')
+                || s($source)->endsWith('jquery-ui.js')
             ) {
                 $this->bag->add([$source => AssetBag::WEIGHT_JQUERY_UI]);
             }

--- a/src/system/ThemeModule/Engine/Asset/Merger.php
+++ b/src/system/ThemeModule/Engine/Asset/Merger.php
@@ -166,7 +166,7 @@ class Merger implements MergerInterface
         while (!feof($source)) {
             if ('css' === $ext) {
                 $line = fgets($source, 4096);
-                $lineParse = (string)s(false !== $line ? trim($line) : '');
+                $lineParse = s(false !== $line ? trim($line) : '')->__toString();
                 $lineParseLength = mb_strlen($lineParse, 'UTF-8');
                 $newLine = '';
                 // parse line char by char

--- a/src/system/ThemeModule/Engine/Asset/Merger.php
+++ b/src/system/ThemeModule/Engine/Asset/Merger.php
@@ -166,7 +166,7 @@ class Merger implements MergerInterface
         while (!feof($source)) {
             if ('css' === $ext) {
                 $line = fgets($source, 4096);
-                $lineParse = s(false !== $line ? trim($line) : '')->__toString();
+                $lineParse = s(false !== $line ? trim($line) : '')->toString();
                 $lineParseLength = mb_strlen($lineParse, 'UTF-8');
                 $newLine = '';
                 // parse line char by char

--- a/src/system/ThemeModule/Engine/Asset/Merger.php
+++ b/src/system/ThemeModule/Engine/Asset/Merger.php
@@ -114,7 +114,7 @@ class Merger implements MergerInterface
             $this->lifetime,
             $this->kernel->getCacheDir() . '/assets/' . $type
         );
-        $key = md5(serialize($assets)) . (int)$this->minify . (int)$this->compress . $this->lifetime . '.combined.' . $type;
+        $key = md5(serialize($assets)) . (int) $this->minify . (int) $this->compress . $this->lifetime . '.combined.' . $type;
         $cacheService->get($key, function() use ($cachedFiles, $type) {
             $data = [];
             foreach ($cachedFiles as $k => $file) {

--- a/src/system/ThemeModule/Engine/Asset/Merger.php
+++ b/src/system/ThemeModule/Engine/Asset/Merger.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Zikula\ThemeModule\Engine\Asset;
 
 use DateTime;
+use function Symfony\Component\String\s;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Routing\RouterInterface;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
@@ -96,13 +97,13 @@ class Merger implements MergerInterface
                 false !== $path
                 && is_file($path)
                 && !in_array($asset, $this->skipFiles)
-                && false === mb_strpos($asset, '/public/bootswatch')
+                && null === s($asset)->indexOf('/public/bootswatch')
                 && !in_array($weight, [AssetBag::WEIGHT_ROUTER_JS, AssetBag::WEIGHT_ROUTES_JS])
             ) {
                 $cachedFiles[] = $path;
-            } elseif ($weight < 0) {
+            } elseif (0 > $weight) {
                 $preCachedFiles[$asset] = $weight;
-            } elseif ($weight > AssetBag::WEIGHT_DEFAULT) {
+            } elseif (AssetBag::WEIGHT_DEFAULT < $weight) {
                 $postCachedFiles[$asset] = $weight;
             } else {
                 $outputFiles[$asset] = $weight;
@@ -165,13 +166,13 @@ class Merger implements MergerInterface
         while (!feof($source)) {
             if ('css' === $ext) {
                 $line = fgets($source, 4096);
-                $lineParse = false !== $line ? trim($line) : '';
-                $lineParse_length = mb_strlen($lineParse, 'UTF-8');
+                $lineParse = (string)s(false !== $line ? trim($line) : '');
+                $lineParseLength = mb_strlen($lineParse, 'UTF-8');
                 $newLine = '';
                 // parse line char by char
-                for ($i = 0; $i < $lineParse_length; $i++) {
+                for ($i = 0; $i < $lineParseLength; $i++) {
                     $char = $lineParse[$i];
-                    $nextchar = $i < ($lineParse_length - 1) ? $lineParse[$i + 1] : '';
+                    $nextchar = $i < ($lineParseLength - 1) ? $lineParse[$i + 1] : '';
                     if (!$inMultilineComment && '/' === $char && '*' === $nextchar) {
                         // a multiline comment starts here
                         $inMultilineComment = true;
@@ -182,29 +183,27 @@ class Merger implements MergerInterface
                         // a multiline comment stops here
                         $inMultilineComment = false;
                         $newLine .= $char . $nextchar;
-                        if ('/*\*//*/' === mb_substr($lineParse, $i - 3, 8)) {
+                        if ('/*\*//*/' === s($lineParse)->slice($i - 3, 8)) {
                             $wasCommentHack = true;
                             $i += 3; // move to end of hack process hack as it where
                             $newLine .= '/*/'; // fix hack comment because we lost some chars with $i += 3
                         }
                         $i++;
-                    } elseif ($importsAllowed && '@' === $char && '@import' === mb_substr($lineParse, $i, 7)) {
+                    } elseif ($importsAllowed && '@' === $char && '@import' === s($lineParse)->slice($i, 7)) {
                         // an @import starts here
-                        $lineParseRest = trim(mb_substr($lineParse, $i + 7));
-                        if (0 === mb_stripos($lineParseRest, 'url')) {
+                        $lineParseRest = s($lineParse)->slice($i + 7)->trim();
+                        if ($lineParseRest->ignoreCase()->startsWith('url')) {
                             // the @import uses url to specify the path
-                            $posEnd = mb_strpos($lineParse, ';', $i);
-                            $charsEnd = mb_substr($lineParse, $posEnd - 1, 2);
+                            $posEnd = s($lineParse)->indexOf(';', $i);
+                            $charsEnd = s($lineParse)->slice($posEnd - 1, 2);
                             if (');' === $charsEnd) {
                                 // used url() without media
-                                $start = mb_strpos($lineParseRest, '(') + 1;
-                                $end = mb_strpos($lineParseRest, ')');
-                                $url = mb_substr($lineParseRest, $start, $end - $start);
-                                if (0 === mb_strpos($url, '"')) {
-                                    $url = mb_substr($url, 1, -1);
-                                }
+                                $start = $lineParseRest->indexOf('(') + 1;
+                                $end = $lineParseRest->indexOf(')');
+                                $url = $lineParseRest->slice($start, $end - $start);
+                                $url = $url->trimStart('"')->trimStart('"');
                                 // fix url
-                                if ('http' === mb_substr($url, 0, 4)) {
+                                if ($url->startsWith('http')) {
                                     $newLine .= '@import url("' . $url . '");';
                                 } else {
                                     $url = dirname($file) . '/' . $url;
@@ -223,24 +222,22 @@ class Merger implements MergerInterface
                             } else {
                                 // @import contains media type so we can't include its contents.
                                 // We need to fix the url instead.
-                                $start = mb_strpos($lineParseRest, '(') + 1;
-                                $end = mb_strpos($lineParseRest, ')');
-                                $url = mb_substr($lineParseRest, $start, $end - $start);
-                                if (0 === mb_strpos($url, '"') | 0 === mb_strpos($url, "'")) {
-                                    $url = mb_substr($url, 1, -1);
-                                }
+                                $start = $lineParseRest->indexOf('(') + 1;
+                                $end = $lineParseRest->indexOf(')');
+                                $url = $lineParseRest->slice($start, $end - $start);
+                                $url = $url->trimStart('"')->trimStart('"');
                                 // fix url
                                 $url = dirname($file) . '/' . $url;
                                 // readd @import with fixed url
-                                $newLine .= '@import url("' . $url . '")' . mb_substr($lineParseRest, $end + 1, mb_strpos($lineParseRest, ';') - $end - 1) . ';';
+                                $newLine .= '@import url("' . $url . '")' . $lineParseRest->slice($end + 1, $lineParseRest->indexOf(';') - $end - 1) . ';';
                                 // skip @import statement
                                 $i += $posEnd - $i;
                             }
-                        } elseif (0 === mb_strpos($lineParseRest, '"') || 0 === mb_strpos($lineParseRest, '\'')) {
+                        } elseif ($lineParseRest->startsWith('"') || $lineParseRest->startsWith('\'')) {
                             // the @import uses an normal string to specify the path
-                            $posEnd = mb_strpos($lineParseRest, ';');
-                            $url = mb_substr($lineParseRest, 1, $posEnd - 2);
-                            $posEnd = mb_strpos($lineParse, ';', $i);
+                            $posEnd = $lineParseRest->indexOf(';');
+                            $url = $lineParseRest->slice(1, $posEnd - 2);
+                            $posEnd = s($lineParse)->indexOf(';', $i);
                             // fix url
                             $url = dirname($file) . '/' . $url;
                             if (!$wasCommentHack) {

--- a/src/system/ThemeModule/Engine/Asset/Merger.php
+++ b/src/system/ThemeModule/Engine/Asset/Merger.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Zikula\ThemeModule\Engine\Asset;
 
 use DateTime;
-use function Symfony\Component\String\s;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Routing\RouterInterface;
+use function Symfony\Component\String\s;
 use Zikula\Bundle\CoreBundle\HttpKernel\ZikulaHttpKernelInterface;
 use Zikula\ThemeModule\Engine\AssetBag;
 

--- a/src/system/ThemeModule/Engine/ParameterBag.php
+++ b/src/system/ThemeModule/Engine/ParameterBag.php
@@ -15,8 +15,8 @@ namespace Zikula\ThemeModule\Engine;
 
 use ArrayIterator;
 use Countable;
-use function Symfony\Component\String\s;
 use IteratorAggregate;
+use function Symfony\Component\String\s;
 
 /**
  * This class provides an abstracted method of collecting, managing and retrieving variables.

--- a/src/system/ThemeModule/Engine/ParameterBag.php
+++ b/src/system/ThemeModule/Engine/ParameterBag.php
@@ -173,7 +173,7 @@ class ParameterBag implements IteratorAggregate, Countable
     private function &resolvePath(string $key, bool $writeContext = false): array
     {
         $array = &$this->parameters;
-        $key = $this->resolveKey($key);
+        $key = (string)(s($key)->trimStart($this->ns));
 
         // Check if there is anything to do, else return
         if (!$key) {
@@ -214,6 +214,12 @@ class ParameterBag implements IteratorAggregate, Countable
      */
     private function resolveKey(string $key): string
     {
-        return (string)s($key)->trimStart($this->ns);
+        //return (string)s($key)->afterLast($this->ns);
+
+        if (false !== mb_strpos($key, $this->ns)) {
+            $key = mb_substr($key, mb_strrpos($key, $this->ns) + 1, mb_strlen($key));
+        }
+
+        return $key;
     }
 }

--- a/src/system/ThemeModule/Engine/ParameterBag.php
+++ b/src/system/ThemeModule/Engine/ParameterBag.php
@@ -15,6 +15,7 @@ namespace Zikula\ThemeModule\Engine;
 
 use ArrayIterator;
 use Countable;
+use function Symfony\Component\String\s;
 use IteratorAggregate;
 
 /**
@@ -172,7 +173,7 @@ class ParameterBag implements IteratorAggregate, Countable
     private function &resolvePath(string $key, bool $writeContext = false): array
     {
         $array = &$this->parameters;
-        $key = (0 === mb_strpos($key, $this->ns)) ? mb_substr($key, 1) : $key;
+        $key = $this->resolveKey($key);
 
         // Check if there is anything to do, else return
         if (!$key) {
@@ -180,7 +181,7 @@ class ParameterBag implements IteratorAggregate, Countable
         }
 
         $parts = explode($this->ns, $key);
-        if (count($parts) < 2) {
+        if (2 > count($parts)) {
             if (!$writeContext) {
                 return $array;
             }
@@ -213,10 +214,6 @@ class ParameterBag implements IteratorAggregate, Countable
      */
     private function resolveKey(string $key): string
     {
-        if (false !== mb_strpos($key, $this->ns)) {
-            $key = mb_substr($key, mb_strrpos($key, $this->ns) + 1, mb_strlen($key));
-        }
-
-        return $key;
+        return (string)s($key)->trimStart($this->ns);
     }
 }

--- a/src/system/ThemeModule/Engine/ParameterBag.php
+++ b/src/system/ThemeModule/Engine/ParameterBag.php
@@ -173,7 +173,7 @@ class ParameterBag implements IteratorAggregate, Countable
     private function &resolvePath(string $key, bool $writeContext = false): array
     {
         $array = &$this->parameters;
-        $key = s($key)->trimStart($this->ns)->__toString();
+        $key = s($key)->trimStart($this->ns)->toString();
 
         // Check if there is anything to do, else return
         if (!$key) {
@@ -214,7 +214,7 @@ class ParameterBag implements IteratorAggregate, Countable
      */
     private function resolveKey(string $key): string
     {
-        //return s($key)->afterLast($this->ns)->__toString();
+        //return s($key)->afterLast($this->ns)->toString();
 
         if (false !== mb_strpos($key, $this->ns)) {
             $key = mb_substr($key, mb_strrpos($key, $this->ns) + 1, mb_strlen($key));

--- a/src/system/ThemeModule/Engine/ParameterBag.php
+++ b/src/system/ThemeModule/Engine/ParameterBag.php
@@ -173,7 +173,7 @@ class ParameterBag implements IteratorAggregate, Countable
     private function &resolvePath(string $key, bool $writeContext = false): array
     {
         $array = &$this->parameters;
-        $key = (string)(s($key)->trimStart($this->ns));
+        $key = s($key)->trimStart($this->ns)->__toString();
 
         // Check if there is anything to do, else return
         if (!$key) {
@@ -214,7 +214,7 @@ class ParameterBag implements IteratorAggregate, Countable
      */
     private function resolveKey(string $key): string
     {
-        //return (string)s($key)->afterLast($this->ns);
+        //return s($key)->afterLast($this->ns)->__toString();
 
         if (false !== mb_strpos($key, $this->ns)) {
             $key = mb_substr($key, mb_strrpos($key, $this->ns) + 1, mb_strlen($key));

--- a/src/system/ThemeModule/EventListener/AddJSConfigListener.php
+++ b/src/system/ThemeModule/EventListener/AddJSConfigListener.php
@@ -97,10 +97,10 @@ class AddJSConfigListener implements EventSubscriberInterface
             'entrypoint' => ZikulaKernel::FRONT_CONTROLLER,
             'baseURL' => $event->getRequest()->getSchemeAndHttpHost() . '/',
             'baseURI' => $event->getRequest()->getBasePath(),
-            'ajaxtimeout' => (int)$this->variableApi->getSystemVar('ajaxtimeout', 5000),
+            'ajaxtimeout' => (int) $this->variableApi->getSystemVar('ajaxtimeout', 5000),
             'lang' => $event->getRequest()->getLocale(),
             'sessionName' => isset($session) ? $session->getName() : $this->defaultSessionName,
-            'uid' => (int)$this->currentUserApi->get('uid')
+            'uid' => (int) $this->currentUserApi->get('uid')
         ];
 
         $config = array_map('htmlspecialchars', $config);

--- a/src/system/UsersModule/Entity/Repository/UserSessionRepository.php
+++ b/src/system/UsersModule/Entity/Repository/UserSessionRepository.php
@@ -56,7 +56,7 @@ class UserSessionRepository extends ServiceEntityRepository implements UserSessi
             ->setParameter('guestUser', Constant::USER_ID_ANONYMOUS)
             ->getQuery();
 
-        return (int)$query->getSingleScalarResult();
+        return (int) $query->getSingleScalarResult();
     }
 
     public function countGuestsSince(DateTime $dateTime): int
@@ -69,7 +69,7 @@ class UserSessionRepository extends ServiceEntityRepository implements UserSessi
             ->setParameter('guestUser', Constant::USER_ID_ANONYMOUS)
             ->getQuery();
 
-        return (int)$query->getSingleScalarResult();
+        return (int) $query->getSingleScalarResult();
     }
 
     public function clearUnsavedData(): void

--- a/src/system/UsersModule/Helper/RegistrationHelper.php
+++ b/src/system/UsersModule/Helper/RegistrationHelper.php
@@ -128,7 +128,7 @@ class RegistrationHelper
      */
     public function approve(UserEntity $user): void
     {
-        $user->setApprovedBy((int)$this->currentUserApi->get('uid'));
+        $user->setApprovedBy((int) $this->currentUserApi->get('uid'));
         $user->setApprovedDate(new DateTime());
 
         $user->setActivated(UsersConstant::ACTIVATED_ACTIVE);

--- a/src/system/UsersModule/Twig/Extension/OnlineExtension.php
+++ b/src/system/UsersModule/Twig/Extension/OnlineExtension.php
@@ -68,6 +68,6 @@ class OnlineExtension extends AbstractExtension
             ->andWhere(Criteria::expr()->gt('lastused', $since));
         $online = $this->sessionRepository->matching($c)->count();
 
-        return (bool)$online;
+        return (bool) $online;
     }
 }

--- a/src/system/UsersModule/Twig/Extension/ProfileExtension.php
+++ b/src/system/UsersModule/Twig/Extension/ProfileExtension.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Zikula\UsersModule\Twig\Extension;
 
-use function Symfony\Component\String\s;
 use InvalidArgumentException;
+use function Symfony\Component\String\s;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;

--- a/src/system/UsersModule/Twig/Extension/ProfileExtension.php
+++ b/src/system/UsersModule/Twig/Extension/ProfileExtension.php
@@ -94,8 +94,8 @@ class ProfileExtension extends AbstractExtension
         int $maxLength = 0,
         string $title = ''
     ): string {
-        if (empty($userId) || $userId < 1) {
-            return (string)$userId;
+        if (empty($userId) || 1 > $userId) {
+            return (string) $userId;
         }
 
         return $this->determineProfileLink($userId, null, $class, $image, $maxLength, $title);
@@ -164,7 +164,7 @@ class ProfileExtension extends AbstractExtension
             // truncate the user name to $maxLength chars
             $length = mb_strlen($userDisplayName);
             $truncEnd = ($maxLength > $length) ? $length : $maxLength;
-            $show = htmlspecialchars((string)s($userDisplayName)->slice(0, $truncEnd), ENT_QUOTES);
+            $show = htmlspecialchars((string) s($userDisplayName)->slice(0, $truncEnd), ENT_QUOTES);
         } else {
             $show = htmlspecialchars($userDisplayName, ENT_QUOTES);
         }

--- a/src/system/UsersModule/Twig/Extension/ProfileExtension.php
+++ b/src/system/UsersModule/Twig/Extension/ProfileExtension.php
@@ -164,7 +164,7 @@ class ProfileExtension extends AbstractExtension
             // truncate the user name to $maxLength chars
             $length = mb_strlen($userDisplayName);
             $truncEnd = ($maxLength > $length) ? $length : $maxLength;
-            $show = htmlspecialchars(s($userDisplayName)->slice(0, $truncEnd)->__toString(), ENT_QUOTES);
+            $show = htmlspecialchars(s($userDisplayName)->slice(0, $truncEnd)->toString(), ENT_QUOTES);
         } else {
             $show = htmlspecialchars($userDisplayName, ENT_QUOTES);
         }

--- a/src/system/UsersModule/Twig/Extension/ProfileExtension.php
+++ b/src/system/UsersModule/Twig/Extension/ProfileExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\UsersModule\Twig\Extension;
 
+use function Symfony\Component\String\s;
 use InvalidArgumentException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
@@ -159,11 +160,11 @@ class ProfileExtension extends AbstractExtension
 
         if (!empty($imagePath)) {
             $show = '<img src="' . htmlspecialchars($imagePath, ENT_QUOTES) . '" alt="' . htmlspecialchars($userDisplayName, ENT_QUOTES) . '" />';
-        } elseif ($maxLength > 0) {
+        } elseif (0 < $maxLength) {
             // truncate the user name to $maxLength chars
             $length = mb_strlen($userDisplayName);
             $truncEnd = ($maxLength > $length) ? $length : $maxLength;
-            $show = htmlspecialchars(mb_substr($userDisplayName, 0, $truncEnd), ENT_QUOTES);
+            $show = htmlspecialchars((string)s($userDisplayName)->slice(0, $truncEnd), ENT_QUOTES);
         } else {
             $show = htmlspecialchars($userDisplayName, ENT_QUOTES);
         }

--- a/src/system/UsersModule/Twig/Extension/ProfileExtension.php
+++ b/src/system/UsersModule/Twig/Extension/ProfileExtension.php
@@ -164,7 +164,7 @@ class ProfileExtension extends AbstractExtension
             // truncate the user name to $maxLength chars
             $length = mb_strlen($userDisplayName);
             $truncEnd = ($maxLength > $length) ? $length : $maxLength;
-            $show = htmlspecialchars((string) s($userDisplayName)->slice(0, $truncEnd), ENT_QUOTES);
+            $show = htmlspecialchars(s($userDisplayName)->slice(0, $truncEnd)->__toString(), ENT_QUOTES);
         } else {
             $show = htmlspecialchars($userDisplayName, ENT_QUOTES);
         }

--- a/src/system/ZAuthModule/Api/PasswordApi.php
+++ b/src/system/ZAuthModule/Api/PasswordApi.php
@@ -174,8 +174,8 @@ class PasswordApi implements PasswordApiInterface
         if (1 === mb_strlen($saltDelimiter) && false !== mb_strpos($saltedHash, $saltDelimiter)) {
             [$hashMethod, $saltStr, $correctHash] = explode($saltDelimiter, $saltedHash);
 
-            if (is_numeric($hashMethod) && ((int)$hashMethod === $hashMethod)) {
-                $hashMethod = (int)$hashMethod;
+            if (is_numeric($hashMethod) && ((int) $hashMethod === $hashMethod)) {
+                $hashMethod = (int) $hashMethod;
             }
             $hashMethodName = $hashMethodCodeToName[$hashMethod] ?? $hashMethod;
 

--- a/src/system/ZAuthModule/Controller/AccountController.php
+++ b/src/system/ZAuthModule/Controller/AccountController.php
@@ -307,7 +307,7 @@ class AccountController extends AbstractController
             $data = $form->getData();
             $code = bin2hex(random_bytes(8));
             $hashedCode = $encoderFactory->getEncoder(AuthenticationMappingEntity::class)->encodePassword($code, null);
-            $currentUserId = (int)$currentUserApi->get('uid');
+            $currentUserId = (int) $currentUserApi->get('uid');
             $userVerificationRepository->setVerificationCode($currentUserId, ZAuthConstant::VERIFYCHGTYPE_EMAIL, $hashedCode, $data['email']);
             $templateArgs = [
                 'uname'    => $currentUserApi->get('uname'),

--- a/src/system/ZAuthModule/Controller/UserAdministrationController.php
+++ b/src/system/ZAuthModule/Controller/UserAdministrationController.php
@@ -428,7 +428,7 @@ class UserAdministrationController extends AbstractController
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             if ($form->get('toggle')->isClicked()) {
-                if ($user->getAttributes()->containsKey(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY) && (bool)$user->getAttributes()->get(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY)) {
+                if ($user->getAttributes()->containsKey(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY) && (bool) $user->getAttributes()->get(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY)) {
                     $user->getAttributes()->remove(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY);
                     $this->addFlash('success', $this->trans('Done! A password change will no longer be required for %userName%.', ['%userName%' => $user->getUname()]));
                 } else {

--- a/src/system/ZAuthModule/Helper/AdministrationActionsHelper.php
+++ b/src/system/ZAuthModule/Helper/AdministrationActionsHelper.php
@@ -104,7 +104,7 @@ class AdministrationActionsHelper
         if ($hasEditPermissionToUser) {
             $userEntity = $this->userRepository->find($mapping->getUid());
             if (null !== $userEntity) {
-                if ((bool)$userEntity->getAttributeValue(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY)
+                if ((bool) $userEntity->getAttributeValue(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY)
                     && $userEntity->getAttributes()->containsKey(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY)
                 ) {
                     $title = $this->translator->trans('Cancel required change of password for %sub%', ['%sub%' => $mapping->getUname()]);

--- a/src/system/ZAuthModule/Helper/BatchPasswordChangeHelper.php
+++ b/src/system/ZAuthModule/Helper/BatchPasswordChangeHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zikula\ZAuthModule\Helper;
 
+use function Symfony\Component\String\s;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Zikula\GroupsModule\Entity\RepositoryInterface\GroupRepositoryInterface;
@@ -55,9 +56,9 @@ class BatchPasswordChangeHelper
 
         /** @var \Zikula\UsersModule\Entity\UserEntity $user */
         foreach ($group->getUsers() as $user) {
-            $authMethod = $user->getAttributeValue('authenticationMethod');
+            $authMethod = s($user->getAttributeValue('authenticationMethod'));
             $uid = $user->getUid();
-            if ((Constant::USER_ID_ANONYMOUS === $uid) || ($currentUid === $uid) || ('native_' !== mb_substr($authMethod, 0, 7))) {
+            if (Constant::USER_ID_ANONYMOUS === $uid || $currentUid === $uid || !$authMethod->startsWith('native_')) {
                 continue;
             }
             $user->setAttribute(ZAuthConstant::REQUIRE_PASSWORD_CHANGE_KEY, true);

--- a/src/system/ZAuthModule/Helper/BatchPasswordChangeHelper.php
+++ b/src/system/ZAuthModule/Helper/BatchPasswordChangeHelper.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Zikula\ZAuthModule\Helper;
 
-use function Symfony\Component\String\s;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
+use function Symfony\Component\String\s;
 use Zikula\GroupsModule\Entity\RepositoryInterface\GroupRepositoryInterface;
 use Zikula\UsersModule\Api\ApiInterface\CurrentUserApiInterface;
 use Zikula\UsersModule\Constant;

--- a/src/system/ZAuthModule/Validator/Constraints/ValidUserFieldsValidator.php
+++ b/src/system/ZAuthModule/Validator/Constraints/ValidUserFieldsValidator.php
@@ -76,7 +76,7 @@ class ValidUserFieldsValidator extends ConstraintValidator
                 ->setParameter('excludedUid', $authenticationMappingEntity->getUid());
         }
 
-        if ((int)$qb->getQuery()->getSingleScalarResult() > 0) {
+        if (0 < (int) $qb->getQuery()->getSingleScalarResult()) {
             $this->context->buildViolation($this->translator->trans('The user name you entered (%userName%) has already been registered.', ['%userName%' => $userName], 'validators'))
                 ->atPath('uname')
                 ->addViolation();
@@ -95,7 +95,7 @@ class ValidUserFieldsValidator extends ConstraintValidator
             $qb->andWhere('m.uid != :excludedUid')
                 ->setParameter('excludedUid', $authenticationMappingEntity->getUid());
         }
-        $uCount = (int)$qb->getQuery()->getSingleScalarResult();
+        $uCount = (int) $qb->getQuery()->getSingleScalarResult();
 
         $query = $this->userVerificationRepository->createQueryBuilder('v')
             ->select('COUNT(v.uid)')
@@ -104,9 +104,9 @@ class ValidUserFieldsValidator extends ConstraintValidator
             ->setParameter('email', $emailAddress)
             ->setParameter('chgtype', ZAuthConstant::VERIFYCHGTYPE_EMAIL)
             ->getQuery();
-        $vCount = (int)$query->getSingleScalarResult();
+        $vCount = (int) $query->getSingleScalarResult();
 
-        if ($uCount + $vCount > 0) {
+        if (0 < $uCount + $vCount) {
             $this->context->buildViolation($this->translator->trans('The email address you entered (%email%) has already been registered.', ['%email%' => $emailAddress], 'validators'))
                 ->atPath('email')
                 ->addViolation();


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixed #4053 
| Refs tickets      | -
| License           | MIT
| Changelog updated | no

## Description

This PR introduces the String component for some string operations.

Currently the `functions.php` file is explicitly included to make the helper methods available (`u()`, `b()`, `s()`).
This inclusion can be removed again when #4352 is done because then the String component will be explicitly added by composer which adds `"files": [ "Resources/functions.php" ]` to the autoloader ([link](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/String/composer.json#L34)).
