### PR TITLE
use native_either as default auth method for ZAuth

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -43,6 +43,7 @@
   - [Routes] Dropdown for choosing bundle/controller/action combination (#4517).
   - [Theme] Add `Symfony\WebpackEncoreBundle` (#4571).
     - Automatically adds webpack assets via a listener.
+  - [Users/ZAuth] Default authentication method is changed to "native either" (#4351).
 
 - Deprecated:
   - [General] Controller methods should not have an `Action` suffix in their names anymore.

--- a/src/system/UsersModule/Controller/ConfigController.php
+++ b/src/system/UsersModule/Controller/ConfigController.php
@@ -99,12 +99,12 @@ class ConfigController extends AbstractController
                 $data = $form->getData();
                 if (!in_array(true, $data['authenticationMethodsStatus'], true)) {
                     // do not allow all methods to be inactive.
-                    $data['authenticationMethodsStatus']['native_uname'] = true;
+                    $data['authenticationMethodsStatus']['native_either'] = true;
                     $this->addFlash(
                         'info',
                         $this->trans(
                             'All methods cannot be inactive. At least one methods must be enabled (%method% has been enabled).',
-                            ['%method%' => $allMethods['native_uname']->getDisplayName()]
+                            ['%method%' => $allMethods['native_either']->getDisplayName()]
                         )
                     );
                 }

--- a/src/system/UsersModule/UsersModuleInstaller.php
+++ b/src/system/UsersModule/UsersModuleInstaller.php
@@ -35,7 +35,7 @@ class UsersModuleInstaller extends AbstractExtensionInstaller
 
         $this->createDefaultData();
         $this->setVars($this->getDefaultModvars());
-        $this->getVariableApi()->set(VariableApi::CONFIG, 'authenticationMethodsStatus', ['native_uname' => true]);
+        $this->getVariableApi()->set(VariableApi::CONFIG, 'authenticationMethodsStatus', ['native_either' => true]);
 
         return true;
     }

--- a/src/system/ZAuthModule/Listener/Core3UpgradeListener.php
+++ b/src/system/ZAuthModule/Listener/Core3UpgradeListener.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Zikula\ZAuthModule\EventListener;
+namespace Zikula\ZAuthModule\Listener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Zikula\Bundle\CoreInstallerBundle\Event\CoreUpgradePreExtensionUpgrade;

--- a/src/system/ZAuthModule/Listener/Core3UpgradeListener.php
+++ b/src/system/ZAuthModule/Listener/Core3UpgradeListener.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\ZAuthModule\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Zikula\Bundle\CoreInstallerBundle\Event\CoreUpgradePreExtensionUpgrade;
+use Zikula\ZAuthModule\ZAuthConstant;
+
+class Core3UpgradeListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            CoreUpgradePreExtensionUpgrade::class => 'upgrade'
+        ];
+    }
+
+    public function upgrade(CoreUpgradePreExtensionUpgrade $event): void
+    {
+        if (!version_compare($event->getCurrentCoreVersion(), '3.0.0', '<')) {
+            return;
+        }
+        $sm = $this->conn->getSchemaManager();
+        $sql = "
+            UPDATE users_attributes
+            SET value='" . ZAuthConstant::AUTHENTICATION_METHOD_EITHER . "'
+            WHERE `name` LIKE 'authenticationMethod'
+            AND `value` IN ('" . ZAuthConstant::AUTHENTICATION_METHOD_UNAME . "', '" . ZAuthConstant::AUTHENTICATION_METHOD_EMAIL . "')
+        ";
+        $this->conn->executeQuery($sql);
+    }
+}

--- a/src/system/ZAuthModule/Listener/Core3UpgradeListener.php
+++ b/src/system/ZAuthModule/Listener/Core3UpgradeListener.php
@@ -14,11 +14,14 @@ declare(strict_types=1);
 namespace Zikula\ZAuthModule\Listener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Zikula\Bundle\CoreBundle\Doctrine\ColumnExistsTrait;
 use Zikula\Bundle\CoreInstallerBundle\Event\CoreUpgradePreExtensionUpgrade;
 use Zikula\ZAuthModule\ZAuthConstant;
 
 class Core3UpgradeListener implements EventSubscriberInterface
 {
+    use ColumnExistsTrait;
+
     public static function getSubscribedEvents()
     {
         return [


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Deprecations?     | no
| Fixed tickets     | fixes #4351
| Refs tickets      | -
| License           | MIT
| Changelog updated | yes

