### PR TITLE
Add new block positions automatically on theme installation fixes #4228

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -18,7 +18,8 @@
   - [extensions] Add StaticContent module to manage all static content (#4369).
   - [CoreBundle] Add `Zikula\Bundle\CoreBundle\Configurator` for writing config files to the filesystem (#4433).
   - [FormExtensionsBundle] Add bsCustomFileInput for direct file selection feedback (#4491).
-  - [ZikulaDefaultTheme] Add new default theme (#4462).
+  - [BlocksModule] Add new block positions automatically on theme installation (#4228). 
+  - [DefaultTheme] Add new default theme (#4462).
     - This looks the same as ZikulaBootstrapTheme but improves the templates in a way that is not BC.
 
 - Deprecated:

--- a/src/system/BlocksModule/Listener/BlockPositionInstallerListener.php
+++ b/src/system/BlocksModule/Listener/BlockPositionInstallerListener.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\BlocksModule\Listener;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Zikula\BlocksModule\Entity\BlockPositionEntity;
+use Zikula\BlocksModule\Entity\RepositoryInterface\BlockPositionRepositoryInterface;
+use Zikula\ExtensionsModule\AbstractTheme;
+use Zikula\ExtensionsModule\Event\ExtensionPostInstallEvent;
+use Zikula\ExtensionsModule\Event\ExtensionStateEvent;
+
+/**
+ * When a new theme is installed, add non-existing block positions.
+ */
+class BlockPositionInstallerListener implements EventSubscriberInterface
+{
+    /**
+     * @var BlockPositionRepositoryInterface
+     */
+    private $blockPositionRepository;
+
+    /**
+     * @var ManagerRegistry
+     */
+    private $managerRegistry;
+
+    public function __construct(
+        BlockPositionRepositoryInterface $blockPositionRepository,
+        ManagerRegistry $managerRegistry
+    ) {
+        $this->blockPositionRepository = $blockPositionRepository;
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ExtensionPostInstallEvent::class => [['createBlockPositions']],
+        ];
+    }
+
+    public function createBlockPositions(ExtensionStateEvent $event): void
+    {
+        $bundle = $event->getExtensionBundle();
+        if (!($bundle instanceof AbstractTheme)) {
+            return;
+        }
+        $config = $bundle->getConfig();
+        $positions =[];
+        foreach ($config as $realm => $attributes) {
+            if (!isset($attributes['block']) || !isset($attributes['block']['positions'])) {
+                continue;
+            }
+            $positions = array_merge($positions, $attributes['block']['positions']);
+        }
+
+        foreach (array_keys($positions) as $name) {
+            $existing = $this->blockPositionRepository->findByName($name);
+            if (!empty($existing)) {
+                continue;
+            }
+            $positionEntity = new BlockPositionEntity();
+            $positionEntity->setName($name);
+            $positionEntity->setDescription($name . ' blocks');
+            $this->managerRegistry->getManager()->persist($positionEntity);
+        }
+        $this->managerRegistry->getManager()->flush();
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | #4228
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

## Description

Add new block positions automatically on theme installation fixes #4228