### PR TITLE
use addAnnotatedClassesToCompile

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -30,6 +30,7 @@
   - [DefaultTheme] Add new default theme (#4462).
     - This looks the same as ZikulaBootstrapTheme but improves the templates in a way that is not BC.
   - [General] Implemented `Twig\Extension\RuntimeExtensionInterface` for all Twig extensions, allowing them to dynamically load (#4522).
+  - [General] Added `addAnnotatedClassesToCompile` method to needed core classes to improve performance when activated.
   - [ThemeModule] Add `Symfony\WebpackEncoreBundle` (#4571).
     - Automatically adds webpack assets via a listener.
 

--- a/couscous.yml
+++ b/couscous.yml
@@ -59,6 +59,9 @@ menu:
                 upgrade3to3:
                     text: Upgrade 3 to 3
                     relativeUrl: Setup/upgradefrom3to3.x.x.html
+                production:
+                    text: Deployment
+                    relativeUrl: Setup/production.html
         configuration:
             name: Configuration
             items:

--- a/docs/Setup/Production.md
+++ b/docs/Setup/Production.md
@@ -1,0 +1,17 @@
+---
+currentMenu: install
+---
+# Production
+
+In an ideal situation, you would test your installation of Zikula in a local (developmet) environment before
+moving the entire site into "production". This process is called _deployment_. 
+
+Symfony provides documentation for this process [here](https://symfony.com/doc/current/deployment.html). 
+
+Before deploying your site, you should **remove all unused Zikula extensions**. 
+
+Another recommended step is to run `composer dump-autoload -a` (authoritative mode). This will allow all supported
+Zikula core classes to load faster. (see composer's [autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md)).
+It will also pre-cache all annotation classes in supported classes which will also speed up loading.
+
+Beware however, as classes that are generated at runtime will not autoload and this [could cause issues](https://getcomposer.org/doc/articles/autoloader-optimization.md#trade-offs-2).

--- a/src/Zikula/CoreBundle/DependencyInjection/CoreExtension.php
+++ b/src/Zikula/CoreBundle/DependencyInjection/CoreExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Zikula\Bundle\CoreBundle\Controller\MainController;
 
 class CoreExtension extends Extension implements PrependExtensionInterface
 {
@@ -44,6 +45,13 @@ class CoreExtension extends Extension implements PrependExtensionInterface
         $config = $this->processConfiguration($configuration, $configs);
         $container->setParameter('datadir', $config['datadir']);
         $container->setParameter('multisites', $config['multisites']);
+
+        $this->addAnnotatedClassesToCompile([
+            MainController::class,
+            'Zikula\\*Module\\Controller\\',
+            'Zikula\\*Theme\\Controller\\',
+            'Zikula\\*Module\\Entity\\',
+        ]);
     }
 
     public function getNamespace(): string

--- a/src/Zikula/CoreInstallerBundle/DependencyInjection/ZikulaCoreInstallerExtension.php
+++ b/src/Zikula/CoreInstallerBundle/DependencyInjection/ZikulaCoreInstallerExtension.php
@@ -27,5 +27,9 @@ class ZikulaCoreInstallerExtension extends Extension
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');
+
+        $this->addAnnotatedClassesToCompile([
+            'Zikula\\Bundle\\CoreInstallerBundle\\Controller\\',
+        ]);
     }
 }

--- a/src/Zikula/HookBundle/DependencyInjection/ZikulaHookExtension.php
+++ b/src/Zikula/HookBundle/DependencyInjection/ZikulaHookExtension.php
@@ -17,6 +17,9 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Zikula\Bundle\HookBundle\Controller\HookController;
+use Zikula\Bundle\HookBundle\Entity\HookBindingEntity;
+use Zikula\Bundle\HookBundle\Entity\HookRuntimeEntity;
 use Zikula\Bundle\HookBundle\HookProviderInterface;
 use Zikula\Bundle\HookBundle\HookSubscriberInterface;
 
@@ -36,5 +39,11 @@ class ZikulaHookExtension extends Extension
         $container->registerForAutoconfiguration(HookSubscriberInterface::class)
             ->addTag('zikula.hook_subscriber')
         ;
+
+        $this->addAnnotatedClassesToCompile([
+            HookController::class,
+            HookBindingEntity::class,
+            HookRuntimeEntity::class
+        ]);
     }
 }

--- a/src/Zikula/WorkflowBundle/DependencyInjection/ZikulaWorkflowExtension.php
+++ b/src/Zikula/WorkflowBundle/DependencyInjection/ZikulaWorkflowExtension.php
@@ -21,8 +21,8 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Zikula\Bundle\WorkflowBundle\Controller\EditorController;
 use function Symfony\Component\String\s;
+use Zikula\Bundle\WorkflowBundle\Controller\EditorController;
 
 /**
  * Class ZikulaWorkflowExtension

--- a/src/Zikula/WorkflowBundle/DependencyInjection/ZikulaWorkflowExtension.php
+++ b/src/Zikula/WorkflowBundle/DependencyInjection/ZikulaWorkflowExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Zikula\Bundle\WorkflowBundle\Controller\EditorController;
 use function Symfony\Component\String\s;
 
 /**
@@ -34,6 +35,10 @@ class ZikulaWorkflowExtension extends Extension implements PrependExtensionInter
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');
+
+        $this->addAnnotatedClassesToCompile([
+            EditorController::class
+        ]);
     }
 
     public function prepend(ContainerBuilder $container)


### PR DESCRIPTION
Bundles can hint Symfony about which of their classes contain annotations so they are compiled when generating the application cache to improve the overall performance. Define the list of annotated classes to compile in the addAnnotatedClassesToCompile() method:

https://symfony.com/doc/current/bundles/extension.html#adding-classes-to-compile

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | -
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes